### PR TITLE
fix: use uppercase AS in Dockerfile FROM statement to resolve FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage Dockerfile for Petrosa Trading Engine
-FROM python:3.11-alpine as base
+FROM python:3.11-alpine AS base
 
 # Build arguments
 ARG VERSION=dev


### PR DESCRIPTION
This PR updates the Dockerfile to use uppercase AS in the FROM statement, resolving the FromAsCasing linter warning. No other changes were made.