### PR TITLE
fix: resolve MongoDB database configuration issue

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: petrosa-tradeengine
-        image: yurisa2/petrosa-tradeengine:VERSION_PLACEHOLDER
+        image: yurisa2/petrosa-tradeengine:v1.1.19
         imagePullPolicy: Always
         ports:
         - containerPort: 8000
@@ -50,8 +50,8 @@ spec:
               key: mongodb-connection-string
         - name: MONGODB_DATABASE
           valueFrom:
-            configMapKeyRef:
-              name: petrosa-common-config
+            secretKeyRef:
+              name: petrosa-sensitive-credentials
               key: MONGODB_DATABASE
         # NATS configuration from configmap
         - name: NATS_ENABLED


### PR DESCRIPTION
This PR fixes a critical Kubernetes deployment issue where the MONGODB_DATABASE environment variable was incorrectly referenced from ConfigMap instead of Secret. Changes include fixing the reference, adding the missing key to the secret, and updating the image tag. All pods are now running successfully.