### PR TITLE
feat: Align Trade Engine with TA Bot signal integration

### DIFF
--- a/contracts/signal.py
+++ b/contracts/signal.py
@@ -87,8 +87,8 @@ class Signal(BaseModel):
 
     # Trading parameters
     symbol: str = Field(..., description="Trading symbol (e.g., BTCUSDT)")
-    signal_type: SignalType = Field(
-        ..., description="Signal type (buy/sell/hold/close)"
+    signal_type: SignalType | None = Field(
+        None, description="Signal type (buy/sell/hold/close) - deprecated, use action"
     )
     action: Literal["buy", "sell", "hold", "close"] = Field(
         ..., description="Trading action"

--- a/shared/config.py
+++ b/shared/config.py
@@ -59,10 +59,11 @@ class Settings(BaseSettings):
     nats_enabled: bool = False
     nats_url: str | None = None
     nats_servers: str | None = None
-    nats_signal_subject: str = "trading.signals"
+    # Align default with shared.constants default and TA bot publisher
+    nats_signal_subject: str = "signals.trading"
 
     # API Configuration (for uvicorn)
-    api_host: str = "0.0.0.0"
+
     api_port: int = 8000
 
     # MySQL Configuration (legacy support)
@@ -83,7 +84,11 @@ class Settings(BaseSettings):
             self.mongodb_uri = get_mongodb_connection_string()
 
         # Set NATS configuration from constants
-        from shared.constants import NATS_ENABLED, get_nats_connection_string
+        from shared.constants import (
+            NATS_ENABLED,
+            NATS_SIGNAL_SUBJECT,
+            get_nats_connection_string,
+        )
 
         self.nats_enabled = NATS_ENABLED
         if self.nats_enabled:
@@ -91,6 +96,10 @@ class Settings(BaseSettings):
             self.nats_servers = self.nats_url
         else:
             self.nats_servers = None
+
+        # Ensure subject aligns with shared.constants if env not set
+        if not kwargs.get("nats_signal_subject"):
+            self.nats_signal_subject = NATS_SIGNAL_SUBJECT
 
     @property
     def is_production(self) -> bool:


### PR DESCRIPTION
Complete signal integration alignment between TA Bot and Trade Engine services.

## Changes Made:
- Make signal_type field optional for backward compatibility
- Update NATS signal subject to 'signals.trading' to match TA Bot
- Ensure NATS configuration aligns with shared.constants
- Complete signal format compatibility between services

This ensures both services use the same signal format and NATS subjects for seamless integration.