### PR TITLE
feat: replace hardcoded version with VERSION_PLACEHOLDER in deployment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: petrosa-tradeengine
-        image: yurisa2/petrosa-tradeengine:v1.1.19
+        image: yurisa2/petrosa-tradeengine:VERSION_PLACEHOLDER
         imagePullPolicy: Always
         ports:
         - containerPort: 8000


### PR DESCRIPTION
## Changes Made

- Replace hardcoded image version v1.1.19 with VERSION_PLACEHOLDER
- Ensure compliance with Petrosa auto-increment system
- Enable seamless integration with CI/CD pipelines and version management

## Files Changed
- k8s/deployment.yaml

## Testing
- Deployment now uses VERSION_PLACEHOLDER instead of hardcoded version
- Ready for auto-increment system integration