### PR TITLE
Fix pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,12 +180,6 @@ norecursedirs = [
     ".ruff_cache",
 ]
 
-# Environment variables for tests
-env = [
-    "ENVIRONMENT=testing",
-    "LOG_LEVEL=DEBUG",
-    "OTEL_NO_AUTO_INIT=1",
-]
 
 [tool.coverage.run]
 source = ["tradeengine", "contracts", "shared"]


### PR DESCRIPTION
This PR fixes the pytest configuration by removing the invalid env option that was causing test failures.