### PR TITLE
fix: Add common configmap with correct NATS URL for external access

### DIFF
--- a/k8s/common-configmap.yaml
+++ b/k8s/common-configmap.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: petrosa-common-config
+  namespace: petrosa-apps
+  labels:
+    app: petrosa
+    component: common-config
+data:
+  # Common environment settings
+  environment: "production"
+  log-level: "INFO"
+
+  # NATS configuration
+  NATS_URL: "nats://192.168.194.253:4222"
+  NATS_ENABLED: "true"
+
+  # OpenTelemetry configuration
+  ENABLE_OTEL: "true"
+  OTEL_SERVICE_VERSION: "VERSION_PLACEHOLDER"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+  OTEL_METRICS_EXPORTER: "otlp"
+  OTEL_TRACES_EXPORTER: "otlp"
+  OTEL_LOGS_EXPORTER: "otlp"
+
+  # Database configuration
+  DB_ADAPTER: "mysql"
+
+  # Trading configuration
+  simulation-enabled: "false"
+  binance-testnet: "false"
+  DEFAULT_SYMBOLS: "BTCUSDT,ETHUSDT,BNBUSDT"
+  SUPPORTED_INTERVALS: "1m,5m,15m,30m,1h,4h,1d"


### PR DESCRIPTION
This PR adds the missing petrosa-common-config configmap and fixes the NATS URL to use the external IP address (192.168.194.253:4222) instead of the internal service name, resolving VPN connectivity issues.