### PR TITLE
fix: remove sensitive .env files and update CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -102,8 +102,10 @@ jobs:
         pytest --cov=tradeengine --cov=contracts --cov=shared --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: PetroSa2/petrosa-tradeengine
         file: ./coverage.xml
         flags: unittests
         name: codecov-umbrella


### PR DESCRIPTION
## Security Fix: Remove Sensitive Environment Files

### Changes Made:
- ✅ Remove .env files containing real API credentials and database passwords
- ✅ Update Codecov action to v5 with proper token configuration  
- ✅ Ensure .env files are properly ignored by git
- ✅ Security: Prevent exposure of sensitive credentials in public repositories

### Security Impact:
- **Before**: Real Binance API credentials and database passwords were exposed in public repositories
- **After**: All sensitive files removed, only .env.example files with placeholder values remain

### Files Changed:
-  - Updated Codecov configuration
-  files removed from all public repositories

### Testing:
- ✅ Pre-commit hooks passed
- ✅ No sensitive data detected in commit
- ✅ .env.example files contain only placeholder values

### Next Steps:
1. **IMMEDIATELY rotate the exposed credentials**:
   - Binance API keys
   - Database passwords
2. Update any documentation referencing the old credentials
3. Ensure all team members use .env.example as template

**⚠️ CRITICAL**: The exposed credentials should be considered compromised and must be rotated immediately.