### PR TITLE
fix: update .env.example to use placeholder API keys

### DIFF
--- a/env.example
+++ b/env.example
@@ -2,8 +2,9 @@
 # These are the exact same credentials and settings used in your Kubernetes deployment
 
 # Binance API Credentials (from petrosa-sensitive-credentials secret)
-BINANCE_API_KEY=2fe0e9581c784734c3197577c3243335f98f5547006feb859bd3ccd054b19aa1
-BINANCE_API_SECRET=5c6acc1d16f1041d80788bd1d5aa19577328e7185c84a193787be8640abf6cb6
+# IMPORTANT: These are placeholder values. Use your actual API keys from Kubernetes secrets
+BINANCE_API_KEY=your-api-key-here
+BINANCE_API_SECRET=your-api-secret-here
 
 # Trading Configuration (from petrosa-common-config ConfigMap)
 BINANCE_TESTNET=true


### PR DESCRIPTION
## Security Fix: Update .env.example with Placeholder API Keys

### Changes Made:
- ✅ **Replace Old API Keys**: Removed old API keys from .env.example file
- ✅ **Add Placeholder Values**: Use  and 
- ✅ **Security Warning**: Added comment about using actual credentials from Kubernetes secrets
- ✅ **No Real Credentials**: Ensure no real credentials are committed to repository

### Security Impact:
- **Before**: .env.example contained old API keys that were exposed
- **After**: Only placeholder values, no real credentials in repository

### Files Changed:
-  - Updated API key placeholders

### Testing:
- ✅ Pre-commit hooks passed
- ✅ No sensitive data detected
- ✅ Security scan passed

### Note:
This change ensures that the repository only contains placeholder values and no real API credentials, improving security posture.