### PR TITLE
fix: enable actual Binance order execution in tradeengine

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -32,12 +32,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: petrosa-common-config
-              key: environment
+              key: ENVIRONMENT
         - name: LOG_LEVEL
           valueFrom:
             configMapKeyRef:
               name: petrosa-common-config
-              key: log-level
+              key: LOG_LEVEL
         - name: HOST
           value: "0.0.0.0"
         - name: PORT

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -83,9 +83,9 @@ app = FastAPI(
 
 # Initialize components
 settings = Settings()
-dispatcher = Dispatcher()
 binance_exchange = BinanceFuturesExchange()
 simulator_exchange = SimulatorExchange()
+dispatcher = Dispatcher(exchange=binance_exchange)
 
 logger = logging.getLogger(__name__)
 

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -14,11 +14,12 @@ from tradeengine.signal_aggregator import SignalAggregator
 class Dispatcher:
     """Central dispatcher for trading operations with distributed state management"""
 
-    def __init__(self) -> None:
+    def __init__(self, exchange=None) -> None:
         self.settings = Settings()
         self.order_manager = OrderManager()
         self.position_manager = PositionManager()
         self.signal_aggregator = SignalAggregator()
+        self.exchange = exchange
         self.logger = logging.getLogger(__name__)
 
     async def initialize(self) -> None:
@@ -285,11 +286,26 @@ class Dispatcher:
             if audit_logger.enabled and audit_logger.connected:
                 audit_logger.log_order(order.model_dump())
 
-            # Execute order
-            await self.order_manager.track_order(order, {"status": "pending"})
-
-            # For now, assume order is pending
-            result = {"status": "pending"}
+            # Execute order on Binance exchange
+            if order.simulate:
+                # Simulated order - just track locally
+                result = {"status": "pending", "simulated": True}
+                await self.order_manager.track_order(order, result)
+            else:
+                # Real order - execute on Binance
+                if self.exchange:
+                    try:
+                        result = await self.exchange.execute_order(order)
+                        await self.order_manager.track_order(order, result)
+                        self.logger.info(f"Order executed on Binance: {result}")
+                    except Exception as exchange_error:
+                        self.logger.error(f"Binance exchange error: {exchange_error}")
+                        result = {"status": "error", "error": str(exchange_error)}
+                        await self.order_manager.track_order(order, result)
+                else:
+                    # No exchange provided, just track locally
+                    result = {"status": "pending", "no_exchange": True}
+                    await self.order_manager.track_order(order, result)
 
             # Log result
             if audit_logger.enabled and audit_logger.connected:
@@ -300,7 +316,7 @@ class Dispatcher:
                     }
                 )
 
-            return result or {"status": "pending"}
+            return result
 
         except Exception as e:
             self.logger.error(f"Order execution error: {e}")

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -14,7 +14,7 @@ from tradeengine.signal_aggregator import SignalAggregator
 class Dispatcher:
     """Central dispatcher for trading operations with distributed state management"""
 
-    def __init__(self, exchange=None) -> None:
+    def __init__(self, exchange: Any = None) -> None:
         self.settings = Settings()
         self.order_manager = OrderManager()
         self.position_manager = PositionManager()


### PR DESCRIPTION
## 🚀 Fix: Enable Actual Binance Order Execution

### Problem
The tradeengine was accepting orders via REST API but only tracking them locally. Orders were never actually sent to Binance, so they wouldn't appear in the UI.

### Root Cause
- Dispatcher's  method was not calling the Binance exchange
- Orders were only stored in local memory, never executed on Binance
- Missing integration between dispatcher and exchange

### Solution
- ✅ Pass Binance exchange instance to dispatcher constructor
- ✅ Update  method to use exchange for real orders
- ✅ Maintain simulation support for testing
- ✅ Fix circular import issues
- ✅ Preserve VERSION_PLACEHOLDER compliance

### Testing
- ✅ Testnet credentials verified working
- ✅ Direct Python script can place orders successfully
- ✅ Tradeengine API accepts orders
- ✅ Ready for testnet order execution testing

### Impact
- Orders from REST API will now be properly executed on Binance testnet
- Orders will be visible in Binance UI
- Maintains backward compatibility with simulation mode

### Files Changed
-  - Add exchange integration
-  - Pass exchange to dispatcher
-  - Maintain VERSION_PLACEHOLDER

### Checklist
- [x] Code follows project conventions
- [x] Pre-commit hooks passed
- [x] VERSION_PLACEHOLDER preserved
- [x] Testnet configuration enabled
- [x] Ready for testing