### PR TITLE
fix: correct ConfigMap key references in deployment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -32,12 +32,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: petrosa-common-config
-              key: environment
+              key: ENVIRONMENT
         - name: LOG_LEVEL
           valueFrom:
             configMapKeyRef:
               name: petrosa-common-config
-              key: log-level
+              key: LOG_LEVEL
         - name: HOST
           value: "0.0.0.0"
         - name: PORT


### PR DESCRIPTION
## Problem

The deployment was failing with  because the Kubernetes deployment manifest was referencing incorrect ConfigMap keys:

- Looking for  key but ConfigMap has  (uppercase)
- Looking for  key but ConfigMap has  (uppercase with underscore)

This caused the GitHub Actions deployment to timeout in run #17311826079.

## Solution

- Changed  key reference to  to match ConfigMap
- Changed  key reference to  to match ConfigMap

## Testing

- Verified ConfigMap keys exist in the cluster
- Applied deployment locally and confirmed pods start successfully
- All 3 replicas are now running without errors

## Impact

- Fixes deployment timeouts in CI/CD pipeline
- Resolves CreateContainerConfigError in Kubernetes pods
- Ensures proper environment variable injection from ConfigMap

Fixes deployment timeout issue from GitHub Actions run #17311826079