### PR TITLE
fix: increase deployment rollout timeout to match health check settings

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -388,7 +388,7 @@ jobs:
 
     - name: Wait for deployment to be ready
       run: |
-        kubectl rollout status deployment/petrosa-tradeengine -n ${{ env.NAMESPACE }} --timeout=300s --insecure-skip-tls-verify
+        kubectl rollout status deployment/petrosa-tradeengine -n ${{ env.NAMESPACE }} --timeout=900s --insecure-skip-tls-verify
 
     - name: Verify deployment
       run: |


### PR DESCRIPTION
## Summary
Fixes deployment timeout failures by increasing GitHub Actions rollout timeout.

## Problem
The deployment step fails with timeout after 300s, even though the K8s health check settings allow up to 660s for startup:
- startupProbe initialDelaySeconds: 60s
- startupProbe failureThreshold: 60
- startupProbe periodSeconds: 10s
- **Total max time**: 60s + (60 × 10s) = 660s

## Solution
Increase `kubectl rollout status` timeout from 300s to 900s (15 minutes) to align with actual pod startup requirements.

## Changes
- **.github/workflows/ci-cd.yml**: Update timeout parameter from 300s to 900s

## Testing
- ✅ No code changes, only workflow configuration
- ✅ Matches the health check timeout settings already deployed

## Impact
- Prevents false deployment failures when pods are legitimately starting up
- Allows time for MongoDB/NATS connection initialization
- No impact on actual deployment behavior, only monitoring timeout