### PR TITLE
fix: Move code copy before OTel installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ COPY requirements.txt .
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Copy application code (including otel_init.py)
+COPY . .
+
 # Install OpenTelemetry auto-instrumentation
 # This enables automatic instrumentation of Python applications
 # The opentelemetry-instrument command will be available for use
@@ -57,9 +60,6 @@ RUN pip install opentelemetry-distro opentelemetry-exporter-otlp-proto-grpc \
     opentelemetry-instrumentation-urllib3 \
     opentelemetry-instrumentation-fastapi \
     && opentelemetry-bootstrap --action=install
-
-# Copy application code
-COPY . .
 
 # Change ownership to app user
 RUN chown -R appuser:appuser /app


### PR DESCRIPTION
## Problem
- Code needs to be copied before OpenTelemetry installation to ensure otel_init.py is available
- Prevents potential ModuleNotFoundError in production

## Solution
- Moved `COPY . .` before OpenTelemetry installation step
- Ensures all application files (including otel_init.py) are available

## Impact
- Prevents potential runtime errors
- Follows Docker best practices
- Aligns with ta-bot implementation

## Testing
- Docker build verified
- Required for OpenTelemetry implementation

Related to OpenTelemetry auto-instrumentation rollout.