### PR TITLE
feat: add OpenTelemetry configuration and Prometheus scrape annotations

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app: petrosa-tradeengine
         version: VERSION_PLACEHOLDER
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
     spec:
       containers:
       - name: petrosa-tradeengine
@@ -42,6 +46,39 @@ spec:
           value: "0.0.0.0"
         - name: PORT
           value: "8000"
+        # OpenTelemetry Configuration
+        - name: ENABLE_OTEL
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: ENABLE_OTEL
+        - name: OTEL_SERVICE_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_SERVICE_VERSION
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_EXPORTER_OTLP_ENDPOINT
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.name=tradeengine,service.version=VERSION_PLACEHOLDER
+        - name: OTEL_METRICS_EXPORTER
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_METRICS_EXPORTER
+        - name: OTEL_TRACES_EXPORTER
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_TRACES_EXPORTER
+        - name: OTEL_LOGS_EXPORTER
+          valueFrom:
+            configMapKeyRef:
+              name: petrosa-common-config
+              key: OTEL_LOGS_EXPORTER
         # MongoDB configuration from secret
         - name: MONGODB_URI
           valueFrom:


### PR DESCRIPTION
## Changes
- Added OTEL environment variables for observability integration
- Added Prometheus scrape annotations for metrics collection
- Fixed metrics port to 8000 (FastAPI main port)
- Enables full Grafana Cloud integration

## Impact
- TradeEngine metrics will be scraped by Grafana Alloy
- OpenTelemetry traces will be sent to Grafana Cloud Tempo
- Full observability enabled for monitoring and troubleshooting

## Testing
- CI/CD pipeline will validate the changes
- Deploy through standard pipeline after merge