### PR TITLE
feat: add OTLP log export for complete observability stack

### DIFF
--- a/k8s/networkpolicy-allow-egress.yaml
+++ b/k8s/networkpolicy-allow-egress.yaml
@@ -31,10 +31,16 @@ spec:
   - ports:
     - protocol: TCP
       port: 9090
-  # Allow OTLP metrics export (Grafana Alloy)
-  - ports:
+  # Allow OTLP metrics/traces/logs export to Grafana Alloy (observability namespace)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: observability
+    ports:
     - protocol: TCP
       port: 4317
+    - protocol: TCP
+      port: 4318
   # Allow NATS connection
   - ports:
     - protocol: TCP


### PR DESCRIPTION
## Summary

This PR enables OTLP log export to complete the unified observability stack.

## Changes

- **otel_init.py**: Add OTLPLogExporter, LoggerProvider, and LoggingHandler for proper log export via OTLP
- **networkpolicy-allow-egress.yaml**: Update to allow egress to observability namespace on ports 4317/4318

## Benefits

- ✅ Logs now exported via OTLP (same as traces and metrics)
- ✅ Unified telemetry pipeline to Grafana Cloud
- ✅ Logs include trace_id for correlation with traces
- ✅ All three signals (traces, metrics, logs) operational

## Testing

- Built and tested with image: yurisa2/petrosa-tradeengine:v1.1.53-logs
- Verified OTLP log export initialization in pods
- Confirmed no authentication errors in Grafana Alloy
- Network connectivity tested and working

## Deployment

CI/CD will build and deploy automatically after merge.