### PR TITLE
fix: use correct pyroscope-io version (0.8.6)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ prometheus-client==0.19.0
 pydantic==2.6.1
 pydantic-settings==2.2.0
 pymongo==4.6.0
-pyroscope-io>=0.8.7
+pyroscope-io==0.8.6
 
 # Testing
 pytest==7.4.4


### PR DESCRIPTION
## Issue

PR #65 CI/CD failed because pyroscope-io 0.8.7 doesn't exist.

## Fix

Change requirement from `pyroscope-io>=0.8.7` to `pyroscope-io==0.8.6`

Latest available version is 0.8.6.

## Testing

- Verified 0.8.6 is available on PyPI
- Pre-commit hooks passed
- Ready to rebuild

Fixes: CI/CD build failure in PR #65