### PR TITLE
fix: attach OTLP logging handler after uvicorn starts

### DIFF
--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -30,6 +30,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Startup
     logger.info("Starting Petrosa Trading Engine...")
 
+    # Attach OTLP logging handler after uvicorn configures logging
+    otel_init.attach_logging_handler()
+
     try:
         # Validate MongoDB configuration first - fail catastrophically if not configured
         logger.info("Validating MongoDB configuration...")


### PR DESCRIPTION
## Root Cause

Uvicorn reconfigures Python logging during startup, which removes the OTLP LoggingHandler we attached during module import.

Result: Handler created but not active → logs not exported.

## Solution

1. Store LoggerProvider globally during setup_telemetry()
2. Create attach_logging_handler() function
3. Call it in api.py lifespan startup (after uvicorn finishes)

This ensures the handler persists and captures all application logs.

## Testing

Verified in pod that root logger had 0 handlers before this fix.

## Impact

✅ Logs will now actually flow to Grafana Cloud Loki via OTLP
✅ Completes the unified observability stack (metrics, traces, logs)

Fixes: Logs not appearing in Grafana Cloud despite OTLP export being configured