### PR TITLE
fix: OTLP logs - strip http:// prefix and ensure handler persistence

### DIFF
--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -75,6 +75,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.warning("⚠️ NATS consumer not initialized (likely disabled)")
 
         logger.info("Trading engine startup completed successfully")
+
+        # Ensure OTLP logging handler is still attached after all initialization
+        # Some imports might have called logging.basicConfig() which clears handlers
+        otel_init.ensure_logging_handler()
+
     except Exception as e:
         logger.error(f"CRITICAL: Startup failed - {e}")
         logger.error("Service will exit due to critical configuration error")


### PR DESCRIPTION
## Root Causes Found

**Issue 1: Invalid OTLP Endpoint Format**
- OTLP endpoint had `http://` prefix: `http://grafana-alloy....:4317`
- gRPC OTLP exporters don't accept protocol prefixes
- Result: Log exporter failing silently, no errors reported

**Issue 2: Handler Removal After Startup**
- At startup: "Total handlers: 2" ✅
- Later: "Handlers: 0" ❌  
- Cause: Something was clearing handlers after lifespan startup

## Fixes Implemented

### 1. Strip Protocol Prefix (Issue 2c)
- Automatically strip `http://` and `https://` from OTLP endpoint
- Applied in `setup_telemetry()` for all exporters
- Works regardless of ConfigMap value

### 2. Handler Persistence (Issue 1a)
- Added global reference `_otlp_logging_handler` to track handler
- Created `ensure_logging_handler()` to re-attach if removed
- Called after all initialization completes
- Handles `logging.basicConfig()` and other reconfigurations

## Testing

Verified in running pod:
- Before: `Handlers: 0`
- After manual attach: `Handlers: 2`, logs sent successfully
- Test logs visible with proper trace context

## Impact

✅ Logs will now flow to Grafana Cloud Loki via OTLP
✅ Handler persists even if logging is reconfigured  
✅ Completes unified observability (metrics, traces, logs)

## Related

- Companion PR needed in petrosa_k8s to remove `http://` from ConfigMap (cleaner config)
- Both fixes work independently