### PR TITLE
URGENT: Revert endpoint stripping that broke metrics/traces

### DIFF
--- a/otel_init.py
+++ b/otel_init.py
@@ -56,20 +56,6 @@ def setup_telemetry(
     # Get configuration from environment variables
     service_version = service_version or os.getenv("OTEL_SERVICE_VERSION", "1.0.0")
     otlp_endpoint = otlp_endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-
-    # Strip http:// or https:// prefix for gRPC OTLP endpoints
-    # gRPC exporters don't expect the protocol prefix
-    if otlp_endpoint:
-        original_endpoint = otlp_endpoint
-        if otlp_endpoint.startswith("http://"):
-            otlp_endpoint = otlp_endpoint[7:]
-        elif otlp_endpoint.startswith("https://"):
-            otlp_endpoint = otlp_endpoint[8:]
-
-        if original_endpoint != otlp_endpoint:
-            print(
-                f"ℹ️  Stripped protocol prefix from OTLP endpoint: {original_endpoint} -> {otlp_endpoint}"
-            )
     enable_metrics = enable_metrics and os.getenv("ENABLE_METRICS", "true").lower() in (
         "true",
         "1",


### PR DESCRIPTION
## Critical Issue

PR #69 broke metrics and traces by stripping http:// prefix from OTLP endpoint.

## What Happened

- Metrics were working → now broken
- Traces were working → now broken  
- Hypothesis that gRPC needs no prefix was WRONG

## This Revert

- Removes endpoint prefix stripping
- **Keeps** handler persistence logic (still valuable)
- Restores metrics and traces

## Root Cause

Metrics and traces NEED the http:// prefix with current configuration.
The gRPC OTLP libraries handle it correctly.

## Next Steps

1. Merge this ASAP to restore service
2. Investigate logs issue separately without breaking working functionality

**This is an urgent fix to restore broken observability.**