### PR TITLE
feat: add OTLP logging handler watchdog

### DIFF
--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -81,7 +81,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         otel_init.ensure_logging_handler()
 
         # Start watchdog to keep OTLP logging handler attached
-        async def logging_handler_watchdog():
+        async def logging_handler_watchdog() -> None:
             """Periodically ensure OTLP logging handler stays attached"""
             import asyncio
 


### PR DESCRIPTION
## Problem Observed

User reported: logs appear at initialization then stop

Evidence:
- Handler missing in running pods (checked: 0 handlers)
- Startup logs show handler attached (Total handlers: 1)
- Something removes handler AFTER startup completes

## Solution: Self-Healing Watchdog

Background task that runs every 30 seconds:
1. Checks if OTLP logging handler is attached
2. Re-attaches if missing
3. Logs when it had to fix it

## Tested in Running Pod

Before: Handlers: 0
After ensure_logging_handler(): Handlers: 1
Test logs sent successfully

## Why This Works

Even if we don't know WHAT removes the handler, the watchdog keeps it attached.
Logs will flow continuously, not just at startup.

## Impact

- Metrics: unaffected (no changes to metrics code)
- Traces: unaffected (no changes to traces code)
- Logs: should flow continuously with self-healing

## Code

Added to api.py lifespan:
- logging_handler_watchdog() async function
- Started as background task
- Uses existing ensure_logging_handler() from PR 70