### PR TITLE
🚨 CRITICAL: Remove hardcoded BINANCE_TESTNET=False in production

### DIFF
--- a/shared/constants.py
+++ b/shared/constants.py
@@ -489,7 +489,9 @@ if ENVIRONMENT == Environment.PRODUCTION:
     JWT_SECRET_KEY = (
         os.getenv("JWT_SECRET_KEY") or "your-secret-key-change-in-production"
     )  # Must be set in production
-    BINANCE_TESTNET = False
+    # REMOVED: BINANCE_TESTNET = False
+    # Reason: Allow testnet usage in production environment for testing
+    # Testnet setting should be controlled by BINANCE_TESTNET env var, not hardcoded
     COINBASE_SANDBOX = False
     KRAKEN_SANDBOX = False
 


### PR DESCRIPTION
## 🚨 ROOT CAUSE FOUND

This is the ACTUAL root cause preventing testnet from working!

### The Bug

**File**: `shared/constants.py:485-494`

```python
# Production overrides
if ENVIRONMENT == Environment.PRODUCTION:
    BINANCE_TESTNET = False  # ← HARDCODED! Ignores env var!
```

### Impact

- ENVIRONMENT=production (from ConfigMap)
- Code executes production override block
- BINANCE_TESTNET hardcoded to False
- **Environment variable completely ignored!**

### Evidence

```bash
$ env | grep BINANCE_TESTNET
BINANCE_TESTNET=true  # ← Env var says true

$ python3 -c "from shared.constants import BINANCE_TESTNET; print(BINANCE_TESTNET)"
False  # ← But constant is False!
```

Debug output:
```
ENV before import: true
Constant after import: False  ← OVERRIDE KICKED IN!
ENV after import: true
```

### Fix

Removed the hardcoded override. Now BINANCE_TESTNET respects the environment variable in all environments.

This allows:
- Using testnet in production for safe testing
- Using mainnet when BINANCE_TESTNET=false is set
- Flexibility based on configuration, not hardcoded assumptions

### Why This Matters

We run in ENVIRONMENT=production but need to use testnet Binance for safe testing.
The hardcoded override prevented this valid use case.

### Testing
Once deployed, verify:
```bash
kubectl logs deployment/petrosa-tradeengine | grep "TESTNET"
# Should show: TESTNET: True (not False)
```
