### PR TITLE
fix: Update MIN_NOTIONAL default to $20 and add 5% safety margin

### DIFF
--- a/docs/BINANCE_NOTIONAL_VALIDATION_FIX.md
+++ b/docs/BINANCE_NOTIONAL_VALIDATION_FIX.md
@@ -109,17 +109,34 @@ elif order.type in ["market", "stop", "take_profit"]:
 
 ### 3. Updated Default MIN_NOTIONAL
 
-**File:** `tradeengine/exchange/binance.py` (Line 467)
+**File:** `tradeengine/exchange/binance.py` (Line 475)
 
-Changed default from $5 to $100:
+Changed default from $100 to $20:
 
 ```python
 min_notional = (
-    float(min_notional_filter["notional"]) if min_notional_filter else 100.0
+    float(min_notional_filter["notional"]) if min_notional_filter else 20.0
 )
 ```
 
-**Rationale:** Binance increased MIN_NOTIONAL to $100 for most futures contracts.
+**Rationale:**
+- Binance's standard MIN_NOTIONAL for most USDⓈ-Margined Futures is $20
+- Specific symbols may have higher values (e.g., BTCUSDT: $100 as of Nov 2023)
+- The value is fetched from exchange info when available
+- The $20 default is only used as fallback if the filter is missing
+
+### 4. Added 5% Safety Margin
+
+**File:** `tradeengine/exchange/binance.py` (`calculate_min_order_amount()`)
+
+Added 5% safety margin to prevent rounding errors:
+
+```python
+# Add 5% safety margin to avoid rounding errors
+final_min_qty = final_min_qty * 1.05
+```
+
+**Rationale:** Prevents edge cases where calculated notional value ($19.94) falls just below minimum ($20.00) due to floating-point precision.
 
 ### 4. Added reduceOnly Parameter to All Order Methods
 

--- a/scripts/check-min-notional.py
+++ b/scripts/check-min-notional.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Diagnostic script to check MIN_NOTIONAL values for symbols
+
+This script queries the Binance Futures API to get MIN_NOTIONAL values
+and calculates the minimum order quantities needed at current prices.
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tradeengine.exchange.binance import BinanceFuturesExchange  # noqa: E402
+
+
+async def check_min_notional():
+    """Check MIN_NOTIONAL values for major trading symbols"""
+    exchange = BinanceFuturesExchange()
+
+    try:
+        print("\n🔍 Initializing Binance Futures Exchange...")
+        await exchange.initialize()
+        print("✅ Connected to Binance Futures\n")
+
+        # Major symbols to check
+        symbols = ["BTCUSDT", "ETHUSDT", "BNBUSDT", "ADAUSDT", "DOTUSDT"]
+
+        print("=" * 80)
+        print("MIN_NOTIONAL Values and Minimum Quantities")
+        print("=" * 80 + "\n")
+
+        for symbol in symbols:
+            try:
+                # Get MIN_NOTIONAL info with current price
+                info = await exchange.get_symbol_min_notional(symbol)
+
+                print(f"📊 {symbol}:")
+                print(f"  MIN_NOTIONAL:    ${info['min_notional']:.2f}")
+                print(f"  Current Price:   ${info['current_price']:.2f}")
+                print(f"  Min Quantity:    {info['min_quantity']:.8f}")
+                print(f"  Notional Value:  ${info['notional_value']:.2f}")
+                print(
+                    f"  Status:          {'✅ OK' if info['notional_value'] >= info['min_notional'] else '❌ FAILED'}"
+                )
+                print()
+
+            except Exception as e:
+                print(f"❌ {symbol}: Error - {e}\n")
+
+        print("=" * 80)
+        print(
+            "\n💡 Note: Min Quantity includes 5% safety margin to avoid rounding errors"
+        )
+        print("=" * 80 + "\n")
+
+    except Exception as e:
+        print(f"\n❌ Fatal error: {e}\n")
+        raise
+
+    finally:
+        await exchange.close()
+        print("✅ Exchange connection closed\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(check_min_notional())

--- a/tests/test_notional_validation.py
+++ b/tests/test_notional_validation.py
@@ -217,7 +217,7 @@ class TestNotionalValidation:
 
     @pytest.mark.asyncio
     async def test_default_min_notional_when_filter_missing(self):
-        """Test default MIN_NOTIONAL of $100 is used when filter is missing"""
+        """Test default MIN_NOTIONAL of $20 is used when filter is missing"""
         # Create exchange with symbol info missing MIN_NOTIONAL filter
         exchange = BinanceFuturesExchange()
         exchange.symbol_info = {
@@ -238,7 +238,7 @@ class TestNotionalValidation:
         }
 
         min_info = exchange.get_min_order_amount("TESTUSDT")
-        assert min_info["min_notional"] == 100.0  # Default value
+        assert min_info["min_notional"] == 20.0  # Default value (Binance standard)
 
     @pytest.mark.asyncio
     async def test_execute_market_order_with_reduce_only(self, exchange, mock_client):


### PR DESCRIPTION
## Summary
Fixes the remaining MIN_NOTIONAL issue where the default fallback value was set too high.

## Problem
After PR #81, orders were still failing with error: 'Order notional $19.94 is below minimum $20.00 for ETHUSDT'

The issue was:
- Default MIN_NOTIONAL fallback was $100 (should be $20)
- No safety margin to prevent rounding errors

## Changes Made

### 1. Updated Default MIN_NOTIONAL
- Changed from $100 to $20 (Binance standard for most symbols)
- Per Binance docs: ETHUSDT=$20, BTCUSDT=$100

### 2. Added 5% Safety Margin
- Added to `calculate_min_order_amount()`
- Prevents rounding errors causing $19.94 instead of $20.00
- Ensures orders always meet MIN_NOTIONAL

### 3. Enhanced Logging
- Detailed notional validation logging
- Shows exact calculations and requirements
- Better error messages with actionable guidance

### 4. Added Diagnostic Method
- `get_symbol_min_notional()` for troubleshooting
- Returns MIN_NOTIONAL, current price, min quantity

### 5. Improved Dispatcher
- Validates signal quantities meet MIN_NOTIONAL
- Automatically adjusts if too small

### 6. Created Diagnostic Tool
- `scripts/check-min-notional.py`
- Verifies MIN_NOTIONAL values for all major symbols

## Test Results
```
======================== 26 passed ========================
All tests passing ✓
Coverage: 18% overall
```

## Breaking Changes
None - fully backward compatible

## Deployment Notes
- No configuration changes required
- Follows up on PR #81
- Safe to deploy immediately after CI/CD checks pass