### PR TITLE
perf: Remove arm64 Docker builds for 50% faster deployments

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -321,7 +321,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem
Current deployment taking 21+ min for Docker builds (see PR #91).
Building for both amd64 AND arm64, but cluster only uses amd64.

## Solution
Remove `linux/arm64` - only build `linux/amd64`.

## Impact
- Docker build: 21 min → ~10 min (50% faster) 
- Total deployment: 25 min → ~15 min

**This will fix the slow deployment you're experiencing right now.**

Per .cursorrules: Pre-approved, merge once checks pass.