### PR TITLE
hotfix: MongoDB connection string fix for trading config system

### DIFF
--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -75,12 +74,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         # Initialize trading configuration manager
         logger.info("Initializing trading configuration manager...")
-        from shared.constants import get_mongodb_connection_string
+        from shared.constants import MONGODB_DATABASE, MONGODB_URI
 
-        mongodb_uri = get_mongodb_connection_string()
-        mongodb_db = os.getenv("MONGODB_DATABASE", "petrosa")
-
-        trading_config_mongodb = MongoDBClient(mongodb_uri, mongodb_db)
+        trading_config_mongodb = MongoDBClient(MONGODB_URI, MONGODB_DATABASE)
         trading_config_manager = TradingConfigManager(
             mongodb_client=trading_config_mongodb, cache_ttl_seconds=60
         )


### PR DESCRIPTION
## Critical Fix

Fixes MongoDB connection error in the trading configuration system deployed in PR #111.

## Error
```
MongoDB connection failed: Bad database name "/petrosa"
```

## Root Cause
`get_mongodb_connection_string()` returns URI with database already appended (`mongodb://host/petrosa`), but we were passing the database name again separately to MongoDBClient, causing it to try to connect to `/petrosa` as a database name.

## Fix
Use `MONGODB_URI` and `MONGODB_DATABASE` constants directly instead of the helper function.

```python
# Before (broken)
mongodb_uri = get_mongodb_connection_string()  # Returns mongodb://host/petrosa
mongodb_db = os.getenv("MONGODB_DATABASE", "petrosa")
MongoDBClient(mongodb_uri, mongodb_db)  # Tries to use /petrosa as db name

# After (fixed)
MongoDBClient(MONGODB_URI, MONGODB_DATABASE)  # Correct
```

## Testing
- Local Docker build: ✅ Success
- Pre-commit hooks: ✅ Passed
- Deployment verification needed after merge

## Impact
- Fixes trading configuration manager startup failure
- Enables all config API endpoints
- Unblocks LLM agent configuration workflows

**Merge immediately once CI passes** - this is blocking trading config system functionality.