### PR TITLE
fix: K8s Job immutability error - use generateName

### DIFF
--- a/k8s/mysql-schema-job.yaml
+++ b/k8s/mysql-schema-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: petrosa-tradeengine-mysql-schema
+  generateName: petrosa-tradeengine-mysql-schema-
   namespace: petrosa-apps
   labels:
     app: petrosa-tradeengine


### PR DESCRIPTION
Fixes CI/CD deployment error by using generateName instead of name for MySQL schema Job. This allows K8s to create unique Jobs on each deployment, avoiding immutability conflicts.