### PR TITLE
fix: delete old Job before kubectl apply to avoid immutability errors

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -398,6 +398,11 @@ jobs:
           echo "✅ All image references updated to versioned tag: ${IMAGE_TAG}"
         fi
 
+    - name: Delete old Job if exists
+      run: |
+        kubectl delete job petrosa-tradeengine-mysql-schema-init -n ${{ env.NAMESPACE }} --insecure-skip-tls-verify --ignore-not-found=true
+        echo "✅ Old Job deleted (if existed)"
+
     - name: Apply Kubernetes manifests
       run: |
         kubectl apply --insecure-skip-tls-verify -f k8s/ -n ${{ env.NAMESPACE }}

--- a/k8s/mysql-schema-job.yaml
+++ b/k8s/mysql-schema-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: petrosa-tradeengine-mysql-schema-
+  name: petrosa-tradeengine-mysql-schema-init
   namespace: petrosa-apps
   labels:
     app: petrosa-tradeengine


### PR DESCRIPTION
**Problem:**
The previous fix using `generateName` doesn't work with `kubectl apply`.
Error: `cannot use generate name with apply`

**Solution:**
1. Changed back to using `name` for the Job
2. Added CI/CD step to delete the old Job before applying manifests:
   ```yaml
   kubectl delete job petrosa-tradeengine-mysql-schema-init --ignore-not-found=true
   ```

**Why This Works:**
- Deletes old Job if it exists (idempotent with `--ignore-not-found`)
- Allows `kubectl apply` to create a fresh Job on every deployment
- ttlSecondsAfterFinished will clean up completed Jobs automatically

**Testing:**
- ✅ K8s Job will be recreated on each deployment
- ✅ No immutability conflicts
- ✅ Compatible with kubectl apply workflow