### PR TITLE
fix: delete both old and new Job names before K8s deployment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -400,8 +400,9 @@ jobs:
 
     - name: Delete old Job if exists
       run: |
+        kubectl delete job petrosa-tradeengine-mysql-schema -n ${{ env.NAMESPACE }} --insecure-skip-tls-verify --ignore-not-found=true
         kubectl delete job petrosa-tradeengine-mysql-schema-init -n ${{ env.NAMESPACE }} --insecure-skip-tls-verify --ignore-not-found=true
-        echo "✅ Old Job deleted (if existed)"
+        echo "✅ Old Jobs deleted (if existed)"
 
     - name: Apply Kubernetes manifests
       run: |


### PR DESCRIPTION
## Problem
The CI/CD deployment was failing because there was an old Job named `petrosa-tradeengine-mysql-schema` (31 hours old, stuck running) that was blocking the deployment of the new Job `petrosa-tradeengine-mysql-schema-init`.

## Solution
Updated the CI/CD workflow to delete both Job names before deployment:
- `petrosa-tradeengine-mysql-schema` (old name)
- `petrosa-tradeengine-mysql-schema-init` (new name)

This ensures that any existing Jobs are cleaned up before applying new manifests, preventing Kubernetes Job immutability errors.

## Changes
- Updated `.github/workflows/ci-cd.yml` to delete both Job names with `--ignore-not-found=true`
- Manually deleted the stuck old Job from the cluster

## Testing
- [ ] CI/CD checks pass
- [ ] Deployment succeeds
- [ ] MySQL schema Job completes successfully