### PR TITLE
fix: use kubectl create for Jobs instead of apply

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -398,15 +398,29 @@ jobs:
           echo "✅ All image references updated to versioned tag: ${IMAGE_TAG}"
         fi
 
-    - name: Delete old Job if exists
+    - name: Delete old MySQL Job if exists
       run: |
         kubectl delete job petrosa-tradeengine-mysql-schema -n ${{ env.NAMESPACE }} --insecure-skip-tls-verify --ignore-not-found=true
         kubectl delete job petrosa-tradeengine-mysql-schema-init -n ${{ env.NAMESPACE }} --insecure-skip-tls-verify --ignore-not-found=true
-        echo "✅ Old Jobs deleted (if existed)"
+        echo "✅ Old MySQL Jobs deleted (if existed)"
+        echo "⏳ Waiting for Job cleanup..."
+        sleep 10
 
-    - name: Apply Kubernetes manifests
+    - name: Apply Kubernetes manifests (except Jobs)
       run: |
-        kubectl apply --insecure-skip-tls-verify -f k8s/ -n ${{ env.NAMESPACE }}
+        # Apply all manifests except Job files (Jobs are immutable)
+        for file in k8s/*.yaml; do
+          if [[ "$file" != *"job.yaml" ]]; then
+            kubectl apply --insecure-skip-tls-verify -f "$file" -n ${{ env.NAMESPACE }}
+          fi
+        done
+        echo "✅ Kubernetes manifests applied (excluding Jobs)"
+
+    - name: Create MySQL Schema Job
+      run: |
+        # Create the Job (Jobs should use create, not apply)
+        kubectl create --insecure-skip-tls-verify -f k8s/mysql-schema-job.yaml -n ${{ env.NAMESPACE }}
+        echo "✅ MySQL Schema Job created"
 
     - name: Wait for deployment to be ready
       run: |


### PR DESCRIPTION
## Problem
Kubernetes Jobs are immutable and cannot be updated with `kubectl apply`. The deployment was failing with:
```
The Job "petrosa-tradeengine-mysql-schema-init" is invalid: spec.template: Invalid value: field is immutable
```

## Root Cause
Using `kubectl apply -f k8s/` on Job manifests causes immutability errors because:
- Jobs cannot be updated once created (spec.template is immutable)
- `kubectl apply` tries to update the existing Job instead of recreating it

## Solution
Changed the deployment workflow to properly handle Jobs:
1. **Delete old Jobs** and wait 10 seconds for Kubernetes to clean up
2. **Apply all manifests except Jobs** using `kubectl apply`
3. **Create the MySQL Schema Job separately** using `kubectl create`

This approach:
- Ensures Jobs are always freshly created
- Prevents immutability errors
- Properly cleans up old Jobs before creating new ones

## Changes
- Updated `.github/workflows/ci-cd.yml`:
  - Added 10-second wait after deleting Jobs
  - Split manifest application into two steps: non-Jobs and Jobs
  - Changed Job deployment from `apply` to `create`

## Testing
- [ ] CI/CD lint and test pass
- [ ] Deployment succeeds
- [ ] MySQL Schema Job completes successfully
- [ ] No immutability errors