### PR TITLE
fix: increase GHA deployment timeout from 15m to 30m

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -424,7 +424,7 @@ jobs:
 
     - name: Wait for deployment to be ready
       run: |
-        kubectl rollout status deployment/petrosa-tradeengine -n ${{ env.NAMESPACE }} --timeout=900s --insecure-skip-tls-verify
+        kubectl rollout status deployment/petrosa-tradeengine -n ${{ env.NAMESPACE }} --timeout=1800s --insecure-skip-tls-verify
 
     - name: Verify deployment
       run: |


### PR DESCRIPTION
## Problem

The hedge mode implementation deployment (PR #121) took 19 minutes to roll out successfully, but the GHA workflow timed out at 15 minutes, causing a false failure.

**Evidence**: https://github.com/PetroSa2/petrosa-tradeengine/actions/runs/18686773987

**Actual deployment status**: ✅ SUCCESSFUL (all 3 pods running v1.1.111)

## Solution

Increase deployment rollout timeout from 900s (15 minutes) to 1800s (30 minutes).

## Changes
- `.github/workflows/ci-cd.yml`: Update `--timeout=900s` to `--timeout=1800s`

## Verification

Current deployment is healthy:
```
replicas: 3/3
readyReplicas: 3/3
availableReplicas: 3/3
Status: Available - True
```

All hedge mode features working in production:
- ✅ LONG/SHORT simultaneous positions on ETHUSDT
- ✅ Multi-strategy position accumulation
- ✅ Strategy position tracking active

## Impact

- Prevents false failures for complex deployments
- No change to actual deployment behavior
- Only affects GHA timeout handling