### PR TITLE
fix: correct Data Manager client import path in MySQL client

### DIFF
--- a/shared/mysql_client.py
+++ b/shared/mysql_client.py
@@ -19,7 +19,7 @@ from pymysql.cursors import DictCursor
 
 # Import Data Manager client
 try:
-    from ..tradeengine.services.data_manager_client import DataManagerClient
+    from tradeengine.services.data_manager_client import DataManagerClient
 
     DATA_MANAGER_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
## 🔧 Fix Import Path for Data Manager Client

This PR fixes the import path for the DataManagerClient in the MySQL client.

### 🐛 Issue
- MySQL client was failing to import DataManagerClient due to incorrect import path
- Import path  was incorrect for shared/mysql_client.py
- This caused  to be False, preventing Data Manager integration

### ✅ Changes Made
- Changed import to 
- This fixes the import error and enables Data Manager integration

### 🚀 Impact
- MySQL client will now properly use Data Manager when 
- Service will no longer hang trying to connect to MySQL directly
- Startup probes will pass and service will become ready

### 🧪 Testing
- [x] Code formatting (black, ruff)
- [x] Linting checks passed
- [x] Pre-commit hooks passed