### PR TITLE
Fix deployment import errors after MongoDB to Data Manager migration

### DIFF
--- a/tradeengine/db/__init__.py
+++ b/tradeengine/db/__init__.py
@@ -1,6 +1,6 @@
 """Database clients for trading configuration system."""
 
-from tradeengine.db.mongodb_client import MongoDBClient
+from tradeengine.db.mongodb_client import DataManagerConfigClient
 from tradeengine.db.mysql_config_repository import MySQLConfigRepository
 
-__all__ = ["MongoDBClient", "MySQLConfigRepository"]
+__all__ = ["DataManagerConfigClient", "MySQLConfigRepository"]

--- a/tradeengine/leverage_manager.py
+++ b/tradeengine/leverage_manager.py
@@ -16,7 +16,7 @@ from binance import Client
 from binance.exceptions import BinanceAPIException
 
 from contracts.trading_config import LeverageStatus
-from tradeengine.db.mongodb_client import MongoDBClient
+from tradeengine.db.mongodb_client import DataManagerConfigClient
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class LeverageManager:
     def __init__(
         self,
         binance_client: Optional[Client] = None,
-        mongodb_client: Optional[MongoDBClient] = None,
+        mongodb_client: Optional[DataManagerConfigClient] = None,
     ):
         """
         Initialize leverage manager.


### PR DESCRIPTION
## Problem
The petrosa-tradeengine deployment was failing with import errors after the MongoDB to Data Manager migration. The application was crashing with:

```
ImportError: cannot import name 'MongoDBClient' from 'tradeengine.db.mongodb_client'
```

## Root Cause
- The `mongodb_client.py` file was refactored to contain `DataManagerConfigClient` instead of `MongoDBClient`
- The `db/__init__.py` file was still trying to import the old `MongoDBClient` class
- The `leverage_manager.py` file was also importing the old class
- MongoDB validation was still required at startup, but we now use the Data Manager service

## Solution
- ✅ Updated `db/__init__.py` to import `DataManagerConfigClient` instead of `MongoDBClient`
- ✅ Updated `leverage_manager.py` to use `DataManagerConfigClient`
- ✅ Made MongoDB validation optional since we now use Data Manager service
- ✅ Updated type hints and parameter types accordingly

## Testing
- ✅ Local import test passes
- ✅ Linting passes
- ✅ Pre-commit hooks pass

## Impact
This fix resolves the deployment crash and allows the application to start properly with the new Data Manager architecture.