### PR TITLE
fix: add missing sqlalchemy and aiomysql dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 
+# Database and persistence
+aiomysql==0.2.0
+
 asyncio-mqtt==0.16.1
 
 # Development and linting
@@ -14,8 +17,6 @@ httpx==0.25.2
 # Documentation
 mkdocs==1.5.3
 mkdocs-material==9.4.8
-
-# Database and persistence
 motor==3.3.2
 mypy==1.8.0
 
@@ -64,5 +65,6 @@ python-dotenv==1.0.0
 python-jose[cryptography]==3.3.0
 python-multipart==0.0.18
 ruff==0.1.15
+sqlalchemy[asyncio]==2.0.25
 structlog==23.2.0
 uvicorn[standard]==0.24.0


### PR DESCRIPTION
## Problem
Deployment v1.1.131 is failing with ModuleNotFoundError for sqlalchemy.

## Solution
- Add sqlalchemy[asyncio]==2.0.25 to support AuditLogger in shared/logger.py
- Add aiomysql==0.2.0 for async MySQL connections

## Testing
- ✅ Local import test passed
- ✅ Linting passed

## Impact
Fixes CrashLoopBackOff in production deployment