### PR TITLE
hotfix: add missing get_logger function

### DIFF
--- a/shared/logger.py
+++ b/shared/logger.py
@@ -141,3 +141,8 @@ class AuditLogger:
 
 # Global audit logger instance
 audit_logger = AuditLogger()
+
+
+def get_logger(name: str = __name__):
+    """Get a logger instance."""
+    return logging.getLogger(name)


### PR DESCRIPTION
## Problem
v1.1.132 failing with ImportError: cannot import name 'get_logger' from 'shared.logger'

## Solution
Added get_logger() function to shared/logger.py

## Testing
Function exists and returns logging.Logger

## Impact
Emergency fix for production crash