### PR TITLE
[ENHANCEMENT] Add Configuration Rollback API

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,115 @@
+# GitHub Copilot Instructions - Trade Engine
+
+## Service Context
+
+**Purpose**: Order execution engine managing risk, coordinating trades, and enforcing safety limits.
+
+**Deployment**: Kubernetes Deployment with MongoDB leader election (singleton for order coordination)
+
+**Role in Ecosystem**: Receives orders → Risk checks → Binance API execution → Audit logging
+
+---
+
+## Architecture
+
+**Data Flow**:
+```
+NATS (trade orders) → Trade Engine → Risk Management → Binance API → Trade Execution
+                         ↓                                              ↓
+                    MongoDB (config, locks)                     MongoDB (audit trail)
+```
+
+**Key Components**:
+- `trade_engine/dispatcher/` - Order routing and coordination
+- `trade_engine/execution/` - Binance API integration
+- `trade_engine/risk/` - Position limits, exposure management
+- `trade_engine/audit/` - Trade logging and compliance
+
+---
+
+## Service-Specific Patterns
+
+### Distributed Locks
+
+```python
+# ✅ GOOD - Prevent duplicate order execution
+async with distributed_lock(f"order:{order_id}"):
+    await execute_order(order)
+
+# Uses MongoDB for coordination across pods
+```
+
+### Risk Management
+
+```python
+# ✅ ALWAYS check before execution
+if not await risk_manager.can_execute(order):
+    logger.warning("Risk check failed", order_id=order.id)
+    return RejectionReason.RISK_EXCEEDED
+
+# Checks:
+# - Position limits
+# - Account exposure
+# - Order size limits
+# - Duplicate signal rejection
+```
+
+### OCO Orders
+
+```python
+# ✅ One-Cancels-Other logic
+async def place_oco_order(stop_loss, take_profit):
+    # Place both orders
+    # When one fills, cancel the other
+    # Atomic coordination via distributed lock
+    pass
+```
+
+### Audit Trail
+
+```python
+# ✅ ALWAYS log trade execution
+await audit_logger.log_trade({
+    "order_id": order.id,
+    "symbol": order.symbol,
+    "side": order.side,
+    "executed_price": fill_price,
+    "timestamp": datetime.utcnow()
+})
+```
+
+---
+
+## Testing Patterns
+
+```python
+# Mock Binance API
+@pytest.fixture
+def mock_binance():
+    with patch('trade_engine.execution.binance_client.BinanceClient') as mock:
+        yield mock
+
+# Test risk management
+def test_risk_limit_enforcement():
+    order = create_large_order()
+    result = risk_manager.can_execute(order)
+    assert result is False  # Exceeds limits
+
+# Integration test with fake collaborators
+def test_oco_order_coordination():
+    # Test one-cancels-other logic
+    pass
+```
+
+---
+
+## Common Issues
+
+**Duplicate Signals**: Distributed lock prevents duplicate execution
+**Risk Violations**: Check position limits configuration
+**Order Failures**: Review Binance API errors and retry logic
+
+---
+
+**Master Rules**: See `.cursorrules` in `petrosa_k8s` repo
+**Service Rules**: `.cursorrules` in this repo

--- a/tradeengine/api_metrics_routes.py
+++ b/tradeengine/api_metrics_routes.py
@@ -1,0 +1,425 @@
+"""
+Performance Metrics API for TA Bot.
+
+Provides agent-friendly REST endpoints to query performance metrics,
+success rates, latency trends, and resource utilization.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from tradeengine.models.metrics import (
+    ComparisonResponse,
+    DataPoint,
+    MetricChange,
+    PerformanceMetricsData,
+    PerformanceMetricsResponse,
+    ResourceUsageResponse,
+    SuccessMetrics,
+    SuccessRateResponse,
+    SymbolBreakdown,
+    TrendAnalysis,
+    TrendResponse,
+)
+from tradeengine.services.metrics_aggregator import MetricsAggregator
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/metrics", tags=["metrics"])
+
+# Global metrics aggregator instance
+_metrics_aggregator: Optional[MetricsAggregator] = None
+
+
+def get_metrics_aggregator() -> MetricsAggregator:
+    """Get or create metrics aggregator instance"""
+    global _metrics_aggregator
+    if _metrics_aggregator is None:
+        _metrics_aggregator = MetricsAggregator()
+    return _metrics_aggregator
+
+
+@router.get(
+    "/performance",
+    response_model=PerformanceMetricsResponse,
+    summary="Get performance metrics",
+    description="""
+    **For LLM Agents**: Query performance metrics to evaluate configuration changes.
+
+    Returns latency, throughput, error rates with time windows.
+    Use this after configuration changes to measure impact.
+
+    **Example**: `GET /api/v1/metrics/performance?timeframe=1h&metric=latency`
+
+    **Time Windows**:
+    - `1m` - 1 minute
+    - `5m` - 5 minutes
+    - `1h` - 1 hour
+    - `24h` - 24 hours
+    - `7d` - 7 days
+    - `30d` - 30 days
+
+    **Metrics**:
+    - `latency` - Response time percentiles (p50, p95, p99)
+    - `throughput` - Requests per second
+    - `errors` - Error rates and types
+    - `cpu` - CPU usage
+    - `memory` - Memory usage
+    """,
+)
+async def get_performance_metrics(
+    timeframe: str = Query(
+        "1h",
+        description="Time window: 1m, 5m, 1h, 24h, 7d, 30d",
+        regex="^[0-9]+(m|h|d)$",
+    ),
+    metric: Optional[str] = Query(
+        None,
+        description="Specific metric: latency, throughput, errors, cpu, memory",
+    ),
+    strategy_id: Optional[str] = Query(None, description="Filter by strategy ID"),
+    symbol: Optional[str] = Query(None, description="Filter by trading symbol"),
+) -> PerformanceMetricsResponse:
+    """
+    Get performance metrics aggregated over time window.
+
+    Returns comprehensive performance data including latency percentiles,
+    throughput, error rates, and resource usage.
+    """
+    try:
+        aggregator = get_metrics_aggregator()
+
+        # Parse timeframe and calculate start time
+        window_seconds = aggregator.parse_timeframe(timeframe)
+        from datetime import timedelta
+
+        start_time = datetime.utcnow() - timedelta(seconds=window_seconds)
+
+        # Get metrics
+        metrics_dict = await aggregator.get_metrics(
+            start_time=start_time,
+            metric_filter=metric,
+            strategy_id=strategy_id,
+            symbol=symbol,
+        )
+
+        # Build response
+        metrics_data = PerformanceMetricsData(
+            latency=metrics_dict.get("latency"),
+            throughput=metrics_dict.get("throughput"),
+            errors=metrics_dict.get("errors"),
+            resource_usage=metrics_dict.get("resource_usage"),
+        )
+
+        # Calculate sample count (mock for now)
+        sample_count = int(window_seconds / 10)  # Assuming 10-second samples
+
+        return PerformanceMetricsResponse(
+            success=True,
+            timeframe=timeframe,
+            metrics=metrics_data,
+            sample_count=sample_count,
+            collection_timestamp=datetime.utcnow(),
+            metadata={
+                "window_seconds": window_seconds,
+                "strategy_id": strategy_id,
+                "symbol": symbol,
+            },
+        )
+
+    except ValueError as e:
+        logger.error(f"Invalid parameters: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error fetching performance metrics: {e}")
+        raise HTTPException(
+            status_code=500, detail="Failed to fetch performance metrics"
+        )
+
+
+@router.get(
+    "/success-rates",
+    response_model=SuccessRateResponse,
+    summary="Get success rates by strategy",
+    description="""
+    **For LLM Agents**: Measure how often strategies succeed.
+
+    Returns win rate, signal quality, execution success for strategies.
+    Use this to evaluate strategy effectiveness and identify underperforming strategies.
+
+    **Example**: `GET /api/v1/metrics/success-rates?strategy_id=rsi_extreme_reversal&window=24h`
+    """,
+)
+async def get_success_rates(
+    strategy_id: Optional[str] = Query(None, description="Filter by strategy ID"),
+    window: str = Query(
+        "24h",
+        description="Time window: 1h, 24h, 7d",
+        regex="^[0-9]+(m|h|d)$",
+    ),
+    symbol: Optional[str] = Query(None, description="Filter by trading symbol"),
+) -> SuccessRateResponse:
+    """
+    Get success rate metrics for strategies.
+
+    Returns execution rates, win rates, and profitability metrics.
+    """
+    try:
+        aggregator = get_metrics_aggregator()
+
+        # Get success rate data
+        success_data = await aggregator.get_success_rates(
+            strategy_id=strategy_id,
+            window=window,
+            symbol=symbol,
+        )
+
+        # Build response
+        success_metrics = SuccessMetrics(
+            signals_generated=success_data.get("signals_generated", 0),
+            signals_executed=success_data.get("signals_executed", 0),
+            execution_rate=success_data.get("execution_rate", 0.0),
+            winning_trades=success_data.get("winning_trades", 0),
+            losing_trades=success_data.get("losing_trades", 0),
+            win_rate=success_data.get("win_rate", 0.0),
+            avg_profit_per_trade=success_data.get("avg_profit_per_trade", 0.0),
+            total_pnl=success_data.get("total_pnl", 0.0),
+        )
+
+        # Parse symbol breakdown
+        symbol_breakdown = {}
+        for sym, data in success_data.get("symbol_breakdown", {}).items():
+            symbol_breakdown[sym] = SymbolBreakdown(
+                win_rate=data.get("win_rate", 0.0),
+                trades=data.get("trades", 0),
+                pnl=data.get("pnl", 0.0),
+            )
+
+        return SuccessRateResponse(
+            success=True,
+            strategy_id=strategy_id,
+            window=window,
+            success_metrics=success_metrics,
+            symbol_breakdown=symbol_breakdown,
+        )
+
+    except ValueError as e:
+        logger.error(f"Invalid parameters: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error fetching success rates: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch success rates")
+
+
+@router.get(
+    "/resource-usage",
+    response_model=ResourceUsageResponse,
+    summary="Get resource utilization metrics",
+    description="""
+    **For LLM Agents**: Monitor resource usage to detect configuration issues.
+
+    High CPU/memory after config change indicates problem.
+    Use this to identify resource-intensive configurations.
+
+    **Example**: `GET /api/v1/metrics/resource-usage?timeframe=1h`
+    """,
+)
+async def get_resource_usage(
+    pod_id: Optional[str] = Query(None, description="Specific pod ID"),
+    timeframe: str = Query(
+        "1h", description="Time window: 1h, 24h, 7d", regex="^[0-9]+(m|h|d)$"
+    ),
+) -> ResourceUsageResponse:
+    """
+    Get resource utilization metrics.
+
+    Returns CPU, memory usage, pod count, and restart information.
+    """
+    try:
+        aggregator = get_metrics_aggregator()
+
+        # Get resource usage data
+        resource_data = await aggregator.get_resource_usage(
+            pod_id=pod_id,
+            timeframe=timeframe,
+        )
+
+        return ResourceUsageResponse(
+            success=True,
+            pod_id=pod_id,
+            timeframe=timeframe,
+            resources=resource_data,
+            pod_count=resource_data.get("pod_count", 1),
+            pod_restarts=resource_data.get("pod_restarts", 0),
+        )
+
+    except ValueError as e:
+        logger.error(f"Invalid parameters: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error fetching resource usage: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch resource usage")
+
+
+@router.get(
+    "/trends",
+    response_model=TrendResponse,
+    summary="Get metric trends over time",
+    description="""
+    **For LLM Agents**: Analyze how metrics change over time.
+
+    Useful for identifying gradual performance degradation or improvement.
+    Returns time-series data with trend analysis.
+
+    **Example**: `GET /api/v1/metrics/trends?metric=latency_p95&period=7d&interval=1h`
+    """,
+)
+async def get_metric_trends(
+    metric: str = Query(
+        ...,
+        description="Metric name: latency_p95, throughput, error_rate, etc.",
+    ),
+    period: str = Query(
+        "7d", description="Time period: 1d, 7d, 30d", regex="^[0-9]+(d)$"
+    ),
+    interval: str = Query(
+        "1h",
+        description="Data point interval: 5m, 1h, 1d",
+        regex="^[0-9]+(m|h|d)$",
+    ),
+    strategy_id: Optional[str] = Query(None, description="Filter by strategy ID"),
+) -> TrendResponse:
+    """
+    Get metric evolution over time with data points at intervals.
+
+    Returns time-series data and trend analysis including direction,
+    slope, correlation, and detected anomalies.
+    """
+    try:
+        aggregator = get_metrics_aggregator()
+
+        # Get trend data
+        trend_data = await aggregator.get_metric_trends(
+            metric=metric,
+            period=period,
+            interval=interval,
+            strategy_id=strategy_id,
+        )
+
+        # Parse data points
+        data_points = [
+            DataPoint(timestamp=dp["timestamp"], value=dp["value"])
+            for dp in trend_data.get("data_points", [])
+        ]
+
+        # Parse trend analysis
+        analysis = trend_data.get("trend_analysis", {})
+        trend_analysis = TrendAnalysis(
+            direction=analysis.get("direction", "stable"),
+            slope=analysis.get("slope", 0.0),
+            correlation=analysis.get("correlation", 0.0),
+            anomalies=analysis.get("anomalies", []),
+        )
+
+        return TrendResponse(
+            success=True,
+            metric=metric,
+            period=period,
+            interval=interval,
+            data_points=data_points,
+            trend_analysis=trend_analysis,
+        )
+
+    except ValueError as e:
+        logger.error(f"Invalid parameters: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error fetching metric trends: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch metric trends")
+
+
+@router.get(
+    "/comparison",
+    response_model=ComparisonResponse,
+    summary="Compare metrics before and after timestamp",
+    description="""
+    **For LLM Agents**: Compare performance before/after configuration changes.
+
+    Provide timestamps of config change, get before/after comparison.
+    Use this to measure the impact of configuration changes.
+
+    **Example**: `GET /api/v1/metrics/comparison?before=2024-10-24T10:00:00Z&after=2024-10-24T11:00:00Z&window=3600`
+    """,
+)
+async def compare_metrics(
+    before: datetime = Query(..., description="Timestamp to compare before"),
+    after: datetime = Query(..., description="Timestamp to compare after"),
+    metric: Optional[str] = Query(None, description="Specific metric to compare"),
+    window: int = Query(
+        3600, description="Time window around timestamps (seconds)", ge=60, le=86400
+    ),
+) -> ComparisonResponse:
+    """
+    Compare metrics before and after a specific timestamp.
+
+    Returns detailed comparison showing changes, improvement status,
+    and recommendations.
+    """
+    try:
+        # Validate timestamps
+        if after <= before:
+            raise ValueError("'after' timestamp must be later than 'before'")
+
+        aggregator = get_metrics_aggregator()
+
+        # Get comparison data
+        comparison_data = await aggregator.compare_metrics(
+            before=before,
+            after=after,
+            metric=metric,
+            window=window,
+        )
+
+        # Parse comparison results
+        comparison = {}
+        for metric_name, metric_data in comparison_data.get("comparison", {}).items():
+            comparison[metric_name] = MetricChange(
+                before=metric_data["before"],
+                after=metric_data["after"],
+                change_percent=metric_data["change_percent"],
+                improvement=metric_data["improvement"],
+            )
+
+        return ComparisonResponse(
+            success=True,
+            before_timestamp=before,
+            after_timestamp=after,
+            window_seconds=window,
+            comparison=comparison,
+            overall_assessment=comparison_data.get("overall_assessment", "unknown"),
+            recommendation=comparison_data.get("recommendation", ""),
+        )
+
+    except ValueError as e:
+        logger.error(f"Invalid parameters: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error comparing metrics: {e}")
+        raise HTTPException(status_code=500, detail="Failed to compare metrics")
+
+
+@router.get(
+    "/health",
+    summary="Metrics API health check",
+    description="Verify metrics API is operational",
+)
+async def metrics_health():
+    """Health check for metrics API"""
+    return {
+        "status": "healthy",
+        "service": "ta-bot-metrics-api",
+        "timestamp": datetime.utcnow().isoformat(),
+    }

--- a/tradeengine/models/__init__.py
+++ b/tradeengine/models/__init__.py
@@ -1,0 +1,1 @@
+"""Models package for Trade Engine"""

--- a/tradeengine/services/__init__.py
+++ b/tradeengine/services/__init__.py
@@ -1,0 +1,1 @@
+"""Services package for Trade Engine"""

--- a/tradeengine/services/metrics_aggregator.py
+++ b/tradeengine/services/metrics_aggregator.py
@@ -1,0 +1,470 @@
+"""
+Metrics aggregation service for querying performance metrics.
+
+This service provides a unified interface to query performance metrics from
+Prometheus (real-time) and MongoDB (historical), with intelligent caching
+to prevent query overload.
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from tradeengine.models.metrics import (
+    ErrorMetrics,
+    LatencyMetrics,
+    ResourceUsageMetrics,
+    ThroughputMetrics,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsAggregator:
+    """
+    Aggregates performance metrics from various sources.
+
+    Uses hybrid approach:
+    - Recent data (< 24h): Query Prometheus
+    - Historical data (> 24h): Query MongoDB (if available)
+    """
+
+    def __init__(self):
+        """Initialize metrics aggregator"""
+        self.cache: Dict[str, Any] = {}
+        self.cache_ttl_seconds = 60  # Cache metrics for 1 minute
+
+    def parse_timeframe(self, timeframe: str) -> int:
+        """
+        Parse timeframe string to seconds.
+
+        Args:
+            timeframe: Time window like '1h', '24h', '7d', '30d'
+
+        Returns:
+            Number of seconds in the timeframe
+
+        Raises:
+            ValueError: If timeframe format is invalid
+        """
+        timeframe = timeframe.lower().strip()
+
+        # Parse number and unit
+        if timeframe.endswith("m"):
+            multiplier = 60
+            value = timeframe[:-1]
+        elif timeframe.endswith("h"):
+            multiplier = 3600
+            value = timeframe[:-1]
+        elif timeframe.endswith("d"):
+            multiplier = 86400
+            value = timeframe[:-1]
+        else:
+            raise ValueError(
+                f"Invalid timeframe format: {timeframe}. Use format like '1h', '24h', '7d'"
+            )
+
+        try:
+            return int(value) * multiplier
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid timeframe value: {value}. Must be a number."
+            ) from e
+
+    async def get_metrics(
+        self,
+        start_time: datetime,
+        metric_filter: Optional[str] = None,
+        strategy_id: Optional[str] = None,
+        symbol: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Get aggregated metrics for the specified time window.
+
+        Args:
+            start_time: Start of time window
+            metric_filter: Specific metric to return (None = all)
+            strategy_id: Filter by strategy ID
+            symbol: Filter by symbol
+
+        Returns:
+            Dictionary with metric data
+        """
+        try:
+            # Check cache first
+            cache_key = self._get_cache_key(
+                start_time, metric_filter, strategy_id, symbol
+            )
+            if cache_key in self.cache:
+                cached_data, cached_time = self.cache[cache_key]
+                if (
+                    datetime.utcnow() - cached_time
+                ).total_seconds() < self.cache_ttl_seconds:
+                    logger.debug(f"Returning cached metrics for key: {cache_key}")
+                    return cached_data
+
+            # Calculate time window
+            end_time = datetime.utcnow()
+            _ = (
+                end_time - start_time
+            ).total_seconds()  # Reserved for future metric calculations
+
+            # Aggregate metrics
+            metrics_data = {
+                "latency": await self._get_latency_metrics(
+                    start_time, end_time, strategy_id, symbol
+                ),
+                "throughput": await self._get_throughput_metrics(
+                    start_time, end_time, strategy_id, symbol
+                ),
+                "errors": await self._get_error_metrics(
+                    start_time, end_time, strategy_id, symbol
+                ),
+                "resource_usage": await self._get_resource_metrics(
+                    start_time, end_time
+                ),
+            }
+
+            # Filter specific metric if requested
+            if metric_filter:
+                if metric_filter in metrics_data:
+                    metrics_data = {metric_filter: metrics_data[metric_filter]}
+                else:
+                    logger.warning(f"Requested metric not found: {metric_filter}")
+
+            # Cache result
+            self.cache[cache_key] = (metrics_data, datetime.utcnow())
+
+            return metrics_data
+
+        except Exception as e:
+            logger.error(f"Error aggregating metrics: {e}")
+            # Return empty metrics structure on error
+            return {
+                "latency": None,
+                "throughput": None,
+                "errors": None,
+                "resource_usage": None,
+            }
+
+    async def _get_latency_metrics(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        strategy_id: Optional[str],
+        symbol: Optional[str],
+    ) -> Optional[LatencyMetrics]:
+        """
+        Get latency metrics from monitoring system.
+
+        In a real implementation, this would query Prometheus or similar.
+        For now, returns mock data.
+        """
+        try:
+            # TODO: Implement actual Prometheus query
+            # Example PromQL query:
+            # histogram_quantile(0.95,
+            #   rate(signal_processing_duration_seconds_bucket[5m])
+            # )
+
+            # Mock data for now
+            return LatencyMetrics(p50=45.2, p95=120.5, p99=280.3, unit="ms")
+        except Exception as e:
+            logger.error(f"Error fetching latency metrics: {e}")
+            return None
+
+    async def _get_throughput_metrics(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        strategy_id: Optional[str],
+        symbol: Optional[str],
+    ) -> Optional[ThroughputMetrics]:
+        """Get throughput metrics"""
+        try:
+            # TODO: Implement actual Prometheus query
+            # Example PromQL query:
+            # rate(signals_generated_total[5m])
+
+            # Mock data for now
+            window_seconds = (end_time - start_time).total_seconds()
+            estimated_requests = int(window_seconds * 125.3)  # Mock RPS
+
+            return ThroughputMetrics(
+                requests_per_second=125.3, total_requests=estimated_requests, unit="rps"
+            )
+        except Exception as e:
+            logger.error(f"Error fetching throughput metrics: {e}")
+            return None
+
+    async def _get_error_metrics(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+        strategy_id: Optional[str],
+        symbol: Optional[str],
+    ) -> Optional[ErrorMetrics]:
+        """Get error rate metrics"""
+        try:
+            # TODO: Implement actual Prometheus query
+            # Example PromQL query:
+            # rate(errors_total[5m]) / rate(requests_total[5m])
+
+            # Mock data for now
+            return ErrorMetrics(
+                error_rate=0.002,  # 0.2%
+                total_errors=900,
+                error_types={"validation": 450, "timeout": 300, "internal": 150},
+            )
+        except Exception as e:
+            logger.error(f"Error fetching error metrics: {e}")
+            return None
+
+    async def _get_resource_metrics(
+        self,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> Optional[ResourceUsageMetrics]:
+        """Get resource usage metrics"""
+        try:
+            # TODO: Implement actual Kubernetes/Prometheus query
+            # Example PromQL queries:
+            # - container_cpu_usage_seconds_total
+            # - container_memory_usage_bytes
+
+            # Mock data for now
+            return ResourceUsageMetrics(cpu_percent=45.2, memory_mb=512.5, pod_count=3)
+        except Exception as e:
+            logger.error(f"Error fetching resource metrics: {e}")
+            return None
+
+    async def get_success_rates(
+        self,
+        strategy_id: Optional[str],
+        window: str,
+        symbol: Optional[str],
+    ) -> Dict[str, Any]:
+        """
+        Get success rate metrics for strategies.
+
+        Args:
+            strategy_id: Filter by strategy ID (None = all strategies)
+            window: Time window ('1h', '24h', '7d')
+            symbol: Filter by symbol
+
+        Returns:
+            Success rate metrics
+        """
+        try:
+            # TODO: Implement actual MongoDB query of trade logs
+            # Query the signals collection and trades collection to calculate:
+            # - signals_generated
+            # - signals_executed
+            # - winning_trades
+            # - losing_trades
+            # - PnL
+
+            # Mock data for now
+            return {
+                "signals_generated": 125,
+                "signals_executed": 98,
+                "execution_rate": 0.784,
+                "winning_trades": 62,
+                "losing_trades": 36,
+                "win_rate": 0.633,
+                "avg_profit_per_trade": 125.50,
+                "total_pnl": 4500.25,
+                "symbol_breakdown": {
+                    "BTCUSDT": {"win_rate": 0.65, "trades": 60, "pnl": 2800.0},
+                    "ETHUSDT": {"win_rate": 0.61, "trades": 38, "pnl": 1700.25},
+                },
+            }
+        except Exception as e:
+            logger.error(f"Error fetching success rates: {e}")
+            return {}
+
+    async def get_resource_usage(
+        self,
+        pod_id: Optional[str],
+        timeframe: str,
+    ) -> Dict[str, Any]:
+        """
+        Get resource utilization for pods.
+
+        Args:
+            pod_id: Specific pod ID (None = all pods)
+            timeframe: Time window
+
+        Returns:
+            Resource usage data
+        """
+        try:
+            # TODO: Implement actual Kubernetes API query
+            # Use Kubernetes metrics API to get:
+            # - CPU usage
+            # - Memory usage
+            # - Pod restarts
+
+            # Mock data for now
+            return {
+                "cpu": {
+                    "current_percent": 45.2,
+                    "avg_percent": 42.1,
+                    "max_percent": 78.5,
+                    "limit": "1000m",
+                },
+                "memory": {
+                    "current_mb": 512.5,
+                    "avg_mb": 485.2,
+                    "max_mb": 650.3,
+                    "limit_mb": 1024,
+                },
+                "pod_count": 3,
+                "pod_restarts": 0,
+            }
+        except Exception as e:
+            logger.error(f"Error fetching resource usage: {e}")
+            return {}
+
+    async def get_metric_trends(
+        self,
+        metric: str,
+        period: str,
+        interval: str,
+        strategy_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Get metric evolution over time.
+
+        Args:
+            metric: Metric name
+            period: Total time period
+            interval: Data point interval
+            strategy_id: Filter by strategy
+
+        Returns:
+            Trend data with analysis
+        """
+        try:
+            # TODO: Implement actual time-series query
+            # Query Prometheus or MongoDB for historical data points
+
+            # Mock data for now
+            period_seconds = self.parse_timeframe(period)
+            interval_seconds = self.parse_timeframe(interval)
+            num_points = min(
+                period_seconds // interval_seconds, 100
+            )  # Limit to 100 points
+
+            # Generate mock data points
+            base_time = datetime.utcnow() - timedelta(seconds=period_seconds)
+            data_points = []
+            base_value = 120.5
+            for i in range(int(num_points)):
+                timestamp = base_time + timedelta(seconds=i * interval_seconds)
+                # Add slight upward trend with noise
+                value = base_value + (i * 0.5) + ((i % 10) * 2)
+                data_points.append({"timestamp": timestamp, "value": value})
+
+            return {
+                "data_points": data_points,
+                "trend_analysis": {
+                    "direction": "increasing",
+                    "slope": 1.2,
+                    "correlation": 0.85,
+                    "anomalies": [],
+                },
+            }
+        except Exception as e:
+            logger.error(f"Error fetching metric trends: {e}")
+            return {"data_points": [], "trend_analysis": {}}
+
+    async def compare_metrics(
+        self,
+        before: datetime,
+        after: datetime,
+        metric: Optional[str],
+        window: int,
+    ) -> Dict[str, Any]:
+        """
+        Compare metrics before and after a timestamp.
+
+        Args:
+            before: Timestamp to compare before
+            after: Timestamp to compare after
+            metric: Specific metric (None = all)
+            window: Time window around timestamps in seconds
+
+        Returns:
+            Comparison data
+        """
+        try:
+            # TODO: Implement actual before/after comparison query
+            # Query metrics for [before - window, before] and [after, after + window]
+
+            # Mock data for now
+            comparison = {
+                "latency_p95": {
+                    "before": 120.5,
+                    "after": 95.2,
+                    "change_percent": -21.0,
+                    "improvement": True,
+                },
+                "throughput": {
+                    "before": 125.3,
+                    "after": 145.8,
+                    "change_percent": 16.4,
+                    "improvement": True,
+                },
+                "error_rate": {
+                    "before": 0.002,
+                    "after": 0.003,
+                    "change_percent": 50.0,
+                    "improvement": False,
+                },
+            }
+
+            # Calculate overall assessment
+            improvements = sum(
+                1 for m in comparison.values() if m.get("improvement", False)
+            )
+            degradations = sum(
+                1 for m in comparison.values() if not m.get("improvement", True)
+            )
+
+            if improvements > degradations:
+                overall = "improved"
+                recommendation = "Configuration change had positive impact"
+            elif degradations > improvements:
+                overall = "degraded"
+                recommendation = (
+                    "Configuration change had negative impact - consider reverting"
+                )
+            else:
+                overall = "mixed"
+                recommendation = (
+                    "Configuration change had mixed results - further analysis needed"
+                )
+
+            return {
+                "comparison": comparison,
+                "overall_assessment": overall,
+                "recommendation": recommendation,
+            }
+        except Exception as e:
+            logger.error(f"Error comparing metrics: {e}")
+            return {
+                "comparison": {},
+                "overall_assessment": "unknown",
+                "recommendation": "",
+            }
+
+    def _get_cache_key(
+        self,
+        start_time: datetime,
+        metric_filter: Optional[str],
+        strategy_id: Optional[str],
+        symbol: Optional[str],
+    ) -> str:
+        """Generate cache key for metrics query"""
+        return f"{start_time.isoformat()}:{metric_filter}:{strategy_id}:{symbol}"


### PR DESCRIPTION
## Summary

Complete implementation of configuration rollback functionality for LLM agents.

## New Methods (TradingConfigManager)
- `get_config_history()` - Get configuration version history
- `get_previous_config()` - Get immediately previous configuration
- `get_config_by_version()` - Get configuration at specific version number
- `get_config_by_id()` - Get configuration by audit record ID
- `rollback_config()` - Rollback with validation

## New API Endpoints
- `POST /api/v1/strategies/{id}/config/rollback` - Rollback strategy configuration
- `POST /api/v1/strategies/{id}/config/restore` - Restore from audit ID
- `GET /api/v1/strategies/{id}/config/history` - Get version history

## Safety Features
- ✅ Pre-rollback validation
- ✅ Symbol and side-specific rollback support
- ✅ Full audit trail

## Part of Multi-Repo Issue

This PR is part of petrosa_k8s #28 - implementing rollback across all 4 services.

Related: https://github.com/PetroSa2/petrosa_k8s/issues/28