### PR TITLE
[TECH-DEBT] Address Copilot feedback on security workflow: clarify comment and improve SARIF upload condition

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,16 +149,18 @@ jobs:
         format: 'sarif'
         output: 'trivy-results.sarif'
         severity: 'CRITICAL,HIGH'
-        exit-code: '1'  # Fail if vulnerabilities found
+        # Use exit-code '1' to fail the pipeline if vulnerabilities are found
+        # This enforces security standards and blocks PRs with high-severity issues
+        exit-code: '1'
         ignore-unfixed: true
         vuln-type: 'os,library'
 
-    - name: Upload Trivy results
+    - name: Upload Trivy results to GitHub Security
       uses: github/codeql-action/upload-sarif@v3
+      # Upload SARIF if the scan completed (success or failure), but not if cancelled/skipped
       if: success() || failure()
       with:
         sarif_file: 'trivy-results.sarif'
-      # Note: Uploads scan results to Security tab for visibility (PR blocking happens via exit-code: '1' above)
 
   # Pipeline status check - aggregates all PR checks
   pipeline:


### PR DESCRIPTION
## Summary

This PR addresses Copilot feedback on the security workflow by improving code clarity and documentation.

## Changes

- **Clarified exit-code comment**: Added detailed explanation for why `exit-code: '1'` is used in Trivy scanner (enforces security standards and blocks PRs with vulnerabilities)
- **Improved step name**: Changed to 'Upload Trivy results to GitHub Security' for better clarity
- **Enhanced SARIF upload condition comment**: Explained that upload happens on success/failure but not on cancel/skip

## Testing

- ✅ Pre-commit hooks passed
- ✅ YAML syntax validated
- ✅ No functional changes - only documentation improvements

## Related Issue

Closes #184

## Acceptance Criteria

- [x] Comment clarified for exit-code behavior
- [x] SARIF upload step name improved
- [x] Upload condition comment enhanced
- [x] No breaking changes to workflow functionality

---

**Type**: tech-debt
**Priority**: medium
**Service**: tradeengine