### PR TITLE
docs: add GitHub CLI profile configuration reference

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -22,8 +22,29 @@ All systems use the same remote MicroK8s cluster, CI/CD pipeline patterns, and d
 - **kubectl**: Required for Kubernetes deployment (remote cluster)
 - **Make**: Required for using the Makefile commands
 - **Poetry**: Optional but recommended for dependency management
+- **GitHub CLI (gh)**: Required for GitHub operations (issue management, PR creation, project board updates)
 
 **Note**: All projects use a **remote MicroK8s cluster** - no local Kubernetes installation required.
+
+### GitHub CLI Profile Configuration (CRITICAL)
+
+**🚨 MANDATORY**: Always use the `yurisa2` GitHub profile for all GitHub CLI operations.
+
+**Before ANY GitHub CLI Operation**:
+```bash
+# Check current active profile
+gh auth status
+
+# If NOT using yurisa2, switch to it
+gh auth switch --user yurisa2
+
+# Verify switch was successful
+gh auth status
+```
+
+**Required Profile**: `yurisa2` (yuri@sa2.com.br) - This profile has correct permissions for project board updates.
+
+**For complete details**: See master cursorrules at `petrosa_k8s/.cursorrules` → "GitHub CLI Profile Configuration"
 
 ## Quick Start Commands
 ```bash


### PR DESCRIPTION
Adds reference to master cursorrules for GitHub CLI profile configuration requirement.

- References master cursorrules for GitHub CLI profile configuration
- Documents requirement to use yurisa2 profile for all GitHub operations
- Prevents permission errors when working with GitHub project board

This is a documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `.cursorrules` documentation.
> 
> - **Adds** `GitHub CLI (gh)` as a prerequisite
> - **Introduces CRITICAL section** mandating the `yurisa2` profile for all `gh` operations, with check/switch/verify commands
> - **References** master rules at `petrosa_k8s/.cursorrules` for full details
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c34abc643d423243ccaaeeb3c805be6c696bfca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->