### PR TITLE
fix: improve dispatch logic and order sizing

### DIFF
--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -870,7 +870,7 @@ class Dispatcher:
         # Format: {signal_id: timestamp} - stores signal IDs with their reception time
         self.signal_cache: dict[str, float] = {}
         self.signal_cache_ttl = (
-            60  # Cache TTL in seconds (signals older than this are considered unique)
+            10  # Cache TTL in seconds (signals older than this are considered unique)
         )
         self.signal_cache_cleanup_interval = 300  # Cleanup every 5 minutes
 
@@ -1658,13 +1658,9 @@ class Dispatcher:
                 amount = min_amount
 
             self.logger.info(
-                "Order amount calculated",
-                event="order_amount_calculated",
-                symbol=signal.symbol,
-                amount=amount,
-                signal_qty=signal.quantity,
-                min_required=min_amount,
-                current_price=current_price,
+                f"Order amount calculated for {signal.symbol}: amount={amount}, "
+                f"signal_qty={signal.quantity}, min_required={min_amount}, "
+                f"current_price={current_price}"
             )
 
             return amount
@@ -1675,19 +1671,15 @@ class Dispatcher:
                 exc_info=True,
             )
             # Fallback: Calculate amount to meet minimum notional with safety margin
-            # Use a $25 target notional, which is above the system's $20 MIN_NOTIONAL default
-            # Note: We use signal.current_price here, but if it was invalid/caused the error,
-            # the fallback calculation may still fail. However, since this is a fallback path
-            # and we can't easily fetch price synchronously, we use what we have.
+            # Use a $110 target notional, which is above the $100 MIN_NOTIONAL for BTCUSDT
             current_price = signal.current_price or 0
 
             if current_price > 0:
-                # Target $25 notional value to avoid MIN_NOTIONAL rejections
-                # ($25 is above the $20 default MIN_NOTIONAL with safety margin)
-                fallback_amount = 25.0 / current_price
+                # Target $110 notional value to avoid MIN_NOTIONAL rejections
+                fallback_amount = 110.0 / current_price
                 self.logger.warning(
                     f"Using fallback amount {fallback_amount} for {signal.symbol} "
-                    f"(target notional: $25.00 at ${current_price:.2f})"
+                    f"(target notional: $110.00 at ${current_price:.2f})"
                 )
                 return fallback_amount
             else:


### PR DESCRIPTION
This PR addresses critical issues identified in signal execution and dispatching.

### Changes:
- **Deduplication TTL**: Reduced  from 60s to 10s. The previous 60s window was too broad, causing legitimate strategy signals (like Iceberg detections) to be rejected as duplicates.
- **Order Sizing**: Increased the fallback target notional from 5 to 10. This ensures that orders meet Binance's 00 minimum requirement for BTCUSDT even in fallback scenarios.
- **Logging Fix**: Removed the unsupported  keyword from  calls in  to fix a  that was crashing the order amount calculation.

These changes are essential for ensuring signals trigger orders correctly on Binance.