### PR TITLE
chore: bump version to 1.1.176

### DIFF
--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -222,7 +222,7 @@ app = FastAPI(
     description=(
         "Advanced cryptocurrency trading engine with multi-strategy signal aggregation"
     ),
-    version="1.1.0",
+    version="1.1.176",
     lifespan=lifespan,
 )
 


### PR DESCRIPTION
Bumping version to trigger a fresh CI build and push a clean image to Docker Hub, resolving the corrupted v1.1.175 image issue.