### PR TITLE
chore: bump version to 1.1.178

### DIFF
--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -222,7 +222,7 @@ app = FastAPI(
     description=(
         "Advanced cryptocurrency trading engine with multi-strategy signal aggregation"
     ),
-    version="1.1.177",
+    version="1.1.178",
     lifespan=lifespan,
 )
 


### PR DESCRIPTION
Retrying build with v1.1.178 to resolve corrupted registry state.