### PR TITLE
Merge configuration rollback and filter hierarchy to main

### DIFF
--- a/contracts/trading_config.py
+++ b/contracts/trading_config.py
@@ -30,16 +30,13 @@ class TradingConfig(BaseModel):
 
     # Scope identifiers
     strategy_id: str | None = Field(
-        None, description="Strategy identifier for strategy-scoped configurations"
+        None, description="Strategy identifier (None for global/symbol configs)"
     )
     symbol: str | None = Field(
         None, description="Trading symbol (None for global configs, e.g., 'BTCUSDT')"
     )
     side: Literal["LONG", "SHORT"] | None = Field(
         None, description="Position side (None for global/symbol configs)"
-    )
-    strategy_id: str | None = Field(
-        None, description="Strategy identifier (None for global/symbol configs)"
     )
 
     # Configuration data

--- a/tests/test_api_filter_routes.py
+++ b/tests/test_api_filter_routes.py
@@ -11,7 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from contracts.trading_config import TradingConfig
 from tradeengine.api import app
 from tradeengine.api_filter_routes import get_config_manager, set_config_manager
 from tradeengine.config_manager import TradingConfigManager
@@ -108,10 +107,17 @@ class TestStrategyFilterRoutes:
 
     def test_update_strategy_filters_success(self, client, mock_config_manager):
         """Test successful update of strategy filters."""
-        # Setup mock
-        mock_config_manager.mongodb_client.upsert_strategy_config = AsyncMock(
-            return_value=True
-        )
+        # Setup mock: set_config returns (success, config, errors)
+        mock_config = MagicMock()
+        mock_config.model_dump.return_value = {
+            "strategy_id": "momentum_strategy",
+            "parameters": {
+                "tp_distance_min_pct": 2.0,
+                "tp_distance_max_pct": 15.0,
+                "enabled_sides": ["LONG"],
+            },
+        }
+        mock_config_manager.set_config = AsyncMock(return_value=(True, mock_config, []))
 
         # Make request
         response = client.put(
@@ -135,11 +141,11 @@ class TestStrategyFilterRoutes:
         assert "metadata" in data
         assert "updated successfully" in data["metadata"]["message"]
 
-        # Verify config manager methods were called
-        mock_config_manager.mongodb_client.upsert_strategy_config.assert_called_once()
-        mock_config_manager.invalidate_cache.assert_called_once_with(
-            strategy_id="momentum_strategy"
-        )
+        # Verify set_config was called with strategy_id for validation/audit
+        mock_config_manager.set_config.assert_called_once()
+        call_kwargs = mock_config_manager.set_config.call_args[1]
+        assert call_kwargs["strategy_id"] == "momentum_strategy"
+        assert call_kwargs["parameters"]["tp_distance_min_pct"] == 2.0
 
     def test_update_strategy_filters_no_db_client(self, client, mock_config_manager):
         """Test error handling when no database client is configured."""
@@ -163,13 +169,11 @@ class TestStrategyFilterRoutes:
         assert data["error"]["code"] == "NO_DB"
 
     def test_update_strategy_filters_upsert_failure(self, client, mock_config_manager):
-        """Test error handling when upsert fails."""
-        # Setup mock
-        mock_config_manager.mongodb_client.upsert_strategy_config = AsyncMock(
-            return_value=False
+        """Test error handling when set_config returns failure."""
+        mock_config_manager.set_config = AsyncMock(
+            return_value=(False, None, ["Failed to save configuration"])
         )
 
-        # Make request
         response = client.put(
             "/api/v1/config/filters/strategy/momentum_strategy",
             json={
@@ -179,7 +183,6 @@ class TestStrategyFilterRoutes:
             },
         )
 
-        # Assert response
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
@@ -189,8 +192,7 @@ class TestStrategyFilterRoutes:
         self, client, mock_config_manager
     ):
         """Test error handling when exception occurs during update."""
-        # Setup mock to raise exception
-        mock_config_manager.mongodb_client.upsert_strategy_config = AsyncMock(
+        mock_config_manager.set_config = AsyncMock(
             side_effect=Exception("Database error")
         )
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -551,6 +551,21 @@ def test_trading_config_audit_get_change_summary() -> None:
     assert "global" in summary
     assert "admin" in summary
 
+    # Strategy-scoped config (strategy_id path)
+    audit = TradingConfigAudit(
+        config_type="strategy",
+        symbol=None,
+        side=None,
+        strategy_id="orderbook_skew",
+        action="update",
+        changed_by="tester",
+    )
+    summary = audit.get_change_summary()
+    assert "UPDATE" in summary
+    assert "strategy" in summary
+    assert "orderbook_skew" in summary
+    assert "tester" in summary
+
 
 def test_leverage_status_is_synced() -> None:
     """Test LeverageStatus is_synced method"""

--- a/tradeengine/api_filter_routes.py
+++ b/tradeengine/api_filter_routes.py
@@ -10,7 +10,6 @@ from typing import Any, Literal
 from fastapi import APIRouter, HTTPException, Path
 from pydantic import BaseModel, Field
 
-from contracts.trading_config import TradingConfig
 from tradeengine.config_manager import TradingConfigManager
 
 logger = logging.getLogger(__name__)
@@ -59,6 +58,17 @@ class APIResponse(BaseModel):
     metadata: dict[str, Any | None] = Field(None, description="Additional metadata")
 
 
+def _http_error_response(he: HTTPException) -> APIResponse:
+    """Convert HTTPException to APIResponse for consistent response shape."""
+    detail = he.detail
+    message = (
+        "; ".join(str(x) for x in detail) if isinstance(detail, list) else str(detail)
+    )
+    return APIResponse(
+        success=False, error={"code": "CONFIG_ERROR", "message": message}
+    )
+
+
 # =============================================================================
 # API Router
 # =============================================================================
@@ -83,6 +93,8 @@ async def get_global_filters() -> APIResponse:
             data={"filters": config},
             message="Global filters retrieved successfully",
         )
+    except HTTPException as he:
+        return _http_error_response(he)
     except Exception as e:
         logger.error(f"Error getting global filters: {e}")
         return APIResponse(
@@ -114,8 +126,8 @@ async def update_global_filters(request: FilterUpdateRequest) -> APIResponse:
                 success=False,
                 error={"code": "UPDATE_FAILED", "message": ", ".join(errors)},
             )
-    except HTTPException:
-        raise
+    except HTTPException as he:
+        return _http_error_response(he)
     except Exception as e:
         logger.error(f"Error updating global filters: {e}")
         return APIResponse(
@@ -137,8 +149,8 @@ async def get_pair_filters(
             data={"symbol": symbol, "filters": config},
             message=f"Filters for {symbol} retrieved successfully",
         )
-    except HTTPException:
-        raise
+    except HTTPException as he:
+        return _http_error_response(he)
     except Exception as e:
         logger.error(f"Error getting pair filters: {e}")
         return APIResponse(
@@ -173,8 +185,8 @@ async def update_pair_filters(
                 success=False,
                 error={"code": "UPDATE_FAILED", "message": ", ".join(errors)},
             )
-    except HTTPException:
-        raise
+    except HTTPException as he:
+        return _http_error_response(he)
     except Exception as e:
         logger.error(f"Error updating pair filters: {e}")
         return APIResponse(
@@ -197,8 +209,8 @@ async def get_side_filters(
             data={"symbol": symbol, "side": side, "filters": config},
             message=f"Filters for {symbol}-{side} retrieved successfully",
         )
-    except HTTPException:
-        raise
+    except HTTPException as he:
+        return _http_error_response(he)
     except Exception as e:
         logger.error(f"Error getting side filters: {e}")
         return APIResponse(
@@ -234,8 +246,8 @@ async def update_side_filters(
                 success=False,
                 error={"code": "UPDATE_FAILED", "message": ", ".join(errors)},
             )
-    except HTTPException:
-        raise
+    except HTTPException as he:
+        return _http_error_response(he)
     except Exception as e:
         logger.error(f"Error updating side filters: {e}")
         return APIResponse(
@@ -285,8 +297,8 @@ async def get_strategy_filters(
             data={"strategy_id": strategy_id, "filters": filters},
             message=f"Filters for strategy {strategy_id} retrieved successfully",
         )
-    except HTTPException:
-        raise
+    except HTTPException as he:
+        return _http_error_response(he)
     except Exception as e:
         logger.error(f"Error getting strategy filters: {e}")
         return APIResponse(
@@ -303,42 +315,36 @@ async def update_strategy_filters(
     try:
         manager = get_config_manager()
 
-        config = TradingConfig(
-            strategy_id=strategy_id,
-            symbol=None,
-            side=None,
-            parameters=request.filters,
-            created_by=request.changed_by,
-            metadata={"reason": request.reason} if request.reason else {},
-        )
-
-        # Save via mongodb client
-        if manager.mongodb_client:
-            success = await manager.mongodb_client.upsert_strategy_config(config)
-
-            if success:
-                manager.invalidate_cache(strategy_id=strategy_id)
-
-                return APIResponse(
-                    success=True,
-                    data={"config": config.model_dump()},
-                    message=f"Filters for strategy {strategy_id} updated successfully",
-                )
-            else:
-                return APIResponse(
-                    success=False,
-                    error={
-                        "code": "UPDATE_FAILED",
-                        "message": "Failed to update strategy filters",
-                    },
-                )
-        else:
+        if not manager.mongodb_client or not manager.mongodb_client.connected:
             return APIResponse(
                 success=False,
                 error={"code": "NO_DB", "message": "MongoDB client not configured"},
             )
-    except HTTPException:
-        raise
+
+        success, config, errors = await manager.set_config(
+            parameters=request.filters,
+            changed_by=request.changed_by,
+            reason=request.reason,
+            strategy_id=strategy_id,
+        )
+
+        if success and config:
+            msg = f"Filters for strategy {strategy_id} updated successfully"
+            return APIResponse(
+                success=True,
+                data={"config": config.model_dump()},
+                message=msg,
+                metadata={"message": msg},
+            )
+        return APIResponse(
+            success=False,
+            error={
+                "code": "UPDATE_FAILED",
+                "message": errors[0] if errors else "Failed to update strategy filters",
+            },
+        )
+    except HTTPException as he:
+        return _http_error_response(he)
     except Exception as e:
         logger.error(f"Error updating strategy filters: {e}")
         return APIResponse(

--- a/tradeengine/config_manager.py
+++ b/tradeengine/config_manager.py
@@ -234,6 +234,7 @@ class TradingConfigManager:
         changed_by: str,
         symbol: str | None = None,
         side: str | None = None,
+        strategy_id: str | None = None,
         reason: str | None = None,
         validate_only: bool = False,
     ) -> tuple[bool, TradingConfig | None, list[str]]:
@@ -245,6 +246,7 @@ class TradingConfigManager:
             changed_by: Who is making the change
             symbol: Trading symbol (None for global)
             side: Position side (None for symbol-level)
+            strategy_id: Strategy identifier (None for global/symbol/symbol_side)
             reason: Reason for the change
             validate_only: If True, only validate without saving
 
@@ -260,8 +262,10 @@ class TradingConfigManager:
             return True, None, []
 
         try:
-            # Determine config type
-            if symbol and side:
+            # Determine config type (strategy scope takes precedence when set)
+            if strategy_id is not None:
+                config_type = "strategy"
+            elif symbol and side:
                 config_type = "symbol_side"
             elif symbol:
                 config_type = "symbol"
@@ -284,14 +288,20 @@ class TradingConfigManager:
                         symbol,  # type: ignore
                         side,  # type: ignore
                     )
+            elif config_type == "strategy" and strategy_id:
+                if self.mongodb_client and self.mongodb_client.connected:
+                    existing_config = await self.mongodb_client.get_strategy_config(
+                        strategy_id
+                    )
 
             # Create new config
             version = (existing_config.version + 1) if existing_config else 1
             now = datetime.utcnow()
 
             new_config = TradingConfig(
-                symbol=symbol,
-                side=side,  # type: ignore
+                symbol=symbol if config_type != "strategy" else None,
+                side=side if config_type != "strategy" else None,  # type: ignore
+                strategy_id=strategy_id if config_type == "strategy" else None,
                 parameters=parameters,
                 version=version,
                 created_at=existing_config.created_at if existing_config else now,
@@ -313,6 +323,11 @@ class TradingConfigManager:
                     success = await self.mongodb_client.set_symbol_side_config(
                         new_config
                     )
+            elif config_type == "strategy" and strategy_id:
+                if self.mongodb_client and self.mongodb_client.connected:
+                    success = await self.mongodb_client.upsert_strategy_config(
+                        new_config
+                    )
 
             if not success:
                 return False, None, ["Failed to save configuration"]
@@ -320,8 +335,9 @@ class TradingConfigManager:
             # Create audit record
             audit = TradingConfigAudit(
                 config_type=config_type,  # type: ignore
-                symbol=symbol,
-                side=side,  # type: ignore
+                symbol=symbol if config_type != "strategy" else None,
+                side=side if config_type != "strategy" else None,  # type: ignore
+                strategy_id=strategy_id if config_type == "strategy" else None,
                 action="update" if existing_config else "create",
                 parameters_before=(
                     existing_config.parameters if existing_config else None
@@ -337,14 +353,18 @@ class TradingConfigManager:
             if self.mongodb_client and self.mongodb_client.connected:
                 await self.mongodb_client.add_audit_record(audit)
 
-            # Invalidate cache for all strategies under this scope.
-            self.invalidate_cache(symbol=symbol, side=side)
+            # Invalidate cache for this scope
+            if config_type == "strategy":
+                self.invalidate_cache(strategy_id=strategy_id)
+            else:
+                self.invalidate_cache(symbol=symbol, side=side)
 
-            logger.info(
-                f"Config updated: {config_type} "
-                f"{'(' + symbol + ')' if symbol else ''}"
-                f"{'-' + side if side else ''} by {changed_by}"
+            scope = (
+                f"({strategy_id})" if strategy_id else f"({symbol})" if symbol else ""
             )
+            if side and not strategy_id:
+                scope += f"-{side}"
+            logger.info(f"Config updated: {config_type} {scope} by {changed_by}")
 
             return True, new_config, []
 


### PR DESCRIPTION
This PR merges the implementation of configuration rollback API and strategy-specific filter endpoints. All conflicts resolved locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new strategy-scoped branch to config persistence/auditing and changes the strategy filter update endpoint to use `TradingConfigManager.set_config`, which could affect how configs are versioned/cached and how failures are reported.
> 
> **Overview**
> Adds **strategy-scoped trading configuration** support across the stack.
> 
> `TradingConfigManager.set_config` now accepts `strategy_id`, persists strategy configs via MongoDB (`get_strategy_config`/`upsert_strategy_config`), writes audits with `config_type="strategy"`, and invalidates cache by `strategy_id`. The filter API routes are updated to return a consistent `APIResponse` (including a new top-level `message`) and to handle `HTTPException` uniformly, while the strategy filter `PUT` endpoint now goes through `set_config` (with MongoDB connectivity checks) instead of calling the Mongo client directly.
> 
> Contracts/tests are updated accordingly: `TradingConfigAudit` gains `strategy` scope fields and summary formatting, and API tests are rewritten to mock/validate the new `set_config` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88898d45ee2649e43b5b33d4f5c254ce6dee2bee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->