### PR TITLE
[INFRA] Refactor deploy workflows to centralized GitOps pattern

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -357,8 +357,50 @@ jobs:
           COMMIT_SHA=${{ github.sha }}
           BUILD_DATE=${{ steps.meta.outputs.date }}
 
-  notify:
+  gitops-update:
+    name: GitOps Update
+    runs-on: ubuntu-latest
     needs: [build-and-push, prepare-release]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Checkout petrosa_k8s
+        uses: actions/checkout@v4
+        with:
+          repository: PetroSa2/petrosa_k8s
+          ref: main
+          token: ${{ secrets.GITOPS_BOT_TOKEN }}
+          path: petrosa_k8s
+
+      - name: Rebase on main
+        run: ./scripts/gitops-rebase-main.sh
+        working-directory: petrosa_k8s
+
+      - name: Update tradeengine image tag in GitOps manifests
+        run: |
+          VERSION="${{ needs.prepare-release.outputs.version }}"
+          # Update the image tag in manifests
+          find petrosa_k8s/k8s/tradeengine -name "*.yaml" -o -name "*.yml" | xargs sed -i "s/VERSION_PLACEHOLDER/$VERSION/g"
+
+          # Also update the version label if needed
+          find petrosa_k8s/k8s/tradeengine -name "*.yaml" -o -name "*.yml" | xargs sed -i "s/version: VERSION_PLACEHOLDER/version: $VERSION/g"
+
+          echo "Updated tradeengine image tag to $VERSION in petrosa_k8s/k8s/tradeengine/"
+
+      - name: Commit and push to petrosa_k8s
+        working-directory: petrosa_k8s
+        run: |
+          git config user.name "gitops-bot"
+          git config user.email "gitops-bot@users.noreply.github.com"
+          git add k8s/tradeengine/
+          if git diff --staged --quiet; then
+            echo "No changes to commit (version might already be up to date)"
+          else
+            git commit -m "gitops: tradeengine image ${{ needs.prepare-release.outputs.version }}"
+            git push origin main
+          fi
+
+  notify:
+    needs: [build-and-push, prepare-release, gitops-update]
     runs-on: ubuntu-latest
     if: always()
 
@@ -368,15 +410,15 @@ jobs:
         VERSION="${{ needs.prepare-release.outputs.version }}"
         TAG_CREATED="true" # Simplification for now, as prepare-release always creates tag on push
 
-        echo "✅ Build and Push successful!"
-        echo "📦 Version: ${VERSION}"
-        echo "🐳 Image Tag: ${IMAGE_TAG}"
-        if [ "$TAG_CREATED" == "true" ]; then
-          echo "🏷️  New tag created: ${VERSION}"
+        if [ "${{ needs.gitops-update.result }}" == "success" ]; then
+          echo "✅ Build, Push, and GitOps Update successful!"
+          echo "📦 Version: ${VERSION}"
+          echo "🚀 Deployed via petrosa_k8s hub"
         else
-          echo "🏷️  Using existing tag: ${VERSION}"
+          echo "❌ GitOps Update failed (or skipped)!"
+          echo "📦 Version: ${VERSION}"
+          echo "🐳 Image pushed, but manifest update failed."
         fi
-        echo "🚀 Ready for deployment via petrosa_k8s hub"
 
   cleanup:
     needs: [build-and-push]

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -82,72 +82,41 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Update deployment manifest with new version
-        run: |
-          VERSION="${{ steps.bump_version.outputs.new_version }}"
-          ENV="${{ inputs.environment }}"
-
-          echo "Updating manifests for tradeengine in $ENV environment with version $VERSION"
-
-          # Find and update deployment manifests
-          find k8s/ -name "*.yaml" -type f | while read -r file; do
-            echo "Checking $file"
-            if grep -q "VERSION_PLACEHOLDER" "$file"; then
-              sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "$file"
-              echo "Updated VERSION_PLACEHOLDER in $file to $VERSION"
-            fi
-          done
-
-          # Show what was changed
-          if git diff --quiet; then
-            echo "No VERSION_PLACEHOLDER found in manifests (this is OK for manual deployments)"
-          else
-            echo "Changes made:"
-            git diff k8s/
-          fi
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+      - name: Checkout petrosa_k8s
+        uses: actions/checkout@v4
         with:
-          version: 'latest'
+          repository: PetroSa2/petrosa_k8s
+          ref: main
+          token: ${{ secrets.GITOPS_BOT_TOKEN }}
+          path: petrosa_k8s
 
-      - name: Configure kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
-          # Validate kubeconfig
-          if ! kubectl config view --kubeconfig ~/.kube/config > /dev/null 2>&1; then
-            echo "ERROR: Decoded kubeconfig is invalid or malformed."
-            exit 1
-          fi
-          echo "✅ Kubeconfig validated successfully"
+      - name: Rebase on main
+        run: ./scripts/gitops-rebase-main.sh
+        working-directory: petrosa_k8s
 
-      - name: Deploy to Kubernetes
+      - name: Update tradeengine image tag in GitOps manifests
         run: |
           VERSION="${{ steps.bump_version.outputs.new_version }}"
-          ENV="${{ inputs.environment }}"
+          # Update the image tag in manifests
+          find petrosa_k8s/k8s/tradeengine -name "*.yaml" -o -name "*.yml" | xargs sed -i "s/VERSION_PLACEHOLDER/$VERSION/g"
 
-          echo "Deploying tradeengine version $VERSION to $ENV"
+          # Also update the version label if needed
+          find petrosa_k8s/k8s/tradeengine -name "*.yaml" -o -name "*.yml" | xargs sed -i "s/version: VERSION_PLACEHOLDER/version: $VERSION/g"
 
-          # Update deployment with new image tag
-          # NOTE: --insecure-skip-tls-verify is required due to infrastructure limitation:
-          # External cluster IP (15.235.72.170:35902) is not in certificate SAN.
-          # SECURITY: This is a known limitation. Future improvement: update certificate
-          # to include external IP or use load balancer with proper certificate.
-          # MITIGATION: Workflow runs in trusted GitHub Actions environment.
-          kubectl set image deployment/petrosa-tradeengine \
-            tradeengine=ghcr.io/petrosa2/tradeengine:$VERSION \
-            --namespace=petrosa-apps \
-            --insecure-skip-tls-verify
+          echo "Updated tradeengine image tag to $VERSION in petrosa_k8s/k8s/tradeengine/"
 
-      - name: Wait for rollout
+      - name: Commit and push to petrosa_k8s
+        working-directory: petrosa_k8s
         run: |
-          echo "Waiting for rollout to complete..."
-          kubectl rollout status deployment/petrosa-tradeengine \
-            --namespace=petrosa-apps \
-            --timeout=5m \
-            --insecure-skip-tls-verify
+          git config user.name "gitops-bot"
+          git config user.email "gitops-bot@users.noreply.github.com"
+          git add k8s/tradeengine/
+          if git diff --staged --quiet; then
+            echo "No changes to commit (version might already be up to date)"
+          else
+            git commit -m "gitops: tradeengine image ${{ steps.bump_version.outputs.new_version }}"
+            git push origin main
+          fi
 
       - name: Create deployment record
         run: |
@@ -178,29 +147,33 @@ jobs:
       - name: Create summary
         run: |
           cat >> $GITHUB_STEP_SUMMARY << EOF
-          # Deployment Successful ✅
+          # GitOps Push Successful ✅
 
           ## Details
-          - **Service**: \`tradeengine\`
-          - **Environment**: \`${{ inputs.environment }}\`
-          - **Version**: \`${{ steps.current_version.outputs.version }}\` → \`${{ steps.bump_version.outputs.new_version }}\`
-          - **Bump Type**: \`${{ inputs.version_bump }}\`
+          - **Service**: `tradeengine`
+          - **Environment**: `${{ inputs.environment }}`
+          - **Version**: `${{ steps.current_version.outputs.version }}` → `${{ steps.bump_version.outputs.new_version }}`
+          - **Bump Type**: `${{ inputs.version_bump }}`
           - **Triggered by**: @${{ github.actor }}
           - **Reason**: ${{ inputs.reason }}
 
+          ## GitOps Transition
+          The new image tag has been pushed to [PetroSa2/petrosa_k8s](https://github.com/PetroSa2/petrosa_k8s).
+
+          The centralized GitOps workflow in `petrosa_k8s` will now:
+          1. Detect the change in `k8s/tradeengine/`
+          2. Validate the manifests
+          3. Apply the changes to the Kubernetes cluster
+
           ## Verification
 
-          Check deployment status:
-          \`\`\`bash
+          Monitor the apply progress here:
+          - [petrosa_k8s Actions](https://github.com/PetroSa2/petrosa_k8s/actions/workflows/apply-k8s-changes.yml)
+
+          Once the `apply-k8s-changes` workflow finishes, you can verify on the cluster:
+          ```bash
           kubectl get pods -n petrosa-apps -l app=tradeengine
-          kubectl logs -n petrosa-apps -l app=tradeengine --tail=50
-          \`\`\`
-
-          ## Rollback (if needed)
-
-          \`\`\`bash
-          kubectl rollout undo deployment/petrosa-tradeengine -n petrosa-apps
-          \`\`\`
+          ```
           EOF
 
       - name: Notify on failure


### PR DESCRIPTION
Refactors manual-deploy.yml and ci-checks.yml to use the centralized GitOps pattern from petrosa_k8s#185.

- Removes kubectl and KUBECONFIG dependency.
- Adds steps to checkout petrosa_k8s, rebase, and update image tags in manifests.
- Updates step summaries to provide links to the GitOps apply workflow.

Parent: PetroSa2/petrosa_k8s#185