### PR TITLE
[INFRA] Refactor deploy workflows to centralized GitOps pattern

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -380,10 +380,10 @@ jobs:
           VERSION="${{ needs.build-and-push.outputs.version }}"
           # Update the image tag in manifests
           find petrosa_k8s/k8s/tradeengine -name "*.yaml" -o -name "*.yml" | xargs sed -i "s/VERSION_PLACEHOLDER/$VERSION/g"
-          
+
           # Also update the version label if needed
           find petrosa_k8s/k8s/tradeengine -name "*.yaml" -o -name "*.yml" | xargs sed -i "s/version: VERSION_PLACEHOLDER/version: $VERSION/g"
-          
+
           echo "Updated tradeengine image tag to $VERSION in petrosa_k8s/k8s/tradeengine/"
 
       - name: Commit and push to petrosa_k8s

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -101,10 +101,10 @@ jobs:
           VERSION="${{ steps.bump_version.outputs.new_version }}"
           # Update the image tag in manifests
           find petrosa_k8s/k8s/tradeengine -name "*.yaml" -o -name "*.yml" | xargs sed -i "s/VERSION_PLACEHOLDER/$VERSION/g"
-          
+
           # Also update the version label if needed
           find petrosa_k8s/k8s/tradeengine -name "*.yaml" -o -name "*.yml" | xargs sed -i "s/version: VERSION_PLACEHOLDER/version: $VERSION/g"
-          
+
           echo "Updated tradeengine image tag to $VERSION in petrosa_k8s/k8s/tradeengine/"
 
       - name: Commit and push to petrosa_k8s


### PR DESCRIPTION
Refactors ci-checks.yml and manual-deploy.yml to use the centralized GitOps pattern from petrosa_k8s#185.

- Removes kubectl and KUBE_CONFIG_DATA/KUBECONFIG dependency.
- Adds steps to checkout petrosa_k8s, rebase, and update image tags in manifests.
- Updates notify jobs to track GitOps status.

Parent: PetroSa2/petrosa_k8s#185