### PR TITLE
fix: use installation_retrieval_mode for GitHub App token

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -368,8 +368,9 @@ jobs:
         id: generate_token
         with:
           app_id: ${{ secrets.GITOPS_APP_ID }}
-          installation_id: ${{ secrets.GITOPS_APP_INSTALLATION_ID }}
           private_key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ secrets.GITOPS_APP_INSTALLATION_ID }}
 
       - name: Checkout petrosa_k8s
         uses: actions/checkout@v4

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -80,8 +80,9 @@ jobs:
         id: generate_token
         with:
           app_id: ${{ secrets.GITOPS_APP_ID }}
-          installation_id: ${{ secrets.GITOPS_APP_INSTALLATION_ID }}
           private_key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ secrets.GITOPS_APP_INSTALLATION_ID }}
 
       - name: Checkout petrosa_k8s
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes GitOps workflow failure by using installation_retrieval_mode instead of installation_id.