### PR TITLE
fix: Docker login was using ghcr.io instead of Docker Hub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,12 +84,11 @@ jobs:
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    - name: Login to GitHub Container Registry
+    - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build and Push Docker Image
       id: build
       uses: docker/build-push-action@v5


### PR DESCRIPTION
The deploy workflow was logging in to `ghcr.io` with `GITHUB_TOKEN` but pushing to `yurisa2/petrosa-tradeengine` (Docker Hub). This caused a 401 error.

Fixed to use `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` like all other repos.