### PR TITLE
fix: decouple /ready from exchange latency via cached ping sentinel (#326)

### DIFF
--- a/tests/test_binance_exchange_comprehensive.py
+++ b/tests/test_binance_exchange_comprehensive.py
@@ -1100,13 +1100,24 @@ class TestAdditionalMethods:
     async def test_ping_loop_updates_sentinel_on_success(self, binance_exchange):
         """_ping_loop updates _last_ping_ok=True and _last_ping_time on successful ping."""
         import asyncio
+        import threading
 
-        binance_exchange.client.futures_ping = Mock(return_value={})
+        ping_called = threading.Event()
+
+        def ping_and_signal():
+            ping_called.set()
+            return {}
+
+        binance_exchange.client.futures_ping = ping_and_signal
         binance_exchange._last_ping_ok = False
 
-        # Run one iteration of the loop then cancel
         task = asyncio.create_task(binance_exchange._ping_loop())
-        await asyncio.sleep(0.05)
+        # Wait (in a thread-safe way) for the executor to confirm the ping ran,
+        # then yield to the event loop so _ping_loop can write the sentinel.
+        await asyncio.get_event_loop().run_in_executor(
+            None, lambda: ping_called.wait(timeout=2.0)
+        )
+        await asyncio.sleep(0)  # one scheduler tick so _ping_loop sets _last_ping_ok
         task.cancel()
         try:
             await task
@@ -1120,12 +1131,22 @@ class TestAdditionalMethods:
     async def test_ping_loop_updates_sentinel_on_failure(self, binance_exchange):
         """_ping_loop sets _last_ping_ok=False when ping raises."""
         import asyncio
+        import threading
 
-        binance_exchange.client.futures_ping = Mock(side_effect=Exception("timeout"))
+        ping_called = threading.Event()
+
+        def ping_fail_and_signal():
+            ping_called.set()
+            raise Exception("timeout")
+
+        binance_exchange.client.futures_ping = ping_fail_and_signal
         binance_exchange._last_ping_ok = True
 
         task = asyncio.create_task(binance_exchange._ping_loop())
-        await asyncio.sleep(0.05)
+        await asyncio.get_event_loop().run_in_executor(
+            None, lambda: ping_called.wait(timeout=2.0)
+        )
+        await asyncio.sleep(0)  # one tick for _ping_loop to set _last_ping_ok=False
         task.cancel()
         try:
             await task

--- a/tests/test_binance_exchange_comprehensive.py
+++ b/tests/test_binance_exchange_comprehensive.py
@@ -1054,12 +1054,37 @@ class TestAdditionalMethods:
             pass
 
     @pytest.mark.asyncio
-    async def test_health_check(self, binance_exchange):
-        """Test health_check method"""
-        binance_exchange.client.futures_ping = Mock(return_value={})
+    async def test_health_check_cached_healthy(self, binance_exchange):
+        """health_check returns cached 'healthy' without calling futures_ping directly."""
+        import time
+
+        binance_exchange._last_ping_ok = True
+        binance_exchange._last_ping_time = time.monotonic()  # fresh sentinel
         result = await binance_exchange.health_check()
-        assert isinstance(result, dict)
-        assert "status" in result or "healthy" in str(result).lower()
+        assert result["status"] == "healthy"
+        assert result.get("cached") is True
+        # futures_ping must NOT be called — that is the whole point of the fix
+        binance_exchange.client.futures_ping.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_health_check_cached_unhealthy(self, binance_exchange):
+        """health_check returns 'unhealthy' when last ping failed (still non-blocking)."""
+        import time
+
+        binance_exchange._last_ping_ok = False
+        binance_exchange._last_ping_time = time.monotonic()
+        result = await binance_exchange.health_check()
+        assert result["status"] == "unhealthy"
+        assert result.get("cached") is True
+        binance_exchange.client.futures_ping.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_health_check_sentinel_expired(self, binance_exchange):
+        """health_check returns 'degraded' when ping sentinel has expired."""
+        binance_exchange._last_ping_time = 0.0  # far in the past
+        result = await binance_exchange.health_check()
+        assert result["status"] == "degraded"
+        assert "expired" in result.get("error", "")
 
     @pytest.mark.asyncio
     async def test_health_check_no_client(self, binance_exchange):
@@ -1068,10 +1093,46 @@ class TestAdditionalMethods:
         binance_exchange.initialized = False
         result = await binance_exchange.health_check()
         assert isinstance(result, dict)
-        # Should indicate unhealthy or error
-        assert (
-            "status" in result or "error" in result or "healthy" in str(result).lower()
-        )
+        assert result.get("status") == "degraded"
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_ping_loop_updates_sentinel_on_success(self, binance_exchange):
+        """_ping_loop updates _last_ping_ok=True and _last_ping_time on successful ping."""
+        import asyncio
+
+        binance_exchange.client.futures_ping = Mock(return_value={})
+        binance_exchange._last_ping_ok = False
+
+        # Run one iteration of the loop then cancel
+        task = asyncio.create_task(binance_exchange._ping_loop())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert binance_exchange._last_ping_ok is True
+        assert binance_exchange._last_ping_time > 0
+
+    @pytest.mark.asyncio
+    async def test_ping_loop_updates_sentinel_on_failure(self, binance_exchange):
+        """_ping_loop sets _last_ping_ok=False when ping raises."""
+        import asyncio
+
+        binance_exchange.client.futures_ping = Mock(side_effect=Exception("timeout"))
+        binance_exchange._last_ping_ok = True
+
+        task = asyncio.create_task(binance_exchange._ping_loop())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert binance_exchange._last_ping_ok is False
 
     @pytest.mark.asyncio
     async def test_load_exchange_info_success(self, binance_exchange):

--- a/tests/test_binance_exchange_comprehensive.py
+++ b/tests/test_binance_exchange_comprehensive.py
@@ -1100,24 +1100,21 @@ class TestAdditionalMethods:
     async def test_ping_loop_updates_sentinel_on_success(self, binance_exchange):
         """_ping_loop updates _last_ping_ok=True and _last_ping_time on successful ping."""
         import asyncio
-        import threading
 
-        ping_called = threading.Event()
+        ping_called = asyncio.Event()
+        loop = asyncio.get_running_loop()
 
         def ping_and_signal():
-            ping_called.set()
+            # Thread-safe: schedule event.set() on the event loop thread
+            loop.call_soon_threadsafe(ping_called.set)
             return {}
 
         binance_exchange.client.futures_ping = ping_and_signal
         binance_exchange._last_ping_ok = False
 
         task = asyncio.create_task(binance_exchange._ping_loop())
-        # Wait (in a thread-safe way) for the executor to confirm the ping ran,
-        # then yield to the event loop so _ping_loop can write the sentinel.
-        await asyncio.get_event_loop().run_in_executor(
-            None, lambda: ping_called.wait(timeout=2.0)
-        )
-        await asyncio.sleep(0)  # one scheduler tick so _ping_loop sets _last_ping_ok
+        await asyncio.wait_for(ping_called.wait(), timeout=5.0)
+        await asyncio.sleep(0)  # one scheduler tick so _ping_loop writes the sentinel
         task.cancel()
         try:
             await task
@@ -1131,22 +1128,20 @@ class TestAdditionalMethods:
     async def test_ping_loop_updates_sentinel_on_failure(self, binance_exchange):
         """_ping_loop sets _last_ping_ok=False when ping raises."""
         import asyncio
-        import threading
 
-        ping_called = threading.Event()
+        ping_called = asyncio.Event()
+        loop = asyncio.get_running_loop()
 
         def ping_fail_and_signal():
-            ping_called.set()
+            loop.call_soon_threadsafe(ping_called.set)
             raise Exception("timeout")
 
         binance_exchange.client.futures_ping = ping_fail_and_signal
         binance_exchange._last_ping_ok = True
 
         task = asyncio.create_task(binance_exchange._ping_loop())
-        await asyncio.get_event_loop().run_in_executor(
-            None, lambda: ping_called.wait(timeout=2.0)
-        )
-        await asyncio.sleep(0)  # one tick for _ping_loop to set _last_ping_ok=False
+        await asyncio.wait_for(ping_called.wait(), timeout=5.0)
+        await asyncio.sleep(0)  # one tick for _ping_loop to write _last_ping_ok=False
         task.cancel()
         try:
             await task

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -248,12 +248,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 logger.info("NATS consumer task cancelled successfully")
 
         # Cancel Binance ping loop before closing exchange
-        if binance_exchange._ping_task and not binance_exchange._ping_task.done():
-            binance_exchange._ping_task.cancel()
-            try:
-                await binance_exchange._ping_task
-            except asyncio.CancelledError:
-                pass
+        await binance_exchange.stop_ping_loop()
 
         await binance_exchange.close()
         await simulator_exchange.close()
@@ -440,15 +435,12 @@ async def readiness_check() -> dict[str, Any]:
         validate_mongodb_config()
 
         _TIMEOUT = 3.0
-        # Check if core components are ready (each bounded to avoid event loop stalls)
-        dispatcher_ready = await asyncio.wait_for(
-            dispatcher.health_check(), timeout=_TIMEOUT
-        )
-        binance_ready = await asyncio.wait_for(
-            binance_exchange.health_check(), timeout=_TIMEOUT
-        )
-        simulator_ready = await asyncio.wait_for(
-            simulator_exchange.health_check(), timeout=_TIMEOUT
+        # Run all component checks concurrently, each bounded to avoid event loop stalls.
+        # Total wall-clock time is max(_TIMEOUT, slowest_check) not sum of timeouts.
+        dispatcher_ready, binance_ready, simulator_ready = await asyncio.gather(
+            asyncio.wait_for(dispatcher.health_check(), timeout=_TIMEOUT),
+            asyncio.wait_for(binance_exchange.health_check(), timeout=_TIMEOUT),
+            asyncio.wait_for(simulator_exchange.health_check(), timeout=_TIMEOUT),
         )
 
         if (

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from collections.abc import AsyncGenerator
@@ -90,8 +91,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     startup_success = True
     consumer_task = None  # Keep reference to prevent garbage collection
 
-    import asyncio
-
     try:
         # Validate MongoDB configuration first - fail catastrophically if not configured
         logger.info("Validating MongoDB configuration...")
@@ -143,7 +142,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         try:
             logger.info("🧪 TESTING BINANCE CONNECTION AND BALANCE...")
             account_info = await binance_exchange.get_account_info()
-            usdt_balance = next(
+            usdt_balance: dict[str, Any] = next(
                 (a for a in account_info.get("assets", []) if a.get("asset") == "USDT"),
                 {},
             )
@@ -162,6 +161,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.error(f"❌ BINANCE CONNECTION TEST FAILED: {test_error}")
 
         logger.info("Initializing simulator exchange...")
+
+        # Start Binance background ping loop (decouples /ready from exchange latency)
+        await binance_exchange.start_ping_loop()
+        logger.info("✅ Binance background ping loop started")
 
         # Initialize dispatcher
         logger.info("Initializing dispatcher...")
@@ -243,6 +246,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 await consumer_task
             except asyncio.CancelledError:
                 logger.info("NATS consumer task cancelled successfully")
+
+        # Cancel Binance ping loop before closing exchange
+        if binance_exchange._ping_task and not binance_exchange._ping_task.done():
+            binance_exchange._ping_task.cancel()
+            try:
+                await binance_exchange._ping_task
+            except asyncio.CancelledError:
+                pass
 
         await binance_exchange.close()
         await simulator_exchange.close()
@@ -428,10 +439,17 @@ async def readiness_check() -> dict[str, Any]:
 
         validate_mongodb_config()
 
-        # Check if core components are ready
-        dispatcher_ready = await dispatcher.health_check()
-        binance_ready = await binance_exchange.health_check()
-        simulator_ready = await simulator_exchange.health_check()
+        _TIMEOUT = 3.0
+        # Check if core components are ready (each bounded to avoid event loop stalls)
+        dispatcher_ready = await asyncio.wait_for(
+            dispatcher.health_check(), timeout=_TIMEOUT
+        )
+        binance_ready = await asyncio.wait_for(
+            binance_exchange.health_check(), timeout=_TIMEOUT
+        )
+        simulator_ready = await asyncio.wait_for(
+            simulator_exchange.health_check(), timeout=_TIMEOUT
+        )
 
         if (
             dispatcher_ready.get("status") == "healthy"
@@ -996,7 +1014,7 @@ async def get_active_signals(
 @app.get("/state")
 async def get_state(
     symbol: str = Query(..., description="Target symbol for state context"),
-):
+) -> dict[str, Any]:
     """
     Returns real-time portfolio, risk, and environment stats for the CIO.
     Ground-truth data derived from engine authoritative state.

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -131,11 +131,32 @@ class BinanceFuturesExchange:
             raise
 
     async def start_ping_loop(self) -> None:
-        """Start background ping loop to keep health sentinel fresh."""
+        """Start background ping loop to keep health sentinel fresh.
+
+        Cancels any previously running ping loop before starting a new one
+        to prevent orphaned tasks on re-initialization.
+        """
+        await self.stop_ping_loop()
         self._ping_task = asyncio.create_task(self._ping_loop())
 
+    async def stop_ping_loop(self) -> None:
+        """Cancel the background ping loop and wait for it to finish."""
+        if self._ping_task and not self._ping_task.done():
+            self._ping_task.cancel()
+            try:
+                await self._ping_task
+            except asyncio.CancelledError:
+                pass
+        self._ping_task = None
+
     async def _ping_loop(self) -> None:
-        """Background coroutine that pings Binance every 20s via executor (non-blocking)."""
+        """Background coroutine that pings Binance every 20s via executor (non-blocking).
+
+        Note: asyncio.wait_for timeout bounds the await but does not interrupt the
+        underlying executor thread. If futures_ping hangs beyond 5s the thread will
+        continue running until the OS-level socket times out. This is acceptable
+        because the sentinel is still updated and the event loop is never blocked.
+        """
         while True:
             try:
                 if self.client is not None:
@@ -148,9 +169,9 @@ class BinanceFuturesExchange:
                     logger.debug("Binance ping OK")
                 else:
                     self._last_ping_ok = False
-            except Exception as e:
+            except Exception:
                 self._last_ping_ok = False
-                logger.warning(f"Binance ping FAIL: {e}")
+                logger.exception("Binance ping FAIL")
             self._last_ping_time = time.monotonic()
             await asyncio.sleep(20)
 

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -36,12 +36,17 @@ logger = logging.getLogger(__name__)
 class BinanceFuturesExchange:
     """Binance Futures exchange client for executing trades"""
 
+    _PING_TTL: float = 30.0  # consider healthy if pinged within this window
+
     def __init__(self) -> None:
         self.client: Client | None = None
         self.exchange_info: dict[str, Any] = {}
         self.symbol_info: dict[str, Any] = {}
         self.initialized = False
         self.rate_monitor: RateLimitMonitor | None = None
+        self._last_ping_ok: bool = True
+        self._last_ping_time: float = 0.0
+        self._ping_task: asyncio.Task | None = None  # type: ignore[type-arg]
 
     async def initialize(self) -> None:
         """Initialize Binance Futures exchange connection"""
@@ -125,21 +130,48 @@ class BinanceFuturesExchange:
             self.initialized = False
             raise
 
+    async def start_ping_loop(self) -> None:
+        """Start background ping loop to keep health sentinel fresh."""
+        self._ping_task = asyncio.create_task(self._ping_loop())
+
+    async def _ping_loop(self) -> None:
+        """Background coroutine that pings Binance every 20s via executor (non-blocking)."""
+        while True:
+            try:
+                if self.client is not None:
+                    loop = asyncio.get_event_loop()
+                    await asyncio.wait_for(
+                        loop.run_in_executor(None, self.client.futures_ping),
+                        timeout=5.0,
+                    )
+                    self._last_ping_ok = True
+                    logger.debug("Binance ping OK")
+                else:
+                    self._last_ping_ok = False
+            except Exception as e:
+                self._last_ping_ok = False
+                logger.warning(f"Binance ping FAIL: {e}")
+            self._last_ping_time = time.monotonic()
+            await asyncio.sleep(20)
+
     async def health_check(self) -> dict[str, Any]:
-        """Check Binance Futures exchange health"""
-        try:
-            if self.client is not None:
-                self.client.futures_ping()
-                return {"status": "healthy", "type": "binance_futures"}
-            else:
-                return {
-                    "status": "degraded",
-                    "type": "binance_futures",
-                    "error": "Client not initialized",
-                }
-        except Exception as e:
-            logger.error(f"Binance Futures health check error: {e}")
-            return {"status": "unhealthy", "error": str(e)}
+        """Check Binance Futures exchange health using cached ping sentinel (non-blocking)."""
+        if self.client is None:
+            return {
+                "status": "degraded",
+                "type": "binance_futures",
+                "error": "Client not initialized",
+            }
+        age = time.monotonic() - self._last_ping_time
+        if age < self._PING_TTL:
+            status = "healthy" if self._last_ping_ok else "unhealthy"
+            return {"status": status, "type": "binance_futures", "cached": True}
+        # Sentinel expired — report degraded (background loop may not have started yet)
+        return {
+            "status": "degraded",
+            "type": "binance_futures",
+            "error": f"ping sentinel expired ({age:.0f}s ago)",
+        }
 
     async def _load_exchange_info(self) -> None:
         """Load futures exchange information and symbol details"""


### PR DESCRIPTION
## Summary

- **Bug 1 (Primary)**: `binance.health_check()` called `futures_ping()` synchronously on the asyncio event loop. Under OCO load, this blocked the loop long enough to cause 89 probe timeouts in 159 minutes.
- **Bug 2**: `readiness_check()` had no per-component timeout — a slow Redis/MongoDB round-trip could still exceed the probe window.

## Changes

**`tradeengine/exchange/binance.py`**
- Added `_ping_loop()` background coroutine: calls `futures_ping()` via `run_in_executor` every 20s with 5s timeout, updates `_last_ping_ok` / `_last_ping_time` sentinel
- `health_check()` now reads the cached sentinel — returns in microseconds, never blocks the event loop
- Added `start_ping_loop()` to start the background task

**`tradeengine/api.py`**
- Import `asyncio` at module level (was inline in lifespan)
- Start `binance_exchange.start_ping_loop()` in lifespan after exchange initialization
- Cancel ping task cleanly on shutdown
- Wrap each component in `readiness_check()` with `asyncio.wait_for(timeout=3.0)`

**`tests/test_binance_exchange_comprehensive.py`**
- Updated existing `test_health_check` → replaced with 3 targeted tests (cached healthy, cached unhealthy, expired sentinel) verifying `futures_ping` is NOT called during probe
- Added `test_ping_loop_updates_sentinel_on_success/failure`

## Test plan

- [x] 1206 tests pass, 76.5% coverage
- [x] `test_health_check_cached_healthy` verifies `futures_ping` is never called
- [x] `test_ping_loop_*` verifies sentinel updates on success and failure
- [x] mypy, ruff, bandit, gitleaks all pass

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)