### PR TITLE
[CRITICAL][P0] fix: cancel_oco_pair uses algo-order DELETE API to prevent orphaned orders (#333)

### DIFF
--- a/tests/test_oco_orders.py
+++ b/tests/test_oco_orders.py
@@ -56,11 +56,14 @@ def mock_exchange():
 
     exchange.execute = AsyncMock(side_effect=mock_execute)
 
-    # Mock batch order cancellation
-    def mock_cancel_batch(symbol: str, orderIdList: list) -> list:
-        return [{"orderId": oid, "status": "CANCELED"} for oid in orderIdList]
+    # Mock algo order cancellation (DELETE /fapi/v1/algo/algoOrder)
+    def mock_request_futures_api(method, path, signed=False, data=None, **kwargs):
+        if method == "delete" and path == "algoOrder":
+            algo_id = (data or {}).get("algoId")
+            return {"algoId": algo_id, "algoStatus": "CANCELLED"}
+        return {}
 
-    exchange.client.futures_cancel_batch_orders = mock_cancel_batch
+    exchange.client._request_futures_api = Mock(side_effect=mock_request_futures_api)
 
     # Mock single order cancellation
     def mock_cancel_order(symbol: str, orderId: str) -> dict:
@@ -235,7 +238,7 @@ async def test_place_oco_orders_short_position(oco_manager: OCOManager):
 
 
 @pytest.mark.asyncio
-async def test_cancel_oco_pair(oco_manager: OCOManager):
+async def test_cancel_oco_pair(oco_manager: OCOManager, mock_exchange):
     """Test cancelling both SL and TP orders"""
     # First, place OCO orders
     await oco_manager.place_oco_orders(
@@ -261,6 +264,12 @@ async def test_cancel_oco_pair(oco_manager: OCOManager):
         oco_list = oco_manager.active_oco_pairs[exchange_key]
         if len(oco_list) > 0:
             assert oco_list[0]["status"] == "cancelled"
+
+    # Verify algo cancel API was called (not the wrong batch cancel)
+    mock_exchange.client._request_futures_api.assert_called()
+    assert not mock_exchange.client.futures_cancel_batch_orders.called, (
+        "futures_cancel_batch_orders must NOT be called for algo orders"
+    )
 
     # Clean up
     await oco_manager.stop_monitoring()

--- a/tests/test_oco_orders.py
+++ b/tests/test_oco_orders.py
@@ -240,8 +240,8 @@ async def test_place_oco_orders_short_position(oco_manager: OCOManager):
 @pytest.mark.asyncio
 async def test_cancel_oco_pair(oco_manager: OCOManager, mock_exchange):
     """Test cancelling both SL and TP orders"""
-    # First, place OCO orders
-    await oco_manager.place_oco_orders(
+    # First, place OCO orders and capture the returned IDs
+    place_result = await oco_manager.place_oco_orders(
         position_id="test_pos_cancel_789",
         symbol="BTCUSDT",
         position_side="LONG",
@@ -249,6 +249,11 @@ async def test_cancel_oco_pair(oco_manager: OCOManager, mock_exchange):
         stop_loss_price=48000.0,
         take_profit_price=52000.0,
     )
+    sl_id = place_result["sl_order_id"]
+    tp_id = place_result["tp_order_id"]
+
+    # Reset call history so we only track cancellation calls
+    mock_exchange.client._request_futures_api.reset_mock()
 
     # Cancel the OCO pair (need to pass symbol and position_side for new key structure)
     result = await oco_manager.cancel_oco_pair(
@@ -265,8 +270,31 @@ async def test_cancel_oco_pair(oco_manager: OCOManager, mock_exchange):
         if len(oco_list) > 0:
             assert oco_list[0]["status"] == "cancelled"
 
-    # Verify algo cancel API was called (not the wrong batch cancel)
-    mock_exchange.client._request_futures_api.assert_called()
+    # Verify algo cancel API called exactly twice (SL + TP) with correct algoIds
+    from unittest.mock import call
+
+    assert mock_exchange.client._request_futures_api.call_count == 2, (
+        "Must call algo DELETE API exactly once for SL and once for TP"
+    )
+    mock_exchange.client._request_futures_api.assert_has_calls(
+        [
+            call(
+                "delete",
+                "algoOrder",
+                signed=True,
+                data={"symbol": "BTCUSDT", "algoId": sl_id},
+            ),
+            call(
+                "delete",
+                "algoOrder",
+                signed=True,
+                data={"symbol": "BTCUSDT", "algoId": tp_id},
+            ),
+        ],
+        any_order=False,
+    )
+
+    # Verify batch cancel API was NOT used
     assert not mock_exchange.client.futures_cancel_batch_orders.called, (
         "futures_cancel_batch_orders must NOT be called for algo orders"
     )

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -326,6 +326,14 @@ class OCOManager:
 
             pair_cancelled = True
             for order_id, label in [(sl_order_id, "SL"), (tp_order_id, "TP")]:
+                if not order_id:
+                    self.logger.warning(
+                        f"⚠️ Missing {label} order ID for {oco_symbol} — "
+                        f"skipping cancel, pair may need reconciliation"
+                    )
+                    pair_cancelled = False
+                    all_cancelled = False
+                    continue
                 try:
                     self.exchange.client._request_futures_api(
                         "delete",

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -324,24 +324,29 @@ class OCOManager:
                 f"sl_order_id={sl_order_id}, tp_order_id={tp_order_id}"
             )
 
-            try:
-                # Cancel both orders using batch cancellation
-                cancel_result = self.exchange.client.futures_cancel_batch_orders(
-                    symbol=oco_symbol, orderIdList=[sl_order_id, tp_order_id]
-                )
-
-                if cancel_result and len(cancel_result) >= 2:
-                    self.logger.info(
-                        f"✅ OCO PAIR CANCELLED for strategy {oco_info.get('strategy_position_id')}"
+            pair_cancelled = True
+            for order_id, label in [(sl_order_id, "SL"), (tp_order_id, "TP")]:
+                try:
+                    self.exchange.client._request_futures_api(
+                        "delete",
+                        "algoOrder",
+                        signed=True,
+                        data={"symbol": oco_symbol, "algoId": order_id},
                     )
-                    oco_info["status"] = "cancelled"
-                else:
-                    self.logger.error(f"❌ FAILED TO CANCEL OCO PAIR: {cancel_result}")
+                    self.logger.info(
+                        f"✅ Cancelled algo {label} order {order_id} for {oco_symbol}"
+                    )
+                except Exception as e:
+                    self.logger.error(
+                        f"❌ Failed to cancel algo {label} order {order_id}: {e}"
+                    )
+                    pair_cancelled = False
                     all_cancelled = False
-
-            except Exception as e:
-                self.logger.error(f"❌ ERROR CANCELLING OCO PAIR: {e}")
-                all_cancelled = False
+            if pair_cancelled:
+                self.logger.info(
+                    f"✅ OCO PAIR CANCELLED for strategy {oco_info.get('strategy_position_id')}"
+                )
+                oco_info["status"] = "cancelled"
 
         return all_cancelled
 


### PR DESCRIPTION
## Summary

- Replaces `futures_cancel_batch_orders` (standard REST) with individual `DELETE /fapi/v1/algo/algoOrder` calls in `OCOManager.cancel_oco_pair()`
- The standard batch endpoint silently ignores conditional algo orders — they accumulate toward the 100-order Binance cap, blocking all trading
- 96 orphaned orders confirmed in the incident (2026-04-15); system was 100% blocked

## Root Cause

`cancel_oco_pair()` called `futures_cancel_batch_orders` which does not cancel algo (conditional) orders. They must be cancelled via `DELETE /fapi/v1/algo/algoOrder` with `algoId`. The batch endpoint returns `[]` silently — no exception, no fallback triggered, orders remain open on Binance.

## Changes

- `tradeengine/dispatcher.py`: Replace batch cancel with per-order `_request_futures_api("delete", "algoOrder", ...)` loop for SL and TP
- `tests/test_oco_orders.py`: Update fixture to mock `_request_futures_api` (not `futures_cancel_batch_orders`); assert algo API is called and batch API is NOT called

## Test Plan

- [x] `tests/test_oco_orders.py::test_cancel_oco_pair` — passes, asserts algo API called
- [x] `tests/test_oco_orders.py` (44 tests) — 0 regressions
- [x] `tests/test_oco_integration.py` + `test_oco_pnl_calculation.py` + `test_binance_exchange_comprehensive.py` — 108 passed
- [x] Reproduction test `_bmad-output/incidents/2026-04-15/reproduction_test.py` — all 3 tests pass

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)