### PR TITLE
feat: add copilot-review-gate workflow (#354)

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -27,6 +27,8 @@ concurrency:
 jobs:
   copilot-review:
     name: copilot-review
+    # Skip workflow_run events that have no linked PR (e.g., upstream job was skipped).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.pull_requests[0] != null
     runs-on: petrosa-org-runners
     permissions:
       contents: read
@@ -116,29 +118,29 @@ jobs:
             const maxWaitSeconds = 20 * 60; // 20 minutes
             const pollIntervalSeconds = 30;
             let waited = 0;
+            let reviewFound = false;
+
+            core.info(
+              `Waiting for Copilot PR review on current head ${headSha} (polling up to ${maxWaitSeconds}s).`
+            );
 
             while (waited <= maxWaitSeconds) {
               if (await hasCopilotReviewForHeadSha()) {
+                reviewFound = true;
                 core.info(`Found submitted Copilot review for head ${headSha}.`);
                 break;
               }
-
-              if (waited === 0) {
-                core.info(
-                  `Waiting for Copilot PR review on current head ${headSha} (polling up to ${maxWaitSeconds}s).`
-                );
-              }
-
-              if (waited >= maxWaitSeconds) {
-                core.setFailed(
-                  `No submitted Copilot PR review for current head ${headSha} after waiting ${maxWaitSeconds}s. ` +
-                    `Copilot may be delayed; re-request Copilot review and retry once it submits a review on the latest commit.`
-                );
-                return;
-              }
-
+              if (waited >= maxWaitSeconds) break;
               await new Promise((r) => setTimeout(r, pollIntervalSeconds * 1000));
               waited += pollIntervalSeconds;
+            }
+
+            if (!reviewFound) {
+              core.setFailed(
+                `No submitted Copilot PR review for current head ${headSha} after waiting ${maxWaitSeconds}s. ` +
+                  `Copilot may be delayed; re-request Copilot review and retry once it submits a review on the latest commit.`
+              );
+              return;
             }
 
             async function loadAllReviewThreads() {
@@ -184,12 +186,20 @@ jobs:
                   });
                 }
                 if (!conn?.pageInfo?.hasNextPage) break;
+                if (p === 19) {
+                  core.setFailed(
+                    'Review thread pagination cap (2000 threads) reached. ' +
+                      'The gate cannot verify all threads on this PR. Reduce the number of review threads before merging.'
+                  );
+                  return null;
+                }
                 tCursor = conn.pageInfo.endCursor;
               }
               return threadsOut;
             }
 
             const threads = await loadAllReviewThreads();
+            if (threads === null) return; // pagination cap hit; already failed
 
             const isCopilotAuthor = (login) => {
               if (!login) return false;

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -1,0 +1,221 @@
+# TEMPLATE — Copy to `.github/workflows/copilot-review-gate.yml` in each Petrosa repo
+# before requiring the `copilot-review / copilot-review` status check on `main`.
+#
+# Enforces merge gating: Copilot must have reviewed the current PR head SHA and
+# all Copilot-started review threads must be resolved.
+#
+# Branch protection must require the check name: copilot-review / copilot-review
+# (workflow name / job name). See docs/COPILOT_REVIEW_ENFORCEMENT.md
+#
+# Related: Issue #330
+
+name: copilot-review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  workflow_run:
+    workflows: ["Request Copilot Review"]
+    types: [completed]
+
+concurrency:
+  group: copilot-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  copilot-review:
+    name: copilot-review
+    runs-on: petrosa-org-runners
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      # GitHub Actions deprecates Node.js 20 for JS actions in 2026; opt into Node 24 early.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+    steps:
+      - name: Verify Copilot review and resolved threads
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function resolvePullRequest() {
+              if (context.eventName === 'pull_request') {
+                return context.payload.pull_request;
+              }
+              if (context.eventName === 'pull_request_review') {
+                return context.payload.pull_request;
+              }
+              if (context.eventName === 'workflow_run') {
+                const run = context.payload.workflow_run;
+                const prs = run.pull_requests || [];
+                if (prs.length === 0) {
+                  core.info('workflow_run has no linked PR; skipping.');
+                  return null;
+                }
+                const { data } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: prs[0].number,
+                });
+                return data;
+              }
+              core.info(`Unhandled event ${context.eventName}; skipping.`);
+              return null;
+            }
+
+            const pr = await resolvePullRequest();
+            if (!pr) {
+              return;
+            }
+
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.info(`Skipping fork PR ${pr.head.repo.full_name}`);
+              return;
+            }
+
+            const pull_number = pr.number;
+            const headSha = pr.head.sha;
+
+            const isCopilotPrReviewer = (login) => {
+              if (!login) return false;
+              const l = String(login).toLowerCase();
+              return (
+                l === 'copilot-pull-request-reviewer' ||
+                l.startsWith('copilot-pull-request-reviewer[')
+              );
+            };
+
+            async function hasCopilotReviewForHeadSha() {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number,
+                per_page: 100,
+              });
+
+              return reviews.some(
+                (r) =>
+                  r.user &&
+                  isCopilotPrReviewer(r.user.login) &&
+                  r.commit_id === headSha &&
+                  r.state !== 'DISMISSED' &&
+                  r.state !== 'PENDING'
+              );
+            }
+
+            // Copilot reviews are asynchronous and often land after CI completes and after the
+            // review request workflow runs. To avoid flaky “rerun until Copilot posts” behavior,
+            // poll for a bounded time before failing.
+            const maxWaitSeconds = 20 * 60; // 20 minutes
+            const pollIntervalSeconds = 30;
+            let waited = 0;
+
+            while (waited <= maxWaitSeconds) {
+              if (await hasCopilotReviewForHeadSha()) {
+                core.info(`Found submitted Copilot review for head ${headSha}.`);
+                break;
+              }
+
+              if (waited === 0) {
+                core.info(
+                  `Waiting for Copilot PR review on current head ${headSha} (polling up to ${maxWaitSeconds}s).`
+                );
+              }
+
+              if (waited >= maxWaitSeconds) {
+                core.setFailed(
+                  `No submitted Copilot PR review for current head ${headSha} after waiting ${maxWaitSeconds}s. ` +
+                    `Copilot may be delayed; re-request Copilot review and retry once it submits a review on the latest commit.`
+                );
+                return;
+              }
+
+              await new Promise((r) => setTimeout(r, pollIntervalSeconds * 1000));
+              waited += pollIntervalSeconds;
+            }
+
+            async function loadAllReviewThreads() {
+              const threadQuery = `query ($owner: String!, $repoName: String!, $pull: Int!, $tcursor: String) {
+                repository(owner: $owner, name: $repoName) {
+                  pullRequest(number: $pull) {
+                    reviewThreads(first: 100, after: $tcursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        isResolved
+                        isOutdated
+                        comments(first: 100) {
+                          nodes { author { login } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+              const threadsOut = [];
+              let tCursor = null;
+              for (let p = 0; p < 20; p++) {
+                const tr = await github.graphql(threadQuery, {
+                  owner,
+                  repoName: repo,
+                  pull: pull_number,
+                  tcursor: tCursor,
+                });
+                const conn = tr.repository?.pullRequest?.reviewThreads;
+                const nodes = conn?.nodes || [];
+                for (const t of nodes) {
+                  const authorLogins = (t.comments?.nodes || []).map(
+                    (c) => c.author?.login
+                  );
+                  threadsOut.push({
+                    isResolved: t.isResolved,
+                    isOutdated: t.isOutdated,
+                    authorLogins,
+                  });
+                }
+                if (!conn?.pageInfo?.hasNextPage) break;
+                tCursor = conn.pageInfo.endCursor;
+              }
+              return threadsOut;
+            }
+
+            const threads = await loadAllReviewThreads();
+
+            const isCopilotAuthor = (login) => {
+              if (!login) return false;
+              const l = String(login).toLowerCase();
+              return (
+                l === 'copilot' ||
+                l === 'copilot-pull-request-reviewer' ||
+                l.startsWith('copilot-pull-request-reviewer[')
+              );
+            };
+
+            const unresolved = [];
+            for (const t of threads) {
+              if (t.isOutdated) continue;
+              const copilotThread = t.authorLogins.some((login) =>
+                isCopilotAuthor(login)
+              );
+              if (copilotThread && !t.isResolved) {
+                unresolved.push('unresolved Copilot thread');
+              }
+            }
+
+            if (unresolved.length > 0) {
+              core.setFailed(
+                'One or more Copilot review threads are still unresolved. Resolve or justify each thread in the PR before merge.'
+              );
+              return;
+            }
+
+            core.info(
+              `Copilot review gate passed for ${repo}#${pull_number} @ ${headSha}`
+            );

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -5,9 +5,9 @@
 # all Copilot-started review threads must be resolved.
 #
 # Branch protection must require the check name: copilot-review / copilot-review
-# (workflow name / job name). See docs/COPILOT_REVIEW_ENFORCEMENT.md
+# (workflow name / job name). See petrosa_k8s/docs/COPILOT_REVIEW_ENFORCEMENT.md
 #
-# Related: Issue #330
+# Related: petrosa_k8s Issue #354 (rollout), Issue #330 (original enforcement design)
 
 name: copilot-review
 
@@ -171,13 +171,16 @@ jobs:
                 const conn = tr.repository?.pullRequest?.reviewThreads;
                 const nodes = conn?.nodes || [];
                 for (const t of nodes) {
-                  const authorLogins = (t.comments?.nodes || []).map(
-                    (c) => c.author?.login
-                  );
+                  const commentNodes = t.comments?.nodes || [];
+                  // Only track the thread-starter (first comment author) to avoid
+                  // blocking on human threads where Copilot later replies.
+                  const starterLogin = commentNodes.length > 0
+                    ? commentNodes[0].author?.login
+                    : null;
                   threadsOut.push({
                     isResolved: t.isResolved,
                     isOutdated: t.isOutdated,
-                    authorLogins,
+                    starterLogin,
                   });
                 }
                 if (!conn?.pageInfo?.hasNextPage) break;
@@ -201,9 +204,9 @@ jobs:
             const unresolved = [];
             for (const t of threads) {
               if (t.isOutdated) continue;
-              const copilotThread = t.authorLogins.some((login) =>
-                isCopilotAuthor(login)
-              );
+              // A "Copilot thread" is one started by Copilot (first comment author).
+              // This avoids blocking on human threads where Copilot later replies.
+              const copilotThread = isCopilotAuthor(t.starterLogin);
               if (copilotThread && !t.isResolved) {
                 unresolved.push('unresolved Copilot thread');
               }

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
       pull-requests: read
     env:
-      # GitHub Actions deprecates Node.js 20 for JS actions in 2026; opt into Node 24 early.
+      # GitHub Actions deprecates Node.js 20 for JS actions in 2026; opt into Node.js 24 early.
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -34,7 +34,7 @@ jobs:
       pull-requests: read
     env:
       # GitHub Actions deprecates Node.js 20 for JS actions in 2026; opt into Node.js 24 early.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"  # Node.js 24 opt-in
 
     steps:
       - name: Verify Copilot review and resolved threads

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: read
     env:
       # Opt into Node.js 24 for JS actions ahead of the June 2026 mandatory switch.
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -95,6 +96,7 @@ jobs:
             };
 
             async function hasCopilotReviewForHeadSha() {
+              // Check formal PR review entries (Copilot posted inline comments or a summary).
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner,
                 repo,
@@ -102,13 +104,27 @@ jobs:
                 per_page: 100,
               });
 
-              return reviews.some(
+              const hasFormalReview = reviews.some(
                 (r) =>
                   r.user &&
                   isCopilotPrReviewer(r.user.login) &&
                   r.commit_id === headSha &&
                   r.state !== 'DISMISSED' &&
                   r.state !== 'PENDING'
+              );
+              if (hasFormalReview) return true;
+
+              // Copilot may complete a clean review (no inline comments) without posting a
+              // formal PR review entry. Check if the Copilot code review workflow ran
+              // successfully on this exact headSha as a fallback.
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRunsForRepo,
+                { owner, repo, head_sha: headSha, status: 'success', per_page: 100 }
+              );
+              return runs.some(
+                (r) =>
+                  r.name === 'Copilot code review' ||
+                  (r.path && r.path.includes('copilot-pull-request-reviewer'))
               );
             }
 

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -1,8 +1,5 @@
-# TEMPLATE — Copy to `.github/workflows/copilot-review-gate.yml` in each Petrosa repo
-# before requiring the `copilot-review / copilot-review` status check on `main`.
-#
-# Enforces merge gating: Copilot must have reviewed the current PR head SHA and
-# all Copilot-started review threads must be resolved.
+# Enforces merge gating on PRs targeting main: Copilot must have reviewed the
+# current PR head SHA and all Copilot-started review threads must be resolved.
 #
 # Branch protection must require the check name: copilot-review / copilot-review
 # (workflow name / job name). See petrosa_k8s/docs/COPILOT_REVIEW_ENFORCEMENT.md
@@ -16,7 +13,9 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
-    types: [submitted, edited, dismissed]
+    types: [submitted, dismissed]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
   workflow_run:
     workflows: ["Request Copilot Review"]
     types: [completed]
@@ -33,8 +32,8 @@ jobs:
       contents: read
       pull-requests: read
     env:
-      # GitHub Actions deprecates Node.js 20 for JS actions in 2026; opt into Node.js 24 early.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"  # Node.js 24 opt-in
+      # Opt into Node.js 24 for JS actions ahead of the June 2026 mandatory switch.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Verify Copilot review and resolved threads
@@ -46,10 +45,11 @@ jobs:
             const repo = context.repo.repo;
 
             async function resolvePullRequest() {
-              if (context.eventName === 'pull_request') {
-                return context.payload.pull_request;
-              }
-              if (context.eventName === 'pull_request_review') {
+              if (
+                context.eventName === 'pull_request' ||
+                context.eventName === 'pull_request_review' ||
+                context.eventName === 'pull_request_review_thread'
+              ) {
                 return context.payload.pull_request;
               }
               if (context.eventName === 'workflow_run') {
@@ -111,7 +111,7 @@ jobs:
             }
 
             // Copilot reviews are asynchronous and often land after CI completes and after the
-            // review request workflow runs. To avoid flaky “rerun until Copilot posts” behavior,
+            // review request workflow runs. To avoid flaky "rerun until Copilot posts" behavior,
             // poll for a bounded time before failing.
             const maxWaitSeconds = 20 * 60; // 20 minutes
             const pollIntervalSeconds = 30;

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -40,7 +40,11 @@ jobs:
 
             let pull_number;
             if (context.eventName === 'workflow_dispatch') {
-              pull_number = parseInt(context.payload.inputs.pull_number);
+              pull_number = parseInt(context.payload.inputs.pull_number, 10);
+              if (isNaN(pull_number) || pull_number <= 0) {
+                core.setFailed('Invalid pull_number input: must be a positive integer.');
+                return;
+              }
             } else {
               const run = context.payload.workflow_run;
               const pr = run.pull_requests[0];

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -41,8 +41,14 @@ jobs:
             let pull_number;
             if (context.eventName === 'workflow_dispatch') {
               pull_number = parseInt(context.payload.inputs.pull_number, 10);
-              if (isNaN(pull_number) || pull_number <= 0) {
-                core.setFailed('Invalid pull_number input: must be a positive integer.');
+              if (!Number.isInteger(pull_number) || pull_number <= 0) {
+                core.setFailed(`Invalid pull_number input: must be a positive integer, got "${context.payload.inputs.pull_number}".`);
+                return;
+              }
+              // Fetch and validate the PR exists and is not a fork
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+              if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+                console.log(`Skipping fork PR from ${pr.head.repo.full_name}`);
                 return;
               }
             } else {

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -10,14 +10,21 @@ on:
   workflow_run:
     workflows: ["CI Checks"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: 'PR number to request Copilot review for'
+        required: true
+        type: number
 
 jobs:
   request-copilot-review:
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.pull_requests[0] != null &&
-      github.event.workflow_run.pull_requests[0].head.repo.full_name == github.repository
+      github.event.workflow_run.pull_requests[0].head.repo.full_name == github.repository)
     runs-on: petrosa-org-runners
     permissions:
       pull-requests: write
@@ -30,20 +37,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const run = context.payload.workflow_run;
-            const pr = run.pull_requests[0];
 
-            if (!pr) {
-              console.log('No pull request associated with this workflow_run.');
-              return;
+            let pull_number;
+            if (context.eventName === 'workflow_dispatch') {
+              pull_number = parseInt(context.payload.inputs.pull_number);
+            } else {
+              const run = context.payload.workflow_run;
+              const pr = run.pull_requests[0];
+              if (!pr) {
+                console.log('No pull request associated with this workflow_run.');
+                return;
+              }
+              if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+                console.log(`Skipping fork PR from ${pr.head.repo.full_name}`);
+                return;
+              }
+              pull_number = pr.number;
             }
-
-            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
-              console.log(`Skipping fork PR from ${pr.head.repo.full_name}`);
-              return;
-            }
-
-            const pull_number = pr.number;
 
             console.log(`Requesting Copilot review for PR #${pull_number}...`);
 


### PR DESCRIPTION
## Summary

- Deploys `copilot-review-gate.yml` from the `petrosa_k8s` template so the required `copilot-review / copilot-review` status check is satisfied on every PR
- The gate waits up to 20 minutes for a submitted Copilot review on the current head SHA, then blocks merge until all Copilot-started review threads are resolved
- Pairs with the existing `request-copilot-review.yml` which requests Copilot only after CI succeeds

## Motivation

Closes governance gap tracked in [petrosa_k8s#354](https://github.com/PetroSa2/petrosa_k8s/issues/354). The `apply-repo-settings.sh` script enforces `copilot-review / copilot-review` as a required check; without this workflow the check would never run, permanently blocking merges.

## Test plan
- [ ] Merge this PR; confirm `copilot-review / copilot-review` check appears on the next PR opened against `main`
- [ ] Verify Copilot review is requested only after CI passes (via `request-copilot-review.yml`)
- [ ] Verify merging requires Copilot review + resolved threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)