### PR TITLE
fix: re-request Copilot review by removing+re-adding reviewer

### DIFF
--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -65,7 +65,10 @@ jobs:
                 return;
               }
               pull_number = pr.number;
-              headSha = pr.head.sha;
+              // Fetch the live PR to get the current head SHA — the workflow_run
+              // payload may be stale if a commit was pushed while CI was in-flight.
+              const { data: livePr } = await github.rest.pulls.get({ owner, repo, pull_number });
+              headSha = livePr.head.sha;
             }
 
             // Short-circuit: skip if Copilot already reviewed the current head SHA.

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -39,6 +39,7 @@ jobs:
             const { owner, repo } = context.repo;
 
             let pull_number;
+            let headSha;
             if (context.eventName === 'workflow_dispatch') {
               pull_number = parseInt(context.payload.inputs.pull_number, 10);
               if (!Number.isInteger(pull_number) || pull_number <= 0) {
@@ -51,6 +52,7 @@ jobs:
                 console.log(`Skipping fork PR from ${pr.head.repo.full_name}`);
                 return;
               }
+              headSha = pr.head.sha;
             } else {
               const run = context.payload.workflow_run;
               const pr = run.pull_requests[0];
@@ -63,9 +65,45 @@ jobs:
                 return;
               }
               pull_number = pr.number;
+              headSha = pr.head.sha;
             }
 
-            console.log(`Requesting Copilot review for PR #${pull_number}...`);
+            // Short-circuit: skip if Copilot already reviewed the current head SHA.
+            // This prevents duplicate review requests on CI reruns with no code changes.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner, repo, pull_number, per_page: 100,
+            });
+            const isCopilot = (login) => {
+              const l = (login || '').toLowerCase();
+              return l === 'copilot-pull-request-reviewer' || l.startsWith('copilot-pull-request-reviewer[');
+            };
+            const alreadyReviewed = reviews.some(
+              (r) => isCopilot(r.user?.login) && r.commit_id === headSha &&
+                r.state !== 'DISMISSED' && r.state !== 'PENDING'
+            );
+            if (alreadyReviewed) {
+              console.log(`Copilot already reviewed HEAD ${headSha}; skipping re-request.`);
+              return;
+            }
+
+            console.log(`Requesting Copilot review for PR #${pull_number} @ ${headSha}...`);
+
+            // Remove first so that re-requesting triggers a fresh review even when
+            // Copilot has already reviewed a previous commit (mirrors the GitHub UI
+            // "Re-request review" button behavior).
+            try {
+              await github.rest.pulls.removeRequestedReviewers({
+                owner,
+                repo,
+                pull_number,
+                reviewers: ['github-copilot'],
+              });
+            } catch (e) {
+              // 422 = reviewer was not in the pending list; safe to ignore.
+              // All other statuses (404 resource not found, 403 permissions, 5xx)
+              // are re-thrown so the step fails visibly.
+              if (e.status !== 422) throw e;
+            }
 
             try {
               await github.rest.pulls.requestReviewers({
@@ -76,9 +114,8 @@ jobs:
               });
               console.log(`Requested Copilot review for PR #${pull_number}`);
             } catch (error) {
-              if (error.status === 422) {
-                console.log('Copilot already requested or unavailable; continuing.');
-              } else {
-                console.log(`Non-blocking error: ${error.message}`);
-              }
+              // 422 = Copilot unavailable or already in review queue; safe to ignore.
+              // All other errors are re-thrown so the step fails visibly.
+              if (error.status !== 422) throw error;
+              console.log('Copilot already requested or unavailable (422); continuing.');
             }


### PR DESCRIPTION
## Problem

When CI passes and a new commit is pushed, `request-copilot-review.yml` calls `requestReviewers` — but if Copilot has already reviewed a previous commit on this PR, GitHub silently ignores the request. Copilot treats the PR as \"already reviewed\" and posts no new review. The result: the copilot-review gate times out and the user has to manually click **Re-request review** in the GitHub UI.

This happened twice on PR #345.

## Fix

Call `removeRequestedReviewers` first, then `requestReviewers`. This is exactly what the GitHub UI **Re-request review** button does internally, and it forces Copilot to treat the next push as a fresh review target.

## Test plan
- [ ] Push a follow-up commit to a PR after Copilot has already reviewed it
- [ ] Verify `Request Copilot Review` workflow runs and Copilot posts a new review without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)