### PR TITLE
fix: apply Copilot-suggested improvements to request-copilot-review.yml (tradeengine)

### DIFF
--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -23,10 +23,9 @@ on:
 
 jobs:
   request-copilot-review:
-    # Fork-triggered workflow_run events are short-circuited by the job-level
-    # head_repository guard above. For workflow_dispatch, the fork guard runs
-    # inside the script. PR resolution happens via the REST API using head_sha
-    # + head_branch (workflow_run.pull_requests[] is unreliable).
+    # `if` head_repository guard below. For workflow_dispatch, the fork guard
+    # runs inside the script. PR resolution happens via the REST API using
+    # head_sha + head_branch (workflow_run.pull_requests[] is unreliable).
     if: >
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -23,8 +23,10 @@ on:
 
 jobs:
   request-copilot-review:
-    # workflow_run.pull_requests[] is always empty (GitHub bug/limitation); the
-    # fork check and PR resolution happen inside the script via the REST API.
+    # Fork-triggered workflow_run events are short-circuited by the job-level
+    # head_repository guard above. For workflow_dispatch, the fork guard runs
+    # inside the script. PR resolution happens via the REST API using head_sha
+    # + head_branch (workflow_run.pull_requests[] is unreliable).
     if: >
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -28,7 +28,8 @@ jobs:
     if: >
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request')
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: petrosa-org-runners
     permissions:
       pull-requests: write
@@ -62,10 +63,10 @@ jobs:
               // workflow_run.pull_requests[] is unreliable — resolve the PR by
               // matching head_sha + head_branch via the REST API instead.
               const run = context.payload.workflow_run;
-              const { data: prs } = await github.rest.pulls.list({
+              const prs = await github.paginate(github.rest.pulls.list, {
                 owner, repo, state: 'open',
                 head: `${owner}:${run.head_branch}`,
-                per_page: 10,
+                per_page: 100,
               });
               const pr = prs.find(
                 (p) => p.head.sha === run.head_sha &&


### PR DESCRIPTION
## Summary

Applies two Copilot-suggested improvements to `request-copilot-review.yml` in `petrosa-tradeengine` as tracked in issue PetroSa2/petrosa_k8s#376.

- **Fork guard**: Add `github.event.workflow_run.head_repository.full_name == github.repository` to the job `if` condition, short-circuiting fork-triggered `workflow_run` events before the job runs
- **Pagination fix**: Replace `pulls.list({ per_page: 10 })` with `github.paginate(github.rest.pulls.list, { per_page: 100 })` to prevent silently missing the target PR when more than 10 open PRs share the same `head_branch`

The equivalent change for `petrosa_k8s` is tracked at https://github.com/PetroSa2/petrosa_k8s/pull/381.

## Test plan

- [x] Pre-commit hooks pass (YAML lint, secret detection, pipeline)
- [ ] Copilot auto-review still triggers correctly on new PRs after merge (no functional regression)

Closes PetroSa2/petrosa_k8s#376

🤖 Generated with [Claude Code](https://claude.com/claude-code)