### PR TITLE
[BUG] Relax Copilot gate — accept any PR review, remove re-request dance (#380)

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -104,7 +104,10 @@ jobs:
               );
             };
 
-            async function hasCopilotReviewForHeadSha() {
+            // Accept any submitted non-dismissed Copilot review on the PR, regardless of
+            // which commit was reviewed. Re-review via API is a no-op (#380) — the
+            // thread-resolution check below is the real enforcement mechanism.
+            async function hasCopilotReviewForPR() {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
                 owner,
                 repo,
@@ -116,7 +119,6 @@ jobs:
                 (r) =>
                   r.user &&
                   isCopilotPrReviewer(r.user.login) &&
-                  r.commit_id === headSha &&
                   r.state !== 'DISMISSED' &&
                   r.state !== 'PENDING'
               );
@@ -130,21 +132,21 @@ jobs:
             let waited = 0;
 
             while (waited <= maxWaitSeconds) {
-              if (await hasCopilotReviewForHeadSha()) {
-                core.info(`Found submitted Copilot review for head ${headSha}.`);
+              if (await hasCopilotReviewForPR()) {
+                core.info(`Found submitted Copilot review for PR #${pull_number}.`);
                 break;
               }
 
               if (waited === 0) {
                 core.info(
-                  `Waiting for Copilot PR review on current head ${headSha} (polling up to ${maxWaitSeconds}s).`
+                  `Waiting for Copilot PR review on PR #${pull_number} (any commit accepted, polling up to ${maxWaitSeconds}s).`
                 );
               }
 
               if (waited >= maxWaitSeconds) {
                 core.setFailed(
-                  `No submitted Copilot PR review for current head ${headSha} after waiting ${maxWaitSeconds}s. ` +
-                    `Copilot may be delayed; re-request Copilot review and retry once it submits a review on the latest commit.`
+                  `No submitted Copilot PR review for PR #${pull_number} after waiting ${maxWaitSeconds}s. ` +
+                    `Request a Copilot review via the GitHub UI and retry once it submits one.`
                 );
                 return;
               }

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -1,8 +1,11 @@
 # TEMPLATE — Copy to `.github/workflows/copilot-review-gate.yml` in each Petrosa repo
 # before requiring the `copilot-review / copilot-review` status check on `main`.
 #
-# Enforces merge gating: Copilot must have reviewed the current PR head SHA and
-# all Copilot-started review threads must be resolved.
+# Enforces merge gating: Copilot must have reviewed the PR (any commit) and
+# all non-outdated Copilot-started review threads must be resolved.
+#
+# Design: one Copilot review per PR is the correct standard (issue #380).
+# Re-review via API is a no-op — the thread-resolution check is the real quality gate.
 #
 # Branch protection must require the check name: copilot-review / copilot-review
 # (workflow name / job name). See petrosa_k8s/docs/COPILOT_REVIEW_ENFORCEMENT.md
@@ -85,7 +88,6 @@ jobs:
             }
 
             const pull_number = pr.number;
-            const headSha = pr.head.sha;
 
             // When triggered by a Copilot review submission, the GitHub REST API can
             // take 10–20s to reflect the new review. A short grace period before the
@@ -234,5 +236,5 @@ jobs:
             }
 
             core.info(
-              `Copilot review gate passed for ${repo}#${pull_number} @ ${headSha}`
+              `Copilot review gate passed for ${repo}#${pull_number}.`
             );

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -82,8 +82,11 @@ jobs:
               headSha = pr.head.sha;
             }
 
-            // Short-circuit: skip if Copilot already reviewed the current head SHA.
-            // This prevents duplicate review requests on CI reruns with no code changes.
+            // Short-circuit: skip if Copilot has already submitted any review on this PR.
+            // One Copilot review per PR is the correct standard (#380) — re-review via
+            // API is a no-op (requestReviewers returns 200 but fires no review_requested
+            // event for Copilot). The thread-resolution check in the gate is the real
+            // quality enforcement; requesting again would have no effect.
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner, repo, pull_number, per_page: 100,
             });
@@ -92,32 +95,15 @@ jobs:
               return l === 'copilot-pull-request-reviewer' || l.startsWith('copilot-pull-request-reviewer[');
             };
             const alreadyReviewed = reviews.some(
-              (r) => isCopilot(r.user?.login) && r.commit_id === headSha &&
+              (r) => isCopilot(r.user?.login) &&
                 r.state !== 'DISMISSED' && r.state !== 'PENDING'
             );
             if (alreadyReviewed) {
-              console.log(`Copilot already reviewed HEAD ${headSha}; skipping re-request.`);
+              console.log(`Copilot already reviewed this PR; skipping re-request.`);
               return;
             }
 
-            console.log(`Requesting Copilot review for PR #${pull_number} @ ${headSha}...`);
-
-            // Remove first so that re-requesting triggers a fresh review even when
-            // Copilot has already reviewed a previous commit (mirrors the GitHub UI
-            // "Re-request review" button behavior).
-            try {
-              await github.rest.pulls.removeRequestedReviewers({
-                owner,
-                repo,
-                pull_number,
-                reviewers: ['github-copilot'],
-              });
-            } catch (e) {
-              // 422 = reviewer was not in the pending list; safe to ignore.
-              // All other statuses (404 resource not found, 403 permissions, 5xx)
-              // are re-thrown so the step fails visibly.
-              if (e.status !== 422) throw e;
-            }
+            console.log(`Requesting Copilot review for PR #${pull_number}...`);
 
             try {
               await github.rest.pulls.requestReviewers({


### PR DESCRIPTION
## Summary

Implements the one-Copilot-review-per-PR design decision from PetroSa2/petrosa_k8s#380.

- **`copilot-review-gate.yml`**: Remove `r.commit_id === headSha` constraint — accept any submitted non-dismissed Copilot review on the PR. Thread-resolution check remains the enforcement mechanism.
- **`request-copilot-review.yml`**: Simplify skip condition to check for any existing review (not just HEAD SHA). Remove the remove+re-request dance (no-op via API per #380 investigation).

Fixes the permanent-block scenario where a follow-up commit caused the gate to poll 20 min for a Copilot re-review that could never arrive via API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)