### PR TITLE
feat: automate resolution of Copilot review threads to clear merge gate (#365)

### DIFF
--- a/scripts/resolve-copilot-comments.py
+++ b/scripts/resolve-copilot-comments.py
@@ -86,7 +86,14 @@ def gh_graphql(query: str, variables: dict) -> dict:
             cmd += ["-F", f"{key}={val}"]
         else:
             cmd += ["-f", f"{key}={val}"]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError:
+        print(
+            "Error: 'gh' CLI not found. Install it from https://cli.github.com and run 'gh auth login'.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if result.returncode != 0:
         print(f"GraphQL error: {result.stderr}", file=sys.stderr)
         sys.exit(1)
@@ -104,7 +111,8 @@ def load_threads(owner: str, repo: str, pr: int) -> tuple[str, list[dict]]:
     cursor = None
     head_sha = None
 
-    for _ in range(20):
+    _PAGE_LIMIT = 20
+    for page in range(_PAGE_LIMIT):
         variables: dict = {"owner": owner, "repo": repo, "pr": pr, "cursor": cursor}
         data = gh_graphql(_THREADS_QUERY, variables)
         pr_data = data["data"]["repository"]["pullRequest"]
@@ -131,6 +139,13 @@ def load_threads(owner: str, repo: str, pr: int) -> tuple[str, list[dict]]:
         if not conn["pageInfo"]["hasNextPage"]:
             break
         cursor = conn["pageInfo"]["endCursor"]
+        if page == _PAGE_LIMIT - 1:
+            print(
+                f"Error: exceeded {_PAGE_LIMIT}-page pagination limit while threads remain. "
+                "Aborting to avoid silently missing unresolved threads.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     return head_sha or "", threads
 

--- a/scripts/resolve-copilot-comments.py
+++ b/scripts/resolve-copilot-comments.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Resolves unresolved Copilot-started review threads on a GitHub PR.
+
+Queries review threads via GitHub GraphQL, posts an "Addressed in commit <sha>"
+reply on each unresolved Copilot thread, then calls resolveReviewThread to set
+isResolved=true — allowing the copilot-review gate to pass without human clicks.
+
+Only threads started by Copilot are resolved; human-started threads are skipped.
+
+Usage:
+    python scripts/resolve-copilot-comments.py <PR_URL_or_number> \
+        [--repo OWNER/REPO] [--sha SHA] [--dry-run]
+
+Examples:
+    python scripts/resolve-copilot-comments.py \
+        https://github.com/PetroSa2/petrosa-tradeengine/pull/364
+    python scripts/resolve-copilot-comments.py 364 \
+        --repo PetroSa2/petrosa-tradeengine --dry-run
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+COPILOT_LOGINS = {"copilot", "copilot-pull-request-reviewer"}
+
+_THREADS_QUERY = """
+query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      headRefOid
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first: 1) {
+            nodes {
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_REPLY_MUTATION = """
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: $threadId
+    body: $body
+  }) {
+    comment { id }
+  }
+}
+"""
+
+_RESOLVE_MUTATION = """
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}
+"""
+
+
+def is_copilot_login(login: str) -> bool:
+    if not login:
+        return False
+    lower = login.lower()
+    return lower in COPILOT_LOGINS or lower.startswith("copilot-pull-request-reviewer[")
+
+
+def gh_graphql(query: str, variables: dict) -> dict:
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for key, val in variables.items():
+        if val is None:
+            continue
+        if isinstance(val, int):
+            cmd += ["-F", f"{key}={val}"]
+        else:
+            cmd += ["-f", f"{key}={val}"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"GraphQL error: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    data = json.loads(result.stdout)
+    if "errors" in data:
+        print(
+            f"GraphQL errors: {json.dumps(data['errors'], indent=2)}", file=sys.stderr
+        )
+        sys.exit(1)
+    return data
+
+
+def load_threads(owner: str, repo: str, pr: int) -> tuple[str, list[dict]]:
+    threads: list[dict] = []
+    cursor = None
+    head_sha = None
+
+    for _ in range(20):
+        variables: dict = {"owner": owner, "repo": repo, "pr": pr, "cursor": cursor}
+        data = gh_graphql(_THREADS_QUERY, variables)
+        pr_data = data["data"]["repository"]["pullRequest"]
+
+        if head_sha is None:
+            head_sha = pr_data["headRefOid"]
+
+        conn = pr_data["reviewThreads"]
+        for node in conn["nodes"]:
+            comments = node.get("comments", {}).get("nodes", [])
+            starter_login = None
+            if comments:
+                author = comments[0].get("author") or {}
+                starter_login = author.get("login")
+            threads.append(
+                {
+                    "id": node["id"],
+                    "isResolved": node["isResolved"],
+                    "isOutdated": node["isOutdated"],
+                    "starterLogin": starter_login,
+                }
+            )
+
+        if not conn["pageInfo"]["hasNextPage"]:
+            break
+        cursor = conn["pageInfo"]["endCursor"]
+
+    return head_sha or "", threads
+
+
+def post_reply(thread_id: str, body: str) -> None:
+    gh_graphql(_REPLY_MUTATION, {"threadId": thread_id, "body": body})
+
+
+def resolve_thread(thread_id: str) -> bool:
+    data = gh_graphql(_RESOLVE_MUTATION, {"threadId": thread_id})
+    return bool(data["data"]["resolveReviewThread"]["thread"]["isResolved"])
+
+
+def parse_pr_ref(pr_arg: str, repo_arg: str | None) -> tuple[str, str, int]:
+    url_match = re.match(r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_arg)
+    if url_match:
+        return url_match.group(1), url_match.group(2), int(url_match.group(3))
+
+    if pr_arg.isdigit():
+        if not repo_arg:
+            print(
+                "Error: --repo OWNER/REPO is required when pr is a number",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        parts = repo_arg.split("/", 1)
+        if len(parts) != 2:
+            print("Error: --repo must be in OWNER/REPO format", file=sys.stderr)
+            sys.exit(1)
+        return parts[0], parts[1], int(pr_arg)
+
+    print(f"Error: unrecognised PR reference: {pr_arg!r}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve unresolved Copilot review threads on a GitHub PR."
+    )
+    parser.add_argument("pr", help="PR URL or PR number")
+    parser.add_argument("--repo", help="OWNER/REPO (required when pr is a number)")
+    parser.add_argument(
+        "--sha",
+        help="Commit SHA to reference in resolution comments (defaults to PR head SHA)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List unresolved threads without resolving them",
+    )
+    args = parser.parse_args(argv)
+
+    owner, repo, pr_number = parse_pr_ref(args.pr, args.repo)
+
+    print(
+        f"Scanning PR #{pr_number} in {owner}/{repo} for unresolved Copilot threads..."
+    )
+
+    head_sha, threads = load_threads(owner, repo, pr_number)
+    sha = args.sha if args.sha else head_sha[:12]
+
+    copilot_unresolved = [
+        t
+        for t in threads
+        if not t["isOutdated"]
+        and not t["isResolved"]
+        and is_copilot_login(t["starterLogin"])
+    ]
+
+    print(f"  Total threads: {len(threads)}")
+    print(f"  Unresolved Copilot threads: {len(copilot_unresolved)}")
+
+    if not copilot_unresolved:
+        print("Nothing to resolve.")
+        return 0
+
+    if args.dry_run:
+        print("\n[dry-run] Would resolve:")
+        for i, t in enumerate(copilot_unresolved, 1):
+            print(f"  {i}. {t['id']}  (started by {t['starterLogin']})")
+        return 0
+
+    resolved_count = 0
+    for i, t in enumerate(copilot_unresolved, 1):
+        tid = t["id"]
+        label = f"[{i}/{len(copilot_unresolved)}]"
+        comment_body = f"Addressed in commit {sha}."
+        print(f"  {label} Replying on thread {tid}...")
+        post_reply(tid, comment_body)
+        print(f"  {label} Resolving thread {tid}...")
+        ok = resolve_thread(tid)
+        if ok:
+            resolved_count += 1
+            print("    ✓ Resolved")
+        else:
+            print(
+                "    ✗ resolveReviewThread returned isResolved=False", file=sys.stderr
+            )
+
+    print(f"\nDone: {resolved_count}/{len(copilot_unresolved)} threads resolved.")
+    return 0 if resolved_count == len(copilot_unresolved) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_resolve_copilot_comments.py
+++ b/tests/test_resolve_copilot_comments.py
@@ -1,10 +1,8 @@
 """Tests for scripts/resolve-copilot-comments.py"""
 
 import importlib.util
-import sys
-import types
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_resolve_copilot_comments.py
+++ b/tests/test_resolve_copilot_comments.py
@@ -1,0 +1,278 @@
+"""Tests for scripts/resolve-copilot-comments.py"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the script as a module (it lives outside the package tree)
+# ---------------------------------------------------------------------------
+_SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "resolve-copilot-comments.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "resolve_copilot_comments", _SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rcc = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# is_copilot_login
+# ---------------------------------------------------------------------------
+
+
+class TestIsCopilotLogin:
+    def test_copilot_lowercase(self):
+        assert rcc.is_copilot_login("copilot") is True
+
+    def test_copilot_pr_reviewer(self):
+        assert rcc.is_copilot_login("copilot-pull-request-reviewer") is True
+
+    def test_copilot_pr_reviewer_bracket_suffix(self):
+        assert rcc.is_copilot_login("copilot-pull-request-reviewer[bot]") is True
+
+    def test_case_insensitive(self):
+        assert rcc.is_copilot_login("Copilot") is True
+        assert rcc.is_copilot_login("COPILOT-PULL-REQUEST-REVIEWER") is True
+
+    def test_human_login(self):
+        assert rcc.is_copilot_login("alice") is False
+
+    def test_empty_string(self):
+        assert rcc.is_copilot_login("") is False
+
+    def test_none_string(self):
+        assert rcc.is_copilot_login(None) is False
+
+
+# ---------------------------------------------------------------------------
+# parse_pr_ref
+# ---------------------------------------------------------------------------
+
+
+class TestParsePrRef:
+    def test_full_url(self):
+        owner, repo, num = rcc.parse_pr_ref(
+            "https://github.com/PetroSa2/petrosa-tradeengine/pull/364", None
+        )
+        assert owner == "PetroSa2"
+        assert repo == "petrosa-tradeengine"
+        assert num == 364
+
+    def test_number_with_repo(self):
+        owner, repo, num = rcc.parse_pr_ref("42", "MyOrg/my-repo")
+        assert owner == "MyOrg"
+        assert repo == "my-repo"
+        assert num == 42
+
+    def test_number_without_repo_exits(self):
+        with pytest.raises(SystemExit) as exc:
+            rcc.parse_pr_ref("42", None)
+        assert exc.value.code != 0
+
+    def test_invalid_ref_exits(self):
+        with pytest.raises(SystemExit) as exc:
+            rcc.parse_pr_ref("not-a-pr", None)
+        assert exc.value.code != 0
+
+    def test_malformed_repo_exits(self):
+        with pytest.raises(SystemExit) as exc:
+            rcc.parse_pr_ref("42", "noslash")
+        assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# load_threads
+# ---------------------------------------------------------------------------
+
+
+def _make_thread(tid, resolved, outdated, starter):
+    return {
+        "id": tid,
+        "isResolved": resolved,
+        "isOutdated": outdated,
+        "comments": {"nodes": [{"author": {"login": starter}}] if starter else []},
+    }
+
+
+def _threads_response(threads, has_next=False, cursor=None, sha="abc123def456"):
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "headRefOid": sha,
+                    "reviewThreads": {
+                        "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                        "nodes": threads,
+                    },
+                }
+            }
+        }
+    }
+
+
+class TestLoadThreads:
+    def test_single_page(self):
+        raw = [
+            _make_thread("T1", False, False, "copilot"),
+            _make_thread("T2", True, False, "alice"),
+        ]
+        response = _threads_response(raw, sha="deadbeef1234")
+
+        with patch.object(rcc, "gh_graphql", return_value=response) as mock_gql:
+            sha, threads = rcc.load_threads("Org", "repo", 1)
+
+        assert sha == "deadbeef1234"
+        assert len(threads) == 2
+        assert threads[0]["id"] == "T1"
+        assert threads[0]["starterLogin"] == "copilot"
+        mock_gql.assert_called_once()
+
+    def test_no_author_on_first_comment(self):
+        raw = [_make_thread("T3", False, False, None)]
+        with patch.object(rcc, "gh_graphql", return_value=_threads_response(raw)):
+            _, threads = rcc.load_threads("Org", "repo", 1)
+
+        assert threads[0]["starterLogin"] is None
+
+    def test_pagination(self):
+        page1 = _threads_response(
+            [_make_thread("T1", False, False, "copilot")],
+            has_next=True,
+            cursor="CUR1",
+            sha="sha111",
+        )
+        page2 = _threads_response(
+            [_make_thread("T2", False, False, "copilot")],
+            has_next=False,
+            sha="sha111",
+        )
+        with patch.object(rcc, "gh_graphql", side_effect=[page1, page2]) as mock_gql:
+            sha, threads = rcc.load_threads("Org", "repo", 1)
+
+        assert len(threads) == 2
+        assert mock_gql.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# main — integration-level with all I/O mocked
+# ---------------------------------------------------------------------------
+
+
+def _build_threads(*specs):
+    """specs: list of (resolved, outdated, starter_login)"""
+    return [
+        {
+            "id": f"TID{i}",
+            "isResolved": resolved,
+            "isOutdated": outdated,
+            "starterLogin": starter,
+        }
+        for i, (resolved, outdated, starter) in enumerate(specs, 1)
+    ]
+
+
+class TestMain:
+    def test_dry_run_does_not_resolve(self):
+        threads = _build_threads(
+            (False, False, "copilot"),
+            (False, False, "copilot-pull-request-reviewer"),
+        )
+        with (
+            patch.object(rcc, "load_threads", return_value=("abcdef123456", threads)),
+            patch.object(rcc, "post_reply") as mock_reply,
+            patch.object(rcc, "resolve_thread") as mock_resolve,
+        ):
+            rc = rcc.main(["https://github.com/O/R/pull/1", "--dry-run"])
+
+        assert rc == 0
+        mock_reply.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    def test_nothing_to_resolve(self):
+        threads = _build_threads(
+            (True, False, "copilot"),
+            (False, True, "copilot"),
+            (False, False, "alice"),
+        )
+        with (
+            patch.object(rcc, "load_threads", return_value=("abc", threads)),
+            patch.object(rcc, "post_reply") as mock_reply,
+            patch.object(rcc, "resolve_thread") as mock_resolve,
+        ):
+            rc = rcc.main(["https://github.com/O/R/pull/1"])
+
+        assert rc == 0
+        mock_reply.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    def test_resolves_copilot_threads(self):
+        threads = _build_threads(
+            (False, False, "copilot"),
+            (False, False, "copilot-pull-request-reviewer"),
+            (False, False, "alice"),  # human — skipped
+        )
+        with (
+            patch.object(rcc, "load_threads", return_value=("abcdef012345", threads)),
+            patch.object(rcc, "post_reply") as mock_reply,
+            patch.object(rcc, "resolve_thread", return_value=True) as mock_resolve,
+        ):
+            rc = rcc.main(["https://github.com/O/R/pull/1", "--sha", "deadbeef"])
+
+        assert rc == 0
+        assert mock_reply.call_count == 2
+        assert mock_resolve.call_count == 2
+        mock_reply.assert_any_call("TID1", "Addressed in commit deadbeef.")
+        mock_reply.assert_any_call("TID2", "Addressed in commit deadbeef.")
+
+    def test_uses_pr_head_sha_when_no_sha_flag(self):
+        threads = _build_threads((False, False, "copilot"))
+        with (
+            patch.object(
+                rcc, "load_threads", return_value=("fullsha9876543210", threads)
+            ),
+            patch.object(rcc, "post_reply") as mock_reply,
+            patch.object(rcc, "resolve_thread", return_value=True),
+        ):
+            rcc.main(["https://github.com/O/R/pull/1"])
+
+        # SHA is truncated to 12 chars from the head SHA
+        mock_reply.assert_called_once_with("TID1", "Addressed in commit fullsha98765.")
+
+    def test_nonzero_exit_on_partial_failure(self):
+        threads = _build_threads(
+            (False, False, "copilot"),
+            (False, False, "copilot"),
+        )
+        with (
+            patch.object(rcc, "load_threads", return_value=("abc", threads)),
+            patch.object(rcc, "post_reply"),
+            patch.object(rcc, "resolve_thread", side_effect=[True, False]),
+        ):
+            rc = rcc.main(["https://github.com/O/R/pull/1"])
+
+        assert rc == 1
+
+    def test_number_ref_with_repo_flag(self):
+        threads = _build_threads((True, False, "copilot"))
+        with (
+            patch.object(
+                rcc, "load_threads", return_value=("abc", threads)
+            ) as mock_load,
+            patch.object(rcc, "post_reply"),
+            patch.object(rcc, "resolve_thread", return_value=True),
+        ):
+            rc = rcc.main(["42", "--repo", "MyOrg/my-repo"])
+
+        assert rc == 0
+        mock_load.assert_called_once_with("MyOrg", "my-repo", 42)


### PR DESCRIPTION
## Summary

Closes #365

Introduces `scripts/resolve-copilot-comments.py`, a standalone tool that programmatically resolves unresolved Copilot-started review threads on a PR, eliminating the manual toil of clicking "Resolve" in the GitHub UI after the agent has already addressed the feedback in code.

## What changed

### `scripts/resolve-copilot-comments.py` (new)
- Paginates through all review threads on a given PR via GitHub GraphQL
- Filters to threads that are: started by Copilot, not outdated, not already resolved
- Posts an **"Addressed in commit `<sha>`"** reply on each thread for auditability
- Calls `resolveReviewThread` mutation to set `isResolved=true`
- Human-started threads are never touched
- Supports `--dry-run`, `--sha` override, and both URL and number+`--repo` PR references
- Uses `gh api graphql` (no extra dependencies)

### `tests/test_resolve_copilot_comments.py` (new)
- 21 unit tests covering: login detection, PR ref parsing, thread pagination, dry-run, SHA auto-detection, partial failure exit code

## Usage

```bash
# Resolve all unresolved Copilot threads on PR #364
python scripts/resolve-copilot-comments.py     https://github.com/PetroSa2/petrosa-tradeengine/pull/364

# Dry-run to preview what would be resolved
python scripts/resolve-copilot-comments.py 364     --repo PetroSa2/petrosa-tradeengine --dry-run

# Pin to a specific commit SHA for the resolution comment
python scripts/resolve-copilot-comments.py 364     --repo PetroSa2/petrosa-tradeengine --sha abc123
```

## Acceptance criteria

- [x] Script exists at `scripts/resolve-copilot-comments.py`
- [x] Identifies and resolves Copilot-started threads via GraphQL `resolveReviewThread`
- [x] Every resolution posts a commit-linked comment for auditability
- [x] Human-started threads are skipped
- [x] Pipeline passes (1288 tests, ruff, mypy, bandit all green)