### PR TITLE
[BUG] Risk UX: zero futures availableBalance triggers max exposure and generic position-limit rejections

### DIFF
--- a/tests/test_position_manager_comprehensive.py
+++ b/tests/test_position_manager_comprehensive.py
@@ -593,11 +593,12 @@ async def test_calculate_portfolio_exposure(position_manager):
 
 @pytest.mark.asyncio
 async def test_check_position_limits_zero_portfolio_value(
-    position_manager, sample_long_order
+    position_manager, sample_long_order, caplog
 ):
     """AC-1 (#352): zero portfolio value returns distinct insufficient-margin rejection"""
     position_manager.total_portfolio_value = 0.0
     position_manager.max_portfolio_exposure_pct = 0.5
+    caplog.set_level("ERROR")
 
     with patch.object(
         position_manager,
@@ -613,15 +614,20 @@ async def test_check_position_limits_zero_portfolio_value(
             with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
                 result = await position_manager.check_position_limits(sample_long_order)
                 assert result is False
+                assert position_manager.rejection_reason == "insufficient_margin"
+                assert any("Insufficient margin" in msg for msg in caplog.messages), (
+                    "expected distinct insufficient-margin log message"
+                )
 
 
 @pytest.mark.asyncio
 async def test_check_position_limits_negative_portfolio_value(
-    position_manager, sample_long_order
+    position_manager, sample_long_order, caplog
 ):
     """AC-1 (#352): negative portfolio value also returns insufficient-margin rejection"""
     position_manager.total_portfolio_value = -500.0
     position_manager.max_portfolio_exposure_pct = 0.5
+    caplog.set_level("ERROR")
 
     with patch.object(
         position_manager,
@@ -637,6 +643,10 @@ async def test_check_position_limits_negative_portfolio_value(
             with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
                 result = await position_manager.check_position_limits(sample_long_order)
                 assert result is False
+                assert position_manager.rejection_reason == "insufficient_margin"
+                assert any("Insufficient margin" in msg for msg in caplog.messages), (
+                    "expected distinct insufficient-margin log message"
+                )
 
 
 @pytest.mark.asyncio
@@ -661,6 +671,7 @@ async def test_check_position_limits_small_positive_balance(
             with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
                 result = await position_manager.check_position_limits(sample_long_order)
                 assert result is True
+                assert position_manager.rejection_reason is None
 
 
 @pytest.mark.asyncio
@@ -677,6 +688,7 @@ async def test_check_position_limits_refresh_failure(
         with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
             result = await position_manager.check_position_limits(sample_long_order)
             assert result is False
+            assert position_manager.rejection_reason == "refresh_failure"
 
 
 @pytest.mark.asyncio

--- a/tests/test_position_manager_comprehensive.py
+++ b/tests/test_position_manager_comprehensive.py
@@ -587,6 +587,112 @@ async def test_calculate_portfolio_exposure(position_manager):
 
 
 # ============================================================================
+# Zero-Balance / Insufficient Margin Tests (#352)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_check_position_limits_zero_portfolio_value(
+    position_manager, sample_long_order
+):
+    """AC-1 (#352): zero portfolio value returns distinct insufficient-margin rejection"""
+    position_manager.total_portfolio_value = 0.0
+    position_manager.max_portfolio_exposure_pct = 0.5
+
+    with patch.object(
+        position_manager,
+        "_refresh_portfolio_value",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        with patch(
+            "shared.mysql_client.position_client.get_open_positions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
+                result = await position_manager.check_position_limits(sample_long_order)
+                assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_position_limits_negative_portfolio_value(
+    position_manager, sample_long_order
+):
+    """AC-1 (#352): negative portfolio value also returns insufficient-margin rejection"""
+    position_manager.total_portfolio_value = -500.0
+    position_manager.max_portfolio_exposure_pct = 0.5
+
+    with patch.object(
+        position_manager,
+        "_refresh_portfolio_value",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        with patch(
+            "shared.mysql_client.position_client.get_open_positions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
+                result = await position_manager.check_position_limits(sample_long_order)
+                assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_position_limits_small_positive_balance(
+    position_manager, sample_long_order
+):
+    """AC-3 (#352): small positive portfolio value allows trading within limits"""
+    position_manager.total_portfolio_value = 1.0
+    position_manager.max_portfolio_exposure_pct = 0.8
+
+    with patch.object(
+        position_manager,
+        "_refresh_portfolio_value",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        with patch(
+            "shared.mysql_client.position_client.get_open_positions",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
+                result = await position_manager.check_position_limits(sample_long_order)
+                assert result is True
+
+
+@pytest.mark.asyncio
+async def test_check_position_limits_refresh_failure(
+    position_manager, sample_long_order
+):
+    """AC-3 (#352): refresh failure is rejected without exposure-calculation side effects"""
+    with patch.object(
+        position_manager,
+        "_refresh_portfolio_value",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
+            result = await position_manager.check_position_limits(sample_long_order)
+            assert result is False
+
+
+@pytest.mark.asyncio
+async def test_calculate_portfolio_exposure_zero_value(position_manager):
+    """AC-2 (#352): _calculate_portfolio_exposure returns 1.0 for zero/negative capital"""
+    position_manager.total_portfolio_value = 0.0
+
+    exposure = position_manager._calculate_portfolio_exposure()
+    assert exposure == 1.0
+
+    position_manager.total_portfolio_value = -100.0
+    exposure = position_manager._calculate_portfolio_exposure()
+    assert exposure == 1.0
+
+
+# ============================================================================
 # Position Query Tests
 # ============================================================================
 

--- a/tradeengine/position_manager.py
+++ b/tradeengine/position_manager.py
@@ -64,6 +64,9 @@ class PositionManager:
         self.exchange = exchange
         self.portfolio_value_last_update: datetime | None = None
         self.portfolio_value_lock = asyncio.Lock()
+        self.rejection_reason: str | None = (
+            None  # Set by check_position_limits on rejection
+        )
 
     async def initialize(self) -> None:
         """Initialize position manager with Data Manager API for persistence and MongoDB for coordination"""
@@ -972,10 +975,12 @@ class PositionManager:
     async def check_position_limits(self, order: TradeOrder) -> bool:
         """Check if order meets position size limits with distributed state"""
         if not RISK_MANAGEMENT_ENABLED:
+            self.rejection_reason = None
             return True
 
         # Refresh portfolio value before checks (mandatory as per AC)
         if not await self._refresh_portfolio_value():
+            self.rejection_reason = "refresh_failure"
             logger.error(
                 f"⛔ RISK REJECTION: Failed to refresh portfolio value for {order.symbol} - aborting entry"
             )
@@ -984,6 +989,7 @@ class PositionManager:
         # AC-1 (#352): Explicit zero-capital guard — return a distinct reason before
         # _calculate_portfolio_exposure() hits the "safest for risk" 1.0 fallback.
         if self.total_portfolio_value <= 0:
+            self.rejection_reason = "insufficient_margin"
             logger.error(
                 f"⛔ RISK REJECTION: Insufficient margin — available capital is "
                 f"${self.total_portfolio_value:.2f} (total_portfolio_value <= 0). "
@@ -1010,6 +1016,7 @@ class PositionManager:
                     f"Position size would exceed limit: {order.symbol} {position_side} "
                     f"current={current_quantity}, new={new_quantity}, max={max_position_size}"
                 )
+                self.rejection_reason = "absolute_position_size"
                 return False
 
         # Check individual position size limit
@@ -1021,6 +1028,7 @@ class PositionManager:
                 f"Position size {order.position_size_pct} exceeds limit "
                 f"{self.max_position_size_pct}"
             )
+            self.rejection_reason = "position_size_pct"
             return False
 
         # Check portfolio exposure limit
@@ -1030,12 +1038,15 @@ class PositionManager:
                 f"Portfolio exposure {current_exposure:.2%} exceeds limit "
                 f"{self.max_portfolio_exposure_pct:.2%}"
             )
+            self.rejection_reason = "portfolio_exposure"
             return False
 
         # Check algo order limits (prevent -4045 error)
         if not await self.check_algo_order_limits(order):
+            self.rejection_reason = "algo_order_limits"
             return False
 
+        self.rejection_reason = None
         return True
 
     async def check_algo_order_limits(self, order: TradeOrder) -> bool:
@@ -1158,9 +1169,10 @@ class PositionManager:
         """Calculate current portfolio exposure
 
         Returns 1.0 (100%) when portfolio value is zero/negative as a safety
-        guard.  check_position_limits() now intercepts this case explicitly
-        via the zero-capital guard (AC-1 #352) so that callers get a
-        distinct "insufficient margin" rejection instead.
+        guard. The zero-capital guard in check_position_limits() (AC-1 #352)
+        intercepts this case first with a distinct ``insufficient_margin``
+        rejection reason; callers should inspect rejection_reason rather than
+        relying on this float value alone for diagnostics.
         """
         if self.total_portfolio_value <= 0:
             return 1.0

--- a/tradeengine/position_manager.py
+++ b/tradeengine/position_manager.py
@@ -974,10 +974,20 @@ class PositionManager:
         if not RISK_MANAGEMENT_ENABLED:
             return True
 
-        # NEW: Refresh portfolio value before checks (mandatory as per AC)
+        # Refresh portfolio value before checks (mandatory as per AC)
         if not await self._refresh_portfolio_value():
             logger.error(
                 f"⛔ RISK REJECTION: Failed to refresh portfolio value for {order.symbol} - aborting entry"
+            )
+            return False
+
+        # AC-1 (#352): Explicit zero-capital guard — return a distinct reason before
+        # _calculate_portfolio_exposure() hits the "safest for risk" 1.0 fallback.
+        if self.total_portfolio_value <= 0:
+            logger.error(
+                f"⛔ RISK REJECTION: Insufficient margin — available capital is "
+                f"${self.total_portfolio_value:.2f} (total_portfolio_value <= 0). "
+                f"Order {order.symbol} rejected; check exchange account funding."
             )
             return False
 
@@ -1145,11 +1155,15 @@ class PositionManager:
             logger.warning(f"Failed to refresh daily P&L from Data Manager: {e}")
 
     def _calculate_portfolio_exposure(self) -> float:
-        """Calculate current portfolio exposure"""
+        """Calculate current portfolio exposure
+
+        Returns 1.0 (100%) when portfolio value is zero/negative as a safety
+        guard.  check_position_limits() now intercepts this case explicitly
+        via the zero-capital guard (AC-1 #352) so that callers get a
+        distinct "insufficient margin" rejection instead.
+        """
         if self.total_portfolio_value <= 0:
-            return (
-                1.0  # Maximum exposure if no portfolio value (safest for risk checks)
-            )
+            return 1.0
 
         total_exposure = 0.0
 


### PR DESCRIPTION
## Summary
Fixes #352

When Binance futures `availableBalance` reaches **0**, `PositionManager.total_portfolio_value` becomes 0. `_calculate_portfolio_exposure()` then returns **1.0 (100% exposure)**, which surfaces as **"Position limits exceeded"** — obscuring the real cause (**no free margin**).

## Changes

1. **`position_manager.py` — `check_position_limits()`**: Added explicit zero-capital guard after portfolio value refresh. When `total_portfolio_value <= 0`, logs a distinct `"Insufficient margin — available capital is /bin/zsh.00"` rejection instead of falling through to the generic exposure check.

2. **`position_manager.py` — `_calculate_portfolio_exposure()`**: Updated docstring to clarify the 1.0 safety default behavior and its relationship to the new guard.

3. **Tests added** (5 new test functions):
   - Zero portfolio value → rejected with insufficient margin
   - Negative portfolio value → rejected with insufficient margin
   - Small positive balance (.00) → accepted when no positions open
   - Refresh failure → rejected early
   - `_calculate_portfolio_exposure()` returns 1.0 for zero/negative

## Acceptance Criteria Coverage

- ✅ **AC-1**: When `total_portfolio_value <= 0`, risk check now returns a distinct "insufficient margin" reason, not generic "position limits exceeded"
- ✅ **AC-2**: Exposure calculation still returns 1.0 for zero capital (documented as intentional safety guard for external callers)
- ✅ **AC-3**: Tests cover: zero balance, small positive balance, refresh failure
- ✅ **AC-4**: No regression — all 41 existing tests pass; zero-capital guard returns early before exposure math runs