### PR TITLE
[ENHANCEMENT] resolve-copilot-comments.py: also resolve outdated threads to fully clear required_conversation_resolution gate

### DIFF
--- a/scripts/resolve-copilot-comments.py
+++ b/scripts/resolve-copilot-comments.py
@@ -2,21 +2,28 @@
 """
 Resolves unresolved Copilot-started review threads on a GitHub PR.
 
-Queries review threads via GitHub GraphQL, posts an "Addressed in commit <sha>"
-reply on each unresolved Copilot thread, then calls resolveReviewThread to set
-isResolved=true — allowing the copilot-review gate to pass without human clicks.
+Queries review threads via GitHub GraphQL, resolves them so that GitHub's
+required_conversation_resolution branch protection gate is fully cleared.
 
-Only threads started by Copilot are resolved; human-started threads are skipped.
+By default, BOTH non-outdated and outdated Copilot-started threads are resolved.
+Outdated threads are resolved silently (no reply comment) to avoid noise on
+stale context. Non-outdated threads receive an "Addressed in commit <sha>" reply.
+Human-started threads are always skipped.
+
+Use --skip-outdated to preserve the legacy behavior (resolve only non-outdated
+Copilot threads, matching the copilot-review gate's own logic).
 
 Usage:
     python scripts/resolve-copilot-comments.py <PR_URL_or_number> \
-        [--repo OWNER/REPO] [--sha SHA] [--dry-run]
+        [--repo OWNER/REPO] [--sha SHA] [--dry-run] [--skip-outdated]
 
 Examples:
     python scripts/resolve-copilot-comments.py \
         https://github.com/PetroSa2/petrosa-tradeengine/pull/364
     python scripts/resolve-copilot-comments.py 364 \
         --repo PetroSa2/petrosa-tradeengine --dry-run
+    python scripts/resolve-copilot-comments.py 364 \
+        --repo PetroSa2/petrosa-tradeengine --skip-outdated
 """
 
 import argparse

--- a/scripts/resolve-copilot-comments.py
+++ b/scripts/resolve-copilot-comments.py
@@ -196,6 +196,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="List unresolved threads without resolving them",
     )
+    parser.add_argument(
+        "--skip-outdated",
+        action="store_true",
+        help="Skip outdated threads (preserves legacy behavior)",
+    )
     args = parser.parse_args(argv)
 
     owner, repo, pr_number = parse_pr_ref(args.pr, args.repo)
@@ -210,9 +215,9 @@ def main(argv: list[str] | None = None) -> int:
     copilot_unresolved = [
         t
         for t in threads
-        if not t["isOutdated"]
-        and not t["isResolved"]
+        if not t["isResolved"]
         and is_copilot_login(t["starterLogin"])
+        and (not args.skip_outdated or not t["isOutdated"])
     ]
 
     print(f"  Total threads: {len(threads)}")
@@ -232,11 +237,15 @@ def main(argv: list[str] | None = None) -> int:
     for i, t in enumerate(copilot_unresolved, 1):
         tid = t["id"]
         label = f"[{i}/{len(copilot_unresolved)}]"
-        comment_body = f"Addressed in commit {sha}."
-        print(f"  {label} Replying on thread {tid}...")
-        post_reply(tid, comment_body)
-        print(f"  {label} Resolving thread {tid}...")
-        ok = resolve_thread(tid)
+        if t["isOutdated"]:
+            print(f"  {label} Resolving outdated thread {tid} (no reply)...")
+            ok = resolve_thread(tid)
+        else:
+            comment_body = f"Addressed in commit {sha}."
+            print(f"  {label} Replying on thread {tid}...")
+            post_reply(tid, comment_body)
+            print(f"  {label} Resolving thread {tid}...")
+            ok = resolve_thread(tid)
         if ok:
             resolved_count += 1
             print("    ✓ Resolved")

--- a/tests/test_resolve_copilot_comments.py
+++ b/tests/test_resolve_copilot_comments.py
@@ -200,7 +200,6 @@ class TestMain:
     def test_nothing_to_resolve(self):
         threads = _build_threads(
             (True, False, "copilot"),
-            (False, True, "copilot"),
             (False, False, "alice"),
         )
         with (
@@ -209,6 +208,23 @@ class TestMain:
             patch.object(rcc, "resolve_thread") as mock_resolve,
         ):
             rc = rcc.main(["https://github.com/O/R/pull/1"])
+
+        assert rc == 0
+        mock_reply.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    def test_nothing_to_resolve_with_skip_outdated(self):
+        threads = _build_threads(
+            (True, False, "copilot"),
+            (False, True, "copilot"),
+            (False, False, "alice"),
+        )
+        with (
+            patch.object(rcc, "load_threads", return_value=("abc", threads)),
+            patch.object(rcc, "post_reply") as mock_reply,
+            patch.object(rcc, "resolve_thread") as mock_resolve,
+        ):
+            rc = rcc.main(["https://github.com/O/R/pull/1", "--skip-outdated"])
 
         assert rc == 0
         mock_reply.assert_not_called()
@@ -232,6 +248,59 @@ class TestMain:
         assert mock_resolve.call_count == 2
         mock_reply.assert_any_call("TID1", "Addressed in commit deadbeef.")
         mock_reply.assert_any_call("TID2", "Addressed in commit deadbeef.")
+
+    def test_resolves_outdated_threads_by_default(self):
+        threads = _build_threads(
+            (False, False, "copilot"),
+            (False, True, "copilot"),  # outdated — resolved by default
+            (False, True, "alice"),  # outdated human — skipped
+        )
+        with (
+            patch.object(rcc, "load_threads", return_value=("abcdef012345", threads)),
+            patch.object(rcc, "post_reply") as mock_reply,
+            patch.object(rcc, "resolve_thread", return_value=True) as mock_resolve,
+        ):
+            rc = rcc.main(["https://github.com/O/R/pull/1", "--sha", "deadbeef"])
+
+        assert rc == 0
+        # Non-outdated: reply + resolve; outdated: resolve only (no reply)
+        assert mock_reply.call_count == 1
+        assert mock_resolve.call_count == 2
+        mock_reply.assert_any_call("TID1", "Addressed in commit deadbeef.")
+
+    def test_skip_outdated_flag_preserves_legacy_behavior(self):
+        threads = _build_threads(
+            (False, False, "copilot"),
+            (False, True, "copilot"),  # outdated — skipped with --skip-outdated
+        )
+        with (
+            patch.object(rcc, "load_threads", return_value=("abc", threads)),
+            patch.object(rcc, "post_reply") as mock_reply,
+            patch.object(rcc, "resolve_thread", return_value=True) as mock_resolve,
+        ):
+            rc = rcc.main(
+                ["https://github.com/O/R/pull/1", "--sha", "dead", "--skip-outdated"]
+            )
+
+        assert rc == 0
+        assert mock_reply.call_count == 1
+        assert mock_resolve.call_count == 1
+        mock_reply.assert_any_call("TID1", "Addressed in commit dead.")
+
+    def test_outdated_threads_no_reply_comment(self):
+        threads = _build_threads(
+            (False, True, "copilot"),  # only outdated
+        )
+        with (
+            patch.object(rcc, "load_threads", return_value=("abc", threads)),
+            patch.object(rcc, "post_reply") as mock_reply,
+            patch.object(rcc, "resolve_thread", return_value=True) as mock_resolve,
+        ):
+            rc = rcc.main(["https://github.com/O/R/pull/1", "--sha", "dead"])
+
+        assert rc == 0
+        mock_reply.assert_not_called()
+        mock_resolve.assert_called_once_with("TID1")
 
     def test_uses_pr_head_sha_when_no_sha_flag(self):
         threads = _build_threads((False, False, "copilot"))


### PR DESCRIPTION
Implements #367

## Changes
- **Default behavior**: The script now resolves both non-outdated AND outdated Copilot-started review threads
- **Silent resolution**: Outdated threads are resolved without posting a reply comment (avoids noise on stale context)
- **`--skip-outdated` flag**: Restores the previous legacy behavior (resolve only non-outdated threads) when explicitly passed
- **Updated tests**: 4 new test cases covering the outdated-thread resolution path

## Root Cause
The `not t["isOutdated"]` filter in the script matched the `copilot-review` gate's own logic, but diverged from GitHub's `required_conversation_resolution` branch protection, which counts unresolved outdated threads as blockers.

## Verification
- All 25 tests pass (21 existing + 4 new)
- `make pipeline` passes (lint, format, typecheck, tests)