### PR TITLE
[BUG][P0] reconcile_from_exchange testnet fallback ignores CONDITIONAL order type, rebuilding 0 pairs

### DIFF
--- a/tests/test_oco_orders.py
+++ b/tests/test_oco_orders.py
@@ -1175,6 +1175,49 @@ async def test_reconcile_from_exchange_fallback_to_standard_orders(
     oco_manager.start_monitoring.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_reconcile_from_exchange_conditional_type_regression(
+    oco_manager, mock_exchange
+):
+    """Fallback to standard orders with type=CONDITIONAL correctly resolves via origType (P0 regression test for #370)."""
+    mock_exchange.get_open_algo_orders = AsyncMock(
+        side_effect=Exception("testnet no support")
+    )
+    mock_exchange.client.futures_get_open_orders = Mock(
+        return_value=[
+            {
+                "orderId": 8001,
+                "symbol": "ETHUSDT",
+                "positionSide": "LONG",
+                "type": "CONDITIONAL",
+                "origType": "STOP_MARKET",
+                "origQty": "0.100",
+                "time": 2000,
+            },
+            {
+                "orderId": 8002,
+                "symbol": "ETHUSDT",
+                "positionSide": "LONG",
+                "type": "CONDITIONAL",
+                "origType": "TAKE_PROFIT_MARKET",
+                "origQty": "0.100",
+                "time": 2001,
+            },
+        ]
+    )
+    oco_manager.start_monitoring = AsyncMock()
+
+    rebuilt = await oco_manager.reconcile_from_exchange()
+
+    assert rebuilt == 1
+    assert "ETHUSDT_LONG" in oco_manager.active_oco_pairs
+    pair = oco_manager.active_oco_pairs["ETHUSDT_LONG"][0]
+    assert pair["sl_order_id"] == "8001"
+    assert pair["tp_order_id"] == "8002"
+    assert pair["reconciled"] is True
+    oco_manager.start_monitoring.assert_called_once()
+
+
 # ============================================================================
 # Ghost-order cleanup Tests (AC3 — -2013 and null order_id handling)
 # ============================================================================

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -661,6 +661,8 @@ class OCOManager:
 
         for o in open_orders:
             order_type = o.get("type", o.get("orderType", ""))
+            if order_type == "CONDITIONAL":
+                order_type = o.get("origType", order_type)
             position_side = o.get("positionSide", "BOTH")
             symbol = o.get("symbol", "")
             key = f"{symbol}_{position_side}"


### PR DESCRIPTION
## Summary

Fixes #370 — `reconcile_from_exchange` testnet fallback silently drops CONDITIONAL orders.

## Root Cause

When `get_open_algo_orders()` fails (as it does on Binance Testnet), the code falls back to `futures_get_open_orders()`. On Testnet, conditional orders (SL/TP) returned by the standard endpoint have `type=CONDITIONAL` instead of `STOP_MARKET` or `TAKE_PROFIT_MARKET`, so they were silently dropped — rebuilding 0 pairs.

## Fix

Added a single check: when `order_type == "CONDITIONAL"`, resolve via `origType` which the Binance API includes in the standard endpoint response metadata. This correctly maps to `STOP_MARKET` / `TAKE_PROFIT_MARKET` for proper classification.

## Validation

- `make pipeline` passes: 1284 passed, 13 skipped
- Coverage: 77.45%
- Lint, type-check, security: all green

Closes #370