### PR TITLE
fix: #494 - rewrite OTEL service.version substring during gitops-update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,10 @@ jobs:
           # Also handle any lingering placeholders for backward compatibility
           find petrosa_k8s/k8s/tradeengine -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -i "s/VERSION_PLACEHOLDER/$VERSION/g"
 
+          # Update OTEL service.version substring inside OTEL_RESOURCE_ATTRIBUTES env values
+          # Bounded by [^,"[:space:]]+ so it stops at the next attribute, closing quote, or whitespace
+          find petrosa_k8s/k8s/tradeengine -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(service\.version=)[^,\"[:space:]]+|\1$VERSION|g"
+
           echo "Updated tradeengine image tag to $VERSION in petrosa_k8s/k8s/tradeengine/"
 
       - name: Commit and push to petrosa_k8s


### PR DESCRIPTION
## Summary

Adds one new sed line to the `gitops-update` step's `Update image tag in k8s manifests` step that rewrites the `service.version=` substring inside any `OTEL_RESOURCE_ATTRIBUTES` env value to the current `$VERSION`.

The character class `[^,"[:space:]]+` bounds the match against the three terminators present in current manifests:
- trailing `,` (multi-attribute lists, e.g. `data-extractor` which also has `deployment.environment=production`)
- `"` (quoted YAML scalars, e.g. `tradeengine`, `realtime-strategies`)
- whitespace (unquoted YAML scalars, e.g. `cio`, `socket-client`)

Existing `VERSION_PLACEHOLDER` sed is left in place — it's a one-shot and currently a no-op (no `VERSION_PLACEHOLDER` literals remain in `petrosa_k8s/k8s/`), but harmless if anyone re-seeds.

Implements [PetroSa2/petrosa_k8s#494](https://github.com/PetroSa2/petrosa_k8s/issues/494). Decision rationale + tradeengine-anomaly root cause analysis: [issue comment](https://github.com/PetroSa2/petrosa_k8s/issues/494#issuecomment-4470835628).

## Test plan

- [ ] CI Pipeline / Pipeline green
- [ ] On merge, the first deploy.yml run substitutes `service.version=` in `petrosa_k8s/k8s/<svc>/...yaml` to the freshly built `$VERSION`
- [ ] `kubectl get deployment <svc> -n petrosa-apps -o yaml | grep service.version` after the post-merge deploy matches the new image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
