### PR TITLE
fix: #354 - align audit logger /health contract with stub reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ A modular, event-driven trading execution system focused on crypto trading. Cons
 
 #### MongoDB (Audit Log)
 
+> **Status note (#354):** the in-process `audit_logger` (`shared/audit.py`) is
+> currently a **stdout stub** — it emits structured log lines via Python
+> `logging` and does not write to MongoDB. The schema below documents the
+> intended persistent backend. The `/health` endpoint reports the live audit
+> contract under `components.audit_logger` (`backend`, `mode`,
+> `is_persistent`). See [`docs/AUDIT_LOGGING.md`](docs/AUDIT_LOGGING.md) for
+> the full contract and migration notes.
+
 **Collection:** `trade_audit_log`
 
 **Document Structure:**

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -1,0 +1,83 @@
+# Audit Logging Contract
+
+This document describes the audit logging behavior of the Petrosa Trade Engine
+and the `/health` contract that operators can rely on.
+
+## Current state: stdout stub
+
+The in-process audit logger at `shared/audit.py` is a **stdout stub**. Audit
+events are emitted as structured log lines via Python's `logging` module. There
+is **no remote persistence layer wired up** through this code path.
+
+The previous implementation hardcoded `connected = False` while leaving the
+underlying log calls operational. Dispatcher call sites gated audit writes on
+`enabled and connected`, so every audit write silently no-op'd while `/health`
+suggested a transient connectivity problem. Issue #354 aligns the names and
+gates with reality.
+
+## Health contract
+
+`GET /health` returns an `audit_logger` component with the following shape:
+
+```json
+{
+  "status": "healthy",
+  "enabled": true,
+  "backend": "stdout",
+  "mode": "stub",
+  "is_persistent": false
+}
+```
+
+Field meanings:
+
+- `status` — `"healthy"` when the logger is enabled and able to emit;
+  `"disabled"` when `enabled` is False. Use this to decide whether the audit
+  pipeline is functioning, not as a proxy for persistence.
+- `enabled` — master switch. When False, every `log_*` call is a no-op and
+  nothing is emitted anywhere.
+- `backend` — destination identifier. Currently always `"stdout"`. A future
+  persistent backend will report e.g. `"mongodb"` or `"mysql"`.
+- `mode` — `"stub"` until a persistent backend is wired up. Switches to
+  `"persistent"` when audit records are durably stored.
+- `is_persistent` — boolean shorthand for "does this backend survive a pod
+  restart?". False for the stub.
+
+The legacy `connected` attribute is preserved on the `AuditLogger` instance for
+backwards compatibility with tests that patch it, but it is no longer consulted
+by any dispatcher or API gate. Treat it as deprecated; do not introduce new
+references.
+
+## Dispatcher behavior
+
+Every audit write in `tradeengine/dispatcher.py` is gated on
+`audit_logger.enabled` only. Disabling the logger (`enabled = False`) is the
+sole way to suppress audit writes — for example, integration tests patch this
+flag to silence audit noise.
+
+## Related modules — do not conflate
+
+A separate **MySQL-backed** `AuditLogger` lives in `shared/logger.py`. That
+class is unrelated to the in-process stub described here. It exists for
+NATS-driven persistent audit ingestion and has its own lifecycle. When wiring
+up a persistent backend for the in-process logger, decide explicitly whether to
+delegate to that module or introduce a new backend rather than collapsing the
+two.
+
+## Migrating to a persistent backend
+
+When persistence is wired up, the following changes are expected:
+
+1. `shared/audit.py` — set `backend` / `mode` / `is_persistent` class
+   attributes to reflect the real backend (e.g. `backend = "mongodb"`,
+   `mode = "persistent"`, `is_persistent = True`).
+2. `health()` — extend the payload with backend-specific connectivity info
+   (e.g. last-write timestamp, connection state). Operators reading
+   `is_persistent: true` then need a separate signal that the backend is
+   actually reachable; consider re-introducing a meaningful `connected`
+   field at that point.
+3. Dispatcher — gates remain `if audit_logger.enabled:`; the logger itself is
+   responsible for graceful degradation if the persistent backend is
+   unreachable.
+4. Tests — the `mock_audit_logger` fixtures only need to patch `enabled`;
+   keeping the legacy `connected` patch is harmless but no longer required.

--- a/shared/audit.py
+++ b/shared/audit.py
@@ -1,3 +1,29 @@
+"""Audit logging for trading operations.
+
+Current implementation is a stdout stub: structured log lines are emitted via
+Python's `logging` module. There is no remote persistence layer wired up here.
+
+The previous version of this module exposed `connected = False` while leaving
+the actual audit calls operational at the log level. Health probes reported
+`audit_logger.connected = false` and dispatcher call sites gated on
+`enabled and connected`, which silently no-op'd every audit write while
+operators saw what looked like a connectivity problem.
+
+The contract is now explicit:
+
+- `enabled` controls whether anything is emitted at all.
+- `backend` names where the records go (currently always ``"stdout"``).
+- `mode` reports ``"stub"`` until a persistent backend is wired up.
+- `is_persistent` is False until that happens.
+
+The ``connected`` attribute is preserved for backwards compatibility (some
+tests still patch it) but is no longer consulted by any gate. It mirrors
+``is_persistent`` so the value remains truthful.
+
+A separate MySQL audit logger lives in :mod:`shared.logger`; do not conflate
+the two.
+"""
+
 import logging
 from typing import Any
 
@@ -5,13 +31,29 @@ from shared.config import Settings
 
 
 class AuditLogger:
-    """Audit logging for trading operations with MongoDB integration"""
+    """Stdout audit logger stub for trading operations."""
+
+    backend = "stdout"
+    mode = "stub"
+    is_persistent = False
 
     def __init__(self) -> None:
         self.settings = Settings()
         self.enabled = True
-        self.connected = False
+        # Deprecated. Kept for backwards-compat with tests that patch it.
+        # Mirrors is_persistent (False for the stub backend).
+        self.connected = self.is_persistent
         self.logger = logging.getLogger(__name__)
+
+    def health(self) -> dict[str, Any]:
+        """Return audit logger health/contract for /health payloads."""
+        return {
+            "status": "healthy" if self.enabled else "disabled",
+            "enabled": self.enabled,
+            "backend": self.backend,
+            "mode": self.mode,
+            "is_persistent": self.is_persistent,
+        }
 
     def log_signal(self, signal_data: dict[str, Any]) -> None:
         """Log trading signal for audit purposes"""
@@ -19,7 +61,6 @@ class AuditLogger:
             return
 
         try:
-            # In a real implementation, this would write to MongoDB
             self.logger.info(f"Signal logged: {signal_data}")
         except Exception as e:
             self.logger.error(f"Failed to log signal: {e}")
@@ -30,7 +71,6 @@ class AuditLogger:
             return
 
         try:
-            # In a real implementation, this would write to MongoDB
             self.logger.info(f"Trade logged: {trade_data}")
         except Exception as e:
             self.logger.error(f"Failed to log trade: {e}")
@@ -81,7 +121,6 @@ class AuditLogger:
             return
 
         try:
-            # In a real implementation, this would write to MongoDB
             self.logger.info(f"Account logged: {account_data}")
         except Exception as e:
             self.logger.error(f"Failed to log account: {e}")
@@ -92,7 +131,6 @@ class AuditLogger:
             return
 
         try:
-            # In a real implementation, this would write to MongoDB
             self.logger.info(f"Risk logged: {risk_data}")
         except Exception as e:
             self.logger.error(f"Failed to log risk: {e}")
@@ -103,7 +141,6 @@ class AuditLogger:
             return
 
         try:
-            # In a real implementation, this would write to MongoDB
             self.logger.info(f"Performance logged: {performance_data}")
         except Exception as e:
             self.logger.error(f"Failed to log performance: {e}")

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -127,10 +127,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.info("✅ Configuration rate limiter initialized")
 
         # Initialize audit logger
-        if audit_logger.enabled and audit_logger.connected:
-            logger.info("Audit logging enabled and connected")
-        elif audit_logger.enabled:
-            logger.warning("Audit logging enabled but not connected")
+        if audit_logger.enabled:
+            logger.info(
+                "Audit logging enabled (backend=%s, mode=%s)",
+                audit_logger.backend,
+                audit_logger.mode,
+            )
         else:
             logger.info("Audit logging disabled")
 
@@ -370,10 +372,7 @@ async def health_check() -> HealthResponse:
             "dispatcher": await dispatcher.health_check(),
             "binance_exchange": await binance_exchange.health_check(),
             "simulator_exchange": await simulator_exchange.health_check(),
-            "audit_logger": {
-                "enabled": audit_logger.enabled,
-                "connected": audit_logger.connected,
-            },
+            "audit_logger": audit_logger.health(),
             "mongodb_config": {
                 "status": "healthy",
                 "configured": True,

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -1459,7 +1459,7 @@ class Dispatcher:
         """Process a trading signal with distributed state management"""
         try:
             # Log signal
-            if audit_logger.enabled and audit_logger.connected:
+            if audit_logger.enabled:
                 audit_logger.log_signal(signal.model_dump())
 
             # Add signal to aggregator
@@ -1494,7 +1494,7 @@ class Dispatcher:
                 }
 
             # Log result
-            if audit_logger.enabled and audit_logger.connected:
+            if audit_logger.enabled:
                 audit_logger.log_signal(
                     {
                         "signal": signal.model_dump(),
@@ -1508,7 +1508,7 @@ class Dispatcher:
 
         except Exception as e:
             self.logger.error(f"Signal processing error: {e}")
-            if audit_logger.enabled and audit_logger.connected:
+            if audit_logger.enabled:
                 audit_logger.log_error(
                     {
                         "error": str(e),
@@ -2141,7 +2141,7 @@ class Dispatcher:
                                 )
 
                                 # Log critical event to audit trail
-                                if audit_logger.enabled and audit_logger.connected:
+                                if audit_logger.enabled:
                                     audit_logger.log_trade(
                                         {
                                             "event": "atomic_rollback",
@@ -2396,7 +2396,7 @@ class Dispatcher:
                 )
 
                 # Log order
-                if audit_logger.enabled and audit_logger.connected:
+                if audit_logger.enabled:
                     audit_logger.log_order(order.model_dump())
 
                 # Execute order on Binance exchange
@@ -2443,7 +2443,7 @@ class Dispatcher:
                         await self.order_manager.track_order(order, result)
 
                 # Log result
-                if audit_logger.enabled and audit_logger.connected:
+                if audit_logger.enabled:
                     audit_logger.log_order(
                         {
                             "order": order.model_dump(),
@@ -2516,7 +2516,7 @@ class Dispatcher:
                     f"❌ ORDER EXECUTION FAILED: {order.order_id} | Error: {e}",
                     exc_info=True,
                 )
-                if audit_logger.enabled and audit_logger.connected:
+                if audit_logger.enabled:
                     audit_logger.log_error(
                         {
                             "error": str(e),


### PR DESCRIPTION
## Summary
Closes #354.

- The in-process `audit_logger` in `shared/audit.py` hardcoded `connected = False`. Every log call still wrote to stdout, but dispatcher and API gates (`enabled and connected`) silently no-op'd — while `/health` reported `audit_logger.connected = false`, implying a transient connectivity problem.
- This PR aligns the names + gates with reality (stdout stub) per Acceptance Criterion 1 (option B: align contract).
- A separate persistent backend (`shared/logger.AuditLogger`, MySQL) is deliberately not touched here.

## Changes
- **shared/audit.py** — introduce `backend` / `mode` / `is_persistent` contract; add `health()` helper; keep `connected` as a deprecated alias so the two existing test fixtures still work.
- **tradeengine/api.py** — `/health` payload now uses `audit_logger.health()` (returns `status`, `enabled`, `backend`, `mode`, `is_persistent`). Startup log reports `backend` / `mode`.
- **tradeengine/dispatcher.py** — all seven `audit_logger.enabled and audit_logger.connected` gates collapse to `audit_logger.enabled` so audit writes actually fire.
- **README.md** — adds a status note to the MongoDB Audit Log section pointing at the stub reality.
- **docs/AUDIT_LOGGING.md** — new contract doc + migration notes for a future persistent backend.

## Acceptance criteria
- [x] AC1 — Align `/health` and naming so operators are not misled (chose alignment over wiring a real backend per scope discussion).
- [x] AC2 — Document intended audit behavior (`docs/AUDIT_LOGGING.md` + README note).
- [x] AC3 — Dispatcher behavior consistent with health contract (gates collapsed; audit writes are no longer silent no-ops).

## Test plan
- [x] `ruff check` clean across repo
- [x] `mypy` clean on edited files
- [x] Targeted pytest sweep: `tests/test_api.py`, `tests/test_dispatcher*.py`, `tests/test_order_manager*.py`, `tests/test_span_attributes.py`, `tests/test_readiness.py` — 140 passed / 2 skipped
- [x] Integration: `tests/integration/test_duplicate_signals.py`, `test_risk_limits.py` (which patch `audit_logger.connected`) — 11 passed
- [ ] Verify `/health` response shape in a deployed environment matches new contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)