### PR TITLE
fix: #372 - add Take-Profit fallback mirroring SL fallback (-2021 retry)

### DIFF
--- a/tests/test_stop_loss_take_profit.py
+++ b/tests/test_stop_loss_take_profit.py
@@ -891,3 +891,257 @@ async def test_sl_floor_overrides_absolute_stop_loss_too_close(dispatcher_with_m
         f"Absolute SL too close to entry should be floored. "
         f"Expected {expected_sl}, got {actual_sl}"
     )
+
+
+# ============================================================================
+# Take-Profit Fallback Tests (per #372)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_place_take_profit_with_fallback_succeeds_first_try(
+    dispatcher_with_mocks, sample_filled_order
+):
+    """First-attempt success path: -2021 never seen, original TP placed."""
+    dispatcher, mock_exchange = dispatcher_with_mocks
+    mock_exchange.execute.return_value = {
+        "status": "NEW",
+        "order_id": "tp-ok",
+    }
+
+    from contracts.order import OrderStatus
+
+    tp_order = TradeOrder(
+        order_id="tp-test",
+        symbol=sample_filled_order.symbol,
+        side="sell",
+        type="take_profit",
+        amount=sample_filled_order.amount,
+        take_profit=sample_filled_order.take_profit,
+        target_price=None,
+        position_id=sample_filled_order.position_id,
+        position_side=sample_filled_order.position_side,
+        exchange="binance",
+        stop_loss=None,
+        conditional_price=None,
+        conditional_direction=None,
+        conditional_timeout=None,
+        iceberg_quantity=None,
+        client_order_id=None,
+        filled_amount=0.0,
+        average_price=None,
+        simulate=False,
+        time_in_force="GTC",
+        position_size_pct=None,
+        status=OrderStatus.PENDING,
+    )
+
+    result = await dispatcher._place_take_profit_with_fallback(
+        tp_order, sample_filled_order
+    )
+
+    assert result["status"] == "NEW"
+    assert result["take_profit_price"] == sample_filled_order.take_profit
+    assert mock_exchange.execute.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_place_take_profit_with_fallback_long_adjusts_down_on_2021(
+    dispatcher_with_mocks, sample_filled_order
+):
+    """LONG TP that would immediately trigger: fallback moves TP DOWN 1%, then succeeds."""
+    dispatcher, mock_exchange = dispatcher_with_mocks
+    mock_exchange.execute.side_effect = [
+        {"status": "error", "error": "APIError -2021 Order would immediately trigger"},
+        {"status": "NEW", "order_id": "tp-fallback-1"},
+    ]
+
+    original_tp = float(sample_filled_order.take_profit)
+    from contracts.order import OrderStatus
+
+    tp_order = TradeOrder(
+        order_id="tp-test",
+        symbol=sample_filled_order.symbol,
+        side="sell",
+        type="take_profit",
+        amount=sample_filled_order.amount,
+        take_profit=original_tp,
+        target_price=None,
+        position_id=sample_filled_order.position_id,
+        position_side="LONG",
+        exchange="binance",
+        stop_loss=None,
+        conditional_price=None,
+        conditional_direction=None,
+        conditional_timeout=None,
+        iceberg_quantity=None,
+        client_order_id=None,
+        filled_amount=0.0,
+        average_price=None,
+        simulate=False,
+        time_in_force="GTC",
+        position_size_pct=None,
+        status=OrderStatus.PENDING,
+    )
+
+    result = await dispatcher._place_take_profit_with_fallback(
+        tp_order,
+        sample_filled_order,  # sample_filled_order.side == "buy" -> LONG entry
+    )
+
+    assert result["status"] == "NEW"
+    assert result["take_profit_price"] == pytest.approx(original_tp * 0.99)
+    assert mock_exchange.execute.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_place_take_profit_with_fallback_short_adjusts_up_on_2021(
+    dispatcher_with_mocks,
+):
+    """SHORT TP that would immediately trigger: fallback moves TP UP 1%, then succeeds."""
+    dispatcher, mock_exchange = dispatcher_with_mocks
+
+    short_order = TradeOrder(
+        position_id="short-pos",
+        symbol="BTCUSDT",
+        side="sell",
+        type="market",
+        amount=0.002,
+        target_price=50000.0,
+        position_side="SHORT",
+        exchange="binance",
+        take_profit=48000.0,
+    )
+
+    mock_exchange.execute.side_effect = [
+        {"status": "error", "error": "code: -2021 immediately trigger"},
+        {"status": "NEW", "order_id": "tp-fallback-2"},
+    ]
+
+    from contracts.order import OrderStatus
+
+    tp_order = TradeOrder(
+        order_id="tp-test",
+        symbol="BTCUSDT",
+        side="buy",
+        type="take_profit",
+        amount=0.002,
+        take_profit=48000.0,
+        target_price=None,
+        position_id="short-pos",
+        position_side="SHORT",
+        exchange="binance",
+        stop_loss=None,
+        conditional_price=None,
+        conditional_direction=None,
+        conditional_timeout=None,
+        iceberg_quantity=None,
+        client_order_id=None,
+        filled_amount=0.0,
+        average_price=None,
+        simulate=False,
+        time_in_force="GTC",
+        position_size_pct=None,
+        status=OrderStatus.PENDING,
+    )
+
+    result = await dispatcher._place_take_profit_with_fallback(tp_order, short_order)
+
+    assert result["status"] == "NEW"
+    assert result["take_profit_price"] == pytest.approx(48000.0 * 1.01)
+    assert mock_exchange.execute.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_place_take_profit_with_fallback_caps_at_two_adjustments(
+    dispatcher_with_mocks, sample_filled_order
+):
+    """AC: cap at 2 adjustments — third attempt does not happen even if 2nd also fails."""
+    dispatcher, mock_exchange = dispatcher_with_mocks
+    mock_exchange.execute.side_effect = [
+        {"status": "error", "error": "-2021"},
+        {"status": "error", "error": "-2021"},
+        {"status": "error", "error": "-2021"},
+    ]
+
+    from contracts.order import OrderStatus
+
+    tp_order = TradeOrder(
+        order_id="tp-test",
+        symbol=sample_filled_order.symbol,
+        side="sell",
+        type="take_profit",
+        amount=sample_filled_order.amount,
+        take_profit=sample_filled_order.take_profit,
+        target_price=None,
+        position_id=sample_filled_order.position_id,
+        position_side="LONG",
+        exchange="binance",
+        stop_loss=None,
+        conditional_price=None,
+        conditional_direction=None,
+        conditional_timeout=None,
+        iceberg_quantity=None,
+        client_order_id=None,
+        filled_amount=0.0,
+        average_price=None,
+        simulate=False,
+        time_in_force="GTC",
+        position_size_pct=None,
+        status=OrderStatus.PENDING,
+    )
+
+    result = await dispatcher._place_take_profit_with_fallback(
+        tp_order, sample_filled_order
+    )
+
+    assert result["status"] == "error"
+    # 1 original + 2 adjustment attempts = 3 total; never 4.
+    assert mock_exchange.execute.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_place_take_profit_with_fallback_non_2021_error_short_circuits(
+    dispatcher_with_mocks, sample_filled_order
+):
+    """Non -2021 errors return immediately without attempting price adjustment."""
+    dispatcher, mock_exchange = dispatcher_with_mocks
+    mock_exchange.execute.return_value = {
+        "status": "error",
+        "error": "APIError -2010 Account has insufficient balance",
+    }
+
+    from contracts.order import OrderStatus
+
+    tp_order = TradeOrder(
+        order_id="tp-test",
+        symbol=sample_filled_order.symbol,
+        side="sell",
+        type="take_profit",
+        amount=sample_filled_order.amount,
+        take_profit=sample_filled_order.take_profit,
+        target_price=None,
+        position_id=sample_filled_order.position_id,
+        position_side="LONG",
+        exchange="binance",
+        stop_loss=None,
+        conditional_price=None,
+        conditional_direction=None,
+        conditional_timeout=None,
+        iceberg_quantity=None,
+        client_order_id=None,
+        filled_amount=0.0,
+        average_price=None,
+        simulate=False,
+        time_in_force="GTC",
+        position_size_pct=None,
+        status=OrderStatus.PENDING,
+    )
+
+    result = await dispatcher._place_take_profit_with_fallback(
+        tp_order, sample_filled_order
+    )
+
+    assert result["status"] == "error"
+    # Original attempt only; no fallback because the error is not -2021.
+    assert mock_exchange.execute.call_count == 1

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -3229,9 +3229,14 @@ class Dispatcher:
                 f"{take_profit_order.amount} @ {adjusted_take_profit}"
             )
 
-            # Execute take profit order
+            # Execute take profit order — with -2021 fallback strategy per #372.
+            # Symmetric to _place_stop_loss_with_fallback: if the market has
+            # already crossed the original TP, retry with the TP moved 1% then
+            # 2% closer to entry before giving up.
             if self.exchange:
-                tp_result = await self.exchange.execute(take_profit_order)
+                tp_result = await self._place_take_profit_with_fallback(
+                    take_profit_order, order
+                )
             else:
                 tp_result = {"status": "error", "error": "No exchange configured"}
 
@@ -3243,10 +3248,14 @@ class Dispatcher:
                 "pending",
                 "NEW",
             ]:
+                # If the fallback adjusted the TP, surface the resolved price
+                # so the log line matches the real on-exchange order rather
+                # than the original (potentially stale) value.
+                resolved_tp = tp_result.get("take_profit_price", order.take_profit)
                 self.logger.info(
                     f"✅ TAKE PROFIT PLACED: {order.symbol} | "
                     f"Order ID: {tp_result.get('order_id', 'N/A')} | "
-                    f"Take Profit Price: {order.take_profit} | "
+                    f"Take Profit Price: {resolved_tp} | "
                     f"Status: {tp_result.get('status')}"
                 )
 
@@ -3569,6 +3578,145 @@ class Dispatcher:
 
         except Exception as e:
             self.logger.error(f"❌ Exception in SL fallback logic: {e}", exc_info=True)
+            return {"status": "error", "error": str(e)}
+
+    async def _place_take_profit_with_fallback(
+        self, take_profit_order: TradeOrder, original_order: TradeOrder
+    ) -> dict[str, Any]:
+        """
+        Place take profit order with fallback strategies for API errors (per #372).
+
+        Mirrors the SL fallback pattern. Fallback strategy for APIError -2021
+        (Order would immediately trigger), which happens when fast market moves
+        have already crossed the planned TP before placement:
+
+        1. Try the original TP price.
+        2. If -2021, adjust TP 1% CLOSER to entry (LONG: lower TP; SHORT: higher TP).
+        3. If still -2021, adjust TP 2% closer to entry.
+        4. Cap at 2 adjustments — if all fail, return the last result so the caller
+           can decide whether to leave the position without a TP.
+
+        Args:
+            take_profit_order: The take profit order to place.
+            original_order: The original position entry order (provides side + entry
+                target_price for context).
+
+        Returns:
+            Result dictionary with status and order details. On successful adjusted
+            placement, the dict is annotated with `take_profit_price`.
+        """
+        try:
+            from typing import cast
+
+            self.logger.info(
+                f"🔄 Attempt 1: Placing TP at original price {take_profit_order.take_profit}"
+            )
+            tp_result = cast(
+                dict[str, Any], await self.exchange.execute(take_profit_order)
+            )
+
+            if tp_result.get("status") in [
+                "filled",
+                "partially_filled",
+                "pending",
+                "NEW",
+            ]:
+                tp_result["take_profit_price"] = take_profit_order.take_profit
+                return tp_result
+
+            error_msg = str(tp_result.get("error", ""))
+            if "-2021" in error_msg or "immediately trigger" in error_msg.lower():
+                self.logger.warning(
+                    f"⚠️  TP order would immediately trigger at "
+                    f"{take_profit_order.take_profit}. Attempting fallback strategies..."
+                )
+
+                original_tp = take_profit_order.take_profit
+                if original_tp is None or float(original_tp) <= 0:
+                    self.logger.error(
+                        "Cannot calculate adjusted TP: invalid original TP price"
+                    )
+                    return tp_result
+
+                # is_long indicates the ENTRY side. TP for a LONG entry is ABOVE
+                # entry; if the market has rallied past it (would immediately
+                # trigger as filled), we adjust TP DOWN (closer to entry).
+                # Symmetrically: TP for a SHORT entry is BELOW entry; if the
+                # market has fallen past it, we adjust TP UP (closer to entry).
+                is_long = original_order.side == "buy"
+
+                # Attempt 2: 1% adjustment toward entry.
+                if is_long:
+                    adjusted_tp = float(original_tp) * 0.99
+                else:
+                    adjusted_tp = float(original_tp) * 1.01
+
+                self.logger.info(
+                    f"🔄 Attempt 2: Placing TP at adjusted price {adjusted_tp} "
+                    f"(original: {original_tp})"
+                )
+
+                take_profit_order.take_profit = adjusted_tp
+                tp_result = cast(
+                    dict[str, Any], await self.exchange.execute(take_profit_order)
+                )
+
+                if tp_result.get("status") in [
+                    "filled",
+                    "partially_filled",
+                    "pending",
+                    "NEW",
+                ]:
+                    self.logger.warning(
+                        f"✅ TP placed at adjusted price {adjusted_tp} "
+                        f"(moved from {original_tp})"
+                    )
+                    tp_result["take_profit_price"] = adjusted_tp
+                    return tp_result
+
+                # Attempt 3: 2% adjustment toward entry (cap per #372 AC).
+                if is_long:
+                    adjusted_tp = float(original_tp) * 0.98
+                else:
+                    adjusted_tp = float(original_tp) * 1.02
+
+                self.logger.info(
+                    f"🔄 Attempt 3: Placing TP at wider adjusted price {adjusted_tp}"
+                )
+
+                take_profit_order.take_profit = adjusted_tp
+                tp_result = cast(
+                    dict[str, Any], await self.exchange.execute(take_profit_order)
+                )
+
+                if tp_result.get("status") in [
+                    "filled",
+                    "partially_filled",
+                    "pending",
+                    "NEW",
+                ]:
+                    self.logger.warning(
+                        f"✅ TP placed at wider adjusted price {adjusted_tp} "
+                        f"(moved from {original_tp})"
+                    )
+                    tp_result["take_profit_price"] = adjusted_tp
+                    return tp_result
+
+                # All attempts failed — position will be SL-protected but
+                # un-take-profited until a downstream re-attempt fires.
+                self.logger.error(
+                    f"❌ All TP placement attempts failed for {original_order.symbol}. "
+                    f"Position is left without a take-profit order; SL still active."
+                )
+                return tp_result
+
+            # For non -2021 errors, surface the original result unchanged so the
+            # caller can distinguish "TP didn't fit the market" from "TP failed
+            # for another reason" (e.g., margin, lot-size, account state).
+            return tp_result
+
+        except Exception as e:
+            self.logger.error(f"❌ Exception in TP fallback logic: {e}", exc_info=True)
             return {"status": "error", "error": str(e)}
 
     async def shutdown(self) -> None:


### PR DESCRIPTION
## Summary

Closes #372.

Fixes the asymmetry where `_place_stop_loss_with_fallback` retries on Binance's `-2021 (Order would immediately trigger)` error but TP placement gave up immediately, leaving positions un-take-profited.

## What changed

- **NEW** `_place_take_profit_with_fallback` in `tradeengine/dispatcher.py` — mirrors the SL fallback exactly:
  - Attempt 1: original TP price.
  - Attempt 2 on `-2021`: adjust TP 1% **closer to entry** (LONG TP moves DOWN; SHORT TP moves UP — opposite direction from SL).
  - Attempt 3 on `-2021`: 2% adjustment.
  - Cap at 2 adjustments per AC.
  - Non-`-2021` errors short-circuit without retrying.
  - Returns the result with a `take_profit_price` annotation when an adjusted attempt succeeds.
- `_place_take_profit_order` now calls the fallback. The success log line uses the resolved TP price so the message matches the on-exchange order rather than the (potentially stale) original.

## Tests

5 new tests in `tests/test_stop_loss_take_profit.py` (all PASS locally):

- `test_place_take_profit_with_fallback_succeeds_first_try`
- `test_place_take_profit_with_fallback_long_adjusts_down_on_2021`
- `test_place_take_profit_with_fallback_short_adjusts_up_on_2021`
- `test_place_take_profit_with_fallback_caps_at_two_adjustments`
- `test_place_take_profit_with_fallback_non_2021_error_short_circuits`

## Rework signal (per PetroSa2/petrosa_k8s#522)

Commit trailer included: `rework: true` + `feature_type: backend` + `author_type: ai`. The #352 risk-management work originally shipped TP placement without fallback parity — this PR repairs that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)