### PR TITLE
test: #559 verification — Copilot dynamic reviewer disabled?

### DIFF
--- a/docs/runbooks/algo-order-accumulation.md
+++ b/docs/runbooks/algo-order-accumulation.md
@@ -64,3 +64,5 @@ Any count above 2 per active position is anomalous. Above 4 means orphans have s
 - Related: #372 (TradeEngine TP fallback) — overlapping order-management surface.
 
 _Last verified clean: 2026-05-18T00:12Z (#559 verification run)._
+
+<!-- #559 verification re-trigger 1779063822 -->

--- a/docs/runbooks/algo-order-accumulation.md
+++ b/docs/runbooks/algo-order-accumulation.md
@@ -62,3 +62,5 @@ Any count above 2 per active position is anomalous. Above 4 means orphans have s
 
 - Originally tracked by #352 AC-7 in `petrosa_k8s`. The PrometheusRule manifests were removed in #536 (never fired anyway — local minimal-prometheus had zero AlertManagers). #539 re-instates them as Grafana Cloud Alerts. This runbook is the AC4 link.
 - Related: #372 (TradeEngine TP fallback) — overlapping order-management surface.
+
+_Last verified clean: 2026-05-18T00:12Z (#559 verification run)._


### PR DESCRIPTION
Throwaway PR to verify that deleting the 'Copilot review for default branch' ruleset across all 8 Petrosa repos kills the `dynamic/copilot-pull-request-reviewer` workflow trigger.

Will be closed without merging as soon as the verification is recorded on #559.