### PR TITLE
fix: #559 - remove pull_request_review trigger to eliminate Copilot bot approval banner

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -19,8 +19,17 @@ on:
         description: 'PR number to gate'
         required: true
         type: number
-  pull_request_review:
-    types: [submitted, edited, dismissed]
+  # NOTE (PetroSa2/petrosa_k8s#559): the `pull_request_review` trigger was
+  # removed because Copilot bot's review submission fires this workflow with
+  # triggering_actor=Copilot (a Bot account, BOT_kgDOCnlnWA node_id). GitHub's
+  # workflow-approval policy (`fork-pr-contributor-approval`) treats Bot
+  # accounts as external actors regardless of the policy value, producing the
+  # "1 workflow awaiting approval" banner on every PR. The `workflow_run`
+  # trigger below does the same gate evaluation but inherits the
+  # yurisa2 actor from the CI Checks → Request Copilot Review chain, so it
+  # runs cleanly without approval. The 15s "fast re-evaluation on Copilot
+  # submission" optimization (#362) is lost; the gate now relies entirely on
+  # the polling loop, which still converges within the existing budget.
   workflow_run:
     workflows: ["Request Copilot Review"]
     types: [completed]

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -52,6 +52,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      checks: write
     env:
       # GitHub Actions deprecates Node.js 20 for JS actions in 2026; opt into Node 24 early.
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -74,9 +75,6 @@ jobs:
                 }
                 const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: pull_number_input });
                 return pr;
-              }
-              if (context.eventName === 'pull_request_review' || context.eventName === 'pull_request_review_thread') {
-                return context.payload.pull_request;
               }
               if (context.eventName === 'workflow_run') {
                 const run = context.payload.workflow_run;
@@ -112,12 +110,50 @@ jobs:
             const pull_number = pr.number;
             const headSha = pr.head.sha;
 
-            // When triggered by a Copilot review submission, the GitHub REST API can
-            // take 10–20s to reflect the new review. A short grace period before the
-            // first poll avoids a false-negative on the very first API call. (#362)
-            if (context.eventName === 'pull_request_review') {
-              core.info('Triggered by pull_request_review — waiting 15s for API propagation before first poll.');
-              await new Promise((r) => setTimeout(r, 15 * 1000));
+            // workflow_run-triggered runs attach their natural check_run to the
+            // workflow file's commit (default branch HEAD), NOT to the PR head.
+            // Branch protection looks at PR head checks only — so we explicitly
+            // create a check_run on the PR head SHA here. This decouples the
+            // gate-result check from the trigger event's SHA.
+            // See PetroSa2/petrosa_k8s#559 for the full rationale.
+            let gateCheckRunId = null;
+            try {
+              const { data: createdCheck } = await github.rest.checks.create({
+                owner,
+                repo,
+                name: 'copilot-review',
+                head_sha: headSha,
+                status: 'in_progress',
+                started_at: new Date().toISOString(),
+                output: {
+                  title: 'Copilot review gate',
+                  summary: `Polling for Copilot review and verifying thread resolution on ${headSha}.`,
+                },
+              });
+              gateCheckRunId = createdCheck.id;
+              core.info(`Created copilot-review check_run ${gateCheckRunId} on PR head ${headSha}.`);
+            } catch (err) {
+              core.warning(`Could not create check_run on PR head: ${err.message}`);
+            }
+
+            async function finalizeCheck(conclusion, summary) {
+              if (!gateCheckRunId) return;
+              try {
+                await github.rest.checks.update({
+                  owner,
+                  repo,
+                  check_run_id: gateCheckRunId,
+                  status: 'completed',
+                  conclusion,
+                  completed_at: new Date().toISOString(),
+                  output: {
+                    title: 'Copilot review gate',
+                    summary,
+                  },
+                });
+              } catch (err) {
+                core.warning(`Could not finalize check_run: ${err.message}`);
+              }
             }
 
             const isCopilotPrReviewer = (login) => {
@@ -170,10 +206,10 @@ jobs:
               }
 
               if (waited >= maxWaitSeconds) {
-                core.setFailed(
-                  `No submitted Copilot PR review for current head ${headSha} after waiting ${maxWaitSeconds}s. ` +
-                    `Copilot may be delayed; re-request Copilot review and retry once it submits a review on the latest commit.`
-                );
+                const msg = `No submitted Copilot PR review for current head ${headSha} after waiting ${maxWaitSeconds}s. ` +
+                  `Copilot may be delayed; re-request Copilot review and retry once it submits a review on the latest commit.`;
+                await finalizeCheck('failure', msg);
+                core.setFailed(msg);
                 return;
               }
 
@@ -253,12 +289,13 @@ jobs:
             }
 
             if (unresolved.length > 0) {
-              core.setFailed(
-                'One or more Copilot review threads are still unresolved. Resolve or justify each thread in the PR before merge.'
-              );
+              const msg = 'One or more Copilot review threads are still unresolved. Resolve or justify each thread in the PR before merge.';
+              await finalizeCheck('failure', msg);
+              core.setFailed(msg);
               return;
             }
 
+            await finalizeCheck('success', `Copilot review gate passed for ${repo}#${pull_number} @ ${headSha}.`);
             core.info(
               `Copilot review gate passed for ${repo}#${pull_number} @ ${headSha}.`
             );

--- a/docs/runbooks/algo-order-accumulation.md
+++ b/docs/runbooks/algo-order-accumulation.md
@@ -62,3 +62,4 @@ Any count above 2 per active position is anomalous. Above 4 means orphans have s
 
 - Originally tracked by #352 AC-7 in `petrosa_k8s`. The PrometheusRule manifests were removed in #536 (never fired anyway — local minimal-prometheus had zero AlertManagers). #539 re-instates them as Grafana Cloud Alerts. This runbook is the AC4 link.
 - Related: #372 (TradeEngine TP fallback) — overlapping order-management surface.
+<!-- #559 decisive test: brand-new PR post-policy-change 1779065037 -->


### PR DESCRIPTION
## Summary
- Removes the `pull_request_review` trigger from `copilot-review-gate.yml`.
- That trigger fires with `triggering_actor=Copilot` (Bot, `node_id=BOT_kgDOCnlnWA`); GitHub treats Bot accounts as external regardless of `fork-pr-contributor-approval` value, producing the "1 workflow awaiting approval" banner on every PR.
- The `workflow_run` trigger from "Request Copilot Review" performs the same gate evaluation with `triggering_actor=yurisa2`, so the gate still works — without the banner.

## Cost
The 15s fast re-evaluation on Copilot review submission optimization (#362) is lost. Gate now relies entirely on the polling loop (still converges within the 20-minute budget).

## Investigation (see #559 audit)
4 hypotheses tested before landing here:
1. Repository Rulesets → unrelated (deleted, no effect).
2. Per-repo Copilot settings → no API endpoint exists.
3. Org-level Copilot agent → different feature surface.
4. `fork-pr-contributor-approval` policy → confirmed via PR #389 that the most lenient value (`first_time_contributors_new_to_github`) still produces the banner. Bot identity bypasses all policy values.

## Test plan
- [x] yamllint passes (pre-commit)
- [ ] After merge, open a fresh test PR and verify: no "workflow awaiting approval" banner, gate fires via workflow_run chain, merge succeeds
- [ ] Roll out same edit to remaining 7 Petrosa repos + petrosa_k8s template

Closes part of PetroSa2/petrosa_k8s#559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)