### PR TITLE
fix: #559 - gate chain-depth bug, trigger from CI Checks instead of Request Copilot Review

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -24,14 +24,20 @@ on:
   # triggering_actor=Copilot (a Bot account, BOT_kgDOCnlnWA node_id). GitHub's
   # workflow-approval policy (`fork-pr-contributor-approval`) treats Bot
   # accounts as external actors regardless of the policy value, producing the
-  # "1 workflow awaiting approval" banner on every PR. The `workflow_run`
-  # trigger below does the same gate evaluation but inherits the
-  # yurisa2 actor from the CI Checks → Request Copilot Review chain, so it
-  # runs cleanly without approval. The 15s "fast re-evaluation on Copilot
-  # submission" optimization (#362) is lost; the gate now relies entirely on
-  # the polling loop, which still converges within the existing budget.
+  # "1 workflow awaiting approval" banner on every PR.
+  #
+  # We trigger from "CI Checks" (one workflow_run hop) instead of
+  # "Request Copilot Review" (two workflow_run hops). At two hops,
+  # `payload.workflow_run.head_branch/head_sha` collapses to the
+  # default branch's HEAD, so PR resolution fails ("No open same-repo PR
+  # for main@..."). With CI Checks as the upstream, payload reports the
+  # actual PR branch + PR head SHA, and the gate can find the PR.
+  #
+  # The Request Copilot Review workflow still triggers from CI Checks in
+  # parallel — Copilot review request happens alongside the gate's polling
+  # loop, so there is no scheduling regression.
   workflow_run:
-    workflows: ["Request Copilot Review"]
+    workflows: ["CI Checks"]
     types: [completed]
 
 concurrency:
@@ -47,7 +53,8 @@ jobs:
     name: copilot-review
     if: >
       github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request')
     runs-on: petrosa-org-runners
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Follow-up to #390. The previous fix had a latent chain-depth bug: the gate was triggered by workflow_run from "Request Copilot Review" (which itself was workflow_run-triggered from CI Checks), so `payload.workflow_run.head_branch/head_sha` collapsed to the default branch's HEAD at two workflow_run hops. PR resolution then failed: "No open same-repo PR for main@747cc207..."

## Verification (from PR #391)
Log at 2026-05-18T01:43:53Z:
> No open same-repo PR for main@747cc2071e381e23d5358a080311d59a866fb869; skipping.

The gate never reached the explicit `checks.create` call. PR #391's HEAD SHA had no `copilot-review` check_run.

## Fix
Trigger the gate from `CI Checks` directly (one workflow_run hop). At one hop, `payload.workflow_run.head_branch/head_sha` reports the original PR branch + PR head SHA, so PR resolution succeeds and the explicit check_run lands on PR head.

Also added `event == 'pull_request'` filter to the job `if` so the gate skips CI Checks runs that fire on main pushes.

## Scheduling
The Request Copilot Review workflow continues to trigger from CI Checks in parallel — Copilot review request happens alongside the gate's polling loop, so the gate still converges within the 20-minute budget.

## Test plan
- [x] yamllint passes
- [ ] After merge, fresh PR exercises the new chain: workflow_run from CI Checks → gate creates explicit check on PR HEAD
- [ ] Roll out same fix to remaining 7 Petrosa repos + petrosa_k8s template

Part of PetroSa2/petrosa_k8s#559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)