### PR TITLE
feat(risk): symbol whitelist pre-trade check (P6.3)

### DIFF
--- a/tests/test_position_manager_comprehensive.py
+++ b/tests/test_position_manager_comprehensive.py
@@ -1067,3 +1067,129 @@ class TestPositionManagerHelperMethods:
         ):
             await position_manager.reset_daily_pnl()
             assert position_manager.daily_pnl == 0.0
+
+
+class TestSymbolWhitelist:
+    """Tests for P6.3 symbol whitelist pre-trade risk check (petrosa_k8s#609)."""
+
+    @pytest.mark.asyncio
+    async def test_symbol_not_in_whitelist_is_rejected(
+        self, position_manager, sample_long_order
+    ):
+        """Order for a symbol not in the whitelist must be rejected."""
+        with patch.object(
+            position_manager,
+            "_get_allowed_symbols",
+            new_callable=AsyncMock,
+            return_value=["ETHUSDT", "BNBUSDT"],
+        ):
+            with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
+                result = await position_manager.check_position_limits(sample_long_order)
+
+        assert result is False
+        assert position_manager.rejection_reason == "symbol_not_allowed"
+
+    @pytest.mark.asyncio
+    async def test_symbol_in_whitelist_proceeds(
+        self, position_manager, sample_long_order
+    ):
+        """Order for a symbol on the whitelist must not be rejected by the whitelist check."""
+        position_manager.total_portfolio_value = 10000.0
+        with patch.object(
+            position_manager,
+            "_get_allowed_symbols",
+            new_callable=AsyncMock,
+            return_value=["BTCUSDT", "ETHUSDT"],
+        ):
+            with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
+                with patch.object(
+                    position_manager,
+                    "_refresh_portfolio_value",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ):
+                    with patch.object(
+                        position_manager,
+                        "_refresh_positions_from_data_manager",
+                        new_callable=AsyncMock,
+                    ):
+                        result = await position_manager.check_position_limits(
+                            sample_long_order
+                        )
+
+        assert result is True
+        assert position_manager.rejection_reason is None
+
+    @pytest.mark.asyncio
+    async def test_empty_whitelist_allows_all_symbols(
+        self, position_manager, sample_long_order
+    ):
+        """Empty allowed_symbols list means all symbols are permitted (safe default)."""
+        position_manager.total_portfolio_value = 10000.0
+        with patch.object(
+            position_manager,
+            "_get_allowed_symbols",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", True):
+                with patch.object(
+                    position_manager,
+                    "_refresh_portfolio_value",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ):
+                    with patch.object(
+                        position_manager,
+                        "_refresh_positions_from_data_manager",
+                        new_callable=AsyncMock,
+                    ):
+                        result = await position_manager.check_position_limits(
+                            sample_long_order
+                        )
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_get_allowed_symbols_falls_back_to_defaults(self, position_manager):
+        """_get_allowed_symbols returns DEFAULT_TRADING_PARAMETERS['allowed_symbols'] when config unavailable."""
+        with patch(
+            "tradeengine.position_manager.PositionManager._get_allowed_symbols",
+            wraps=position_manager._get_allowed_symbols,
+        ):
+            with patch(
+                "tradeengine.api_filter_routes.get_config_manager",
+                side_effect=Exception("no config manager"),
+            ):
+                with patch(
+                    "tradeengine.defaults.DEFAULT_TRADING_PARAMETERS",
+                    {"allowed_symbols": ["BTCUSDT"]},
+                ):
+                    result = await position_manager._get_allowed_symbols()
+
+        assert result == ["BTCUSDT"]
+
+    @pytest.mark.asyncio
+    async def test_get_allowed_symbols_uses_live_config(self, position_manager):
+        """_get_allowed_symbols prefers live config over defaults."""
+        mock_mgr = AsyncMock()
+        mock_mgr.get_config = AsyncMock(
+            return_value={"allowed_symbols": ["ETHUSDT", "SOLUSDT"]}
+        )
+        with patch(
+            "tradeengine.api_filter_routes.get_config_manager",
+            return_value=mock_mgr,
+        ):
+            result = await position_manager._get_allowed_symbols()
+
+        assert result == ["ETHUSDT", "SOLUSDT"]
+
+    @pytest.mark.asyncio
+    async def test_risk_disabled_bypasses_whitelist(
+        self, position_manager, sample_long_order
+    ):
+        """When RISK_MANAGEMENT_ENABLED is False the whitelist check is skipped."""
+        with patch("tradeengine.position_manager.RISK_MANAGEMENT_ENABLED", False):
+            result = await position_manager.check_position_limits(sample_long_order)
+
+        assert result is True

--- a/tradeengine/defaults.py
+++ b/tradeengine/defaults.py
@@ -56,6 +56,7 @@ DEFAULT_TRADING_PARAMETERS = {
     "timeframe_conflict_resolution": "higher_timeframe_wins",
     "max_signal_age_seconds": 300,
     "min_confidence_threshold": 0.5,
+    "allowed_symbols": [],
     # -------------------------------------------------------------------------
     # Strategy Weights (default weights for conflict resolution)
     # -------------------------------------------------------------------------

--- a/tradeengine/position_manager.py
+++ b/tradeengine/position_manager.py
@@ -946,6 +946,27 @@ class PositionManager:
         except Exception as e:
             logger.error(f"Error exporting position closed metrics: {e}")
 
+    async def _get_allowed_symbols(self) -> list[str]:
+        """Return allowed_symbols from live config, falling back to DEFAULT_TRADING_PARAMETERS.
+
+        Empty list means all symbols are permitted (safe default).
+        """
+        try:
+            from tradeengine.api_filter_routes import get_config_manager
+
+            mgr = get_config_manager()
+            global_config = await mgr.get_config()
+            if global_config and "allowed_symbols" in global_config:
+                value = global_config["allowed_symbols"]
+                if isinstance(value, list):
+                    return value
+        except Exception as e:
+            logger.warning("Failed to get allowed_symbols from config: %s", e)
+
+        from tradeengine.defaults import DEFAULT_TRADING_PARAMETERS
+
+        return DEFAULT_TRADING_PARAMETERS.get("allowed_symbols", [])
+
     async def get_position_size_limit(self, symbol: str) -> float:
         """Get position size limit for symbol (checks config, then default)"""
         try:
@@ -977,6 +998,17 @@ class PositionManager:
         if not RISK_MANAGEMENT_ENABLED:
             self.rejection_reason = None
             return True
+
+        # P6.3: Symbol whitelist check — runs before any expensive portfolio refresh.
+        # Empty / unset list means all symbols are allowed (safe default).
+        allowed_symbols = await self._get_allowed_symbols()
+        if allowed_symbols and order.symbol not in allowed_symbols:
+            self.rejection_reason = "symbol_not_allowed"
+            logger.warning(
+                "⛔ RISK REJECTION: Symbol %s not in allowed_symbols whitelist",
+                order.symbol,
+            )
+            return False
 
         # Refresh portfolio value before checks (mandatory as per AC)
         if not await self._refresh_portfolio_value():


### PR DESCRIPTION
## Summary

- Implements P6.3 (petrosa_k8s#609): adds a symbol whitelist to the pre-trade risk path.
- New `_get_allowed_symbols()` helper on `PositionManager` reads from live config first, falls back to `DEFAULT_TRADING_PARAMETERS["allowed_symbols"]` (default `[]`).
- `check_position_limits()` rejects orders with `rejection_reason="symbol_not_allowed"` when whitelist is non-empty and symbol is not on it.
- Empty list (default) allows all symbols — safe, backwards-compatible default.

## Changed files

- `tradeengine/defaults.py` — add `"allowed_symbols": []` to `DEFAULT_TRADING_PARAMETERS`
- `tradeengine/position_manager.py` — `_get_allowed_symbols()` helper + whitelist guard at top of `check_position_limits()`
- `tests/test_position_manager_comprehensive.py` — `TestSymbolWhitelist` class (6 tests)

## Test plan

- [x] `pytest tests/test_position_manager_comprehensive.py::TestSymbolWhitelist` — 6/6 pass
- [x] `test_symbol_not_in_whitelist_is_rejected` — rejection_reason == "symbol_not_allowed"
- [x] `test_symbol_in_whitelist_proceeds` — passes through to other checks
- [x] `test_empty_whitelist_allows_all_symbols` — safe default preserved
- [x] `test_get_allowed_symbols_falls_back_to_defaults` — exception path falls back correctly
- [x] `test_get_allowed_symbols_uses_live_config` — live config takes precedence
- [x] `test_risk_disabled_bypasses_whitelist` — RISK_MANAGEMENT_ENABLED=False skips check entirely

Closes petrosa_k8s#609

🤖 Generated with [Claude Code](https://claude.com/claude-code)