### PR TITLE
feat(nats): #586 - publish execution.events.<strategy_id> on order lifecycle (AC2, AC4)

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -62,6 +62,7 @@ class Settings(BaseSettings):
     # Align default with shared.constants default and TA bot publisher
     nats_topic_signals: str = "signals.trading.*"
     nats_topic_heartbeat: str = "cio.heartbeat"
+    nats_topic_execution_events: str = "execution.events"
 
     # CIO Enforcement (Ticket #304 / P0 #1)
     enforce_cio_audit: bool = True  # Default to True for maximum safety
@@ -91,6 +92,7 @@ class Settings(BaseSettings):
         # Set NATS configuration from constants
         from shared.constants import (
             NATS_ENABLED,
+            NATS_TOPIC_EXECUTION_EVENTS,
             NATS_TOPIC_HEARTBEAT,
             NATS_TOPIC_SIGNALS,
             get_nats_connection_string,
@@ -109,6 +111,9 @@ class Settings(BaseSettings):
 
         if not kwargs.get("nats_topic_heartbeat"):
             self.nats_topic_heartbeat = NATS_TOPIC_HEARTBEAT
+
+        if not kwargs.get("nats_topic_execution_events"):
+            self.nats_topic_execution_events = NATS_TOPIC_EXECUTION_EVENTS
 
     @property
     def is_production(self) -> bool:

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -131,6 +131,10 @@ NATS_ENABLED = os.getenv("NATS_ENABLED", "false").lower() == "true"
 NATS_URL = os.getenv("NATS_URL", "nats://nats-server:4222")
 NATS_TOPIC_SIGNALS = os.getenv("NATS_TOPIC_SIGNALS", "signals.trading.*")
 NATS_TOPIC_HEARTBEAT = os.getenv("NATS_TOPIC_HEARTBEAT", "cio.heartbeat")
+# Per PetroSa2/petrosa_k8s#586 (P0.2c) — prefix only; publisher appends ".<strategy_id>".
+NATS_TOPIC_EXECUTION_EVENTS = os.getenv(
+    "NATS_TOPIC_EXECUTION_EVENTS", "execution.events"
+)
 NATS_QUEUE_GROUP = os.getenv("NATS_QUEUE_GROUP", "petrosa-tradeengine")
 NATS_CONNECT_TIMEOUT = int(os.getenv("NATS_CONNECT_TIMEOUT", "5"))
 NATS_RECONNECT_TIME_WAIT = int(os.getenv("NATS_RECONNECT_TIME_WAIT", "1"))

--- a/tests/test_dispatcher_execution_events.py
+++ b/tests/test_dispatcher_execution_events.py
@@ -1,0 +1,165 @@
+"""
+Tests that the dispatcher correctly invokes the execution-event publisher
+for both signal-keyed (rejection) and order-keyed (lifecycle) emissions.
+
+Scope: PetroSa2/petrosa_k8s#586, P0.2c — exercises only the two emit helpers
+and verifies subject/event_type/decision_id propagation. Full dispatch flow
+is covered by other tests in the suite.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from contracts.order import OrderStatus, TradeOrder
+from contracts.signal import Signal
+from shared.constants import UTC
+
+
+def _build_signal(**overrides):
+    base = {
+        "strategy_id": "rsi_reversal",
+        "symbol": "BTCUSDT",
+        "action": "buy",
+        "price": 50000.0,
+        "quantity": 0.001,
+        "current_price": 50000.0,
+        "confidence": 0.8,
+        "source": "petrosa-cio",
+        "strategy": "rsi_reversal",
+        "decision_id": "dec-deadbeef",
+    }
+    base.update(overrides)
+    return Signal(**base)
+
+
+def _build_order(strategy_id: str = "rsi_reversal", decision_id: str = "dec-1"):
+    return TradeOrder(
+        order_id="local-order-1",
+        symbol="BTCUSDT",
+        side="buy",
+        type="market",
+        amount=0.01,
+        target_price=50000.0,
+        status=OrderStatus.PENDING,
+        filled_amount=0.0,
+        strategy_metadata={
+            "strategy_id": strategy_id,
+            "decision_id": decision_id,
+        },
+        exchange="binance",
+    )
+
+
+@pytest.fixture
+def dispatcher():
+    """Build a minimally-initialized Dispatcher without touching network/IO."""
+    from tradeengine.dispatcher import Dispatcher
+
+    # Bypass __init__'s heavy setup by instantiating then patching just what helpers need.
+    d = Dispatcher.__new__(Dispatcher)
+    d.logger = MagicMock()
+    return d
+
+
+@pytest.mark.asyncio
+async def test_emit_from_signal_propagates_decision_id_and_reason(dispatcher):
+    signal = _build_signal(decision_id="dec-XYZ")
+    with patch("tradeengine.dispatcher.execution_event_publisher") as pub:
+        pub.publish = AsyncMock(return_value=True)
+        await dispatcher._emit_execution_event_from_signal(
+            signal,
+            event_type="rejected",
+            reason="risk_position_limit",
+        )
+
+    pub.publish.assert_awaited_once()
+    kw = pub.publish.await_args.kwargs
+    assert kw["event_type"] == "rejected"
+    assert kw["strategy_id"] == "rsi_reversal"
+    assert kw["decision_id"] == "dec-XYZ"
+    assert kw["reason"] == "risk_position_limit"
+    # order_id unknown pre-execution
+    assert kw["order_id"] == ""
+    # extra carries cheap context already on the signal
+    assert kw["extra"]["symbol"] == "BTCUSDT"
+    assert kw["extra"]["side"] == "buy"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event_type,reason",
+    [
+        ("placed", "binance_accepted"),
+        ("filled", "binance_filled"),
+        ("partial_fill", "partial_5_of_10"),
+        ("rejected", "exchange_rejected"),
+    ],
+)
+async def test_emit_from_order_covers_all_lifecycle_events(
+    dispatcher, event_type, reason
+):
+    order = _build_order(strategy_id="momentum_v2", decision_id="dec-MOM")
+    result = {"order_id": "binance-7777", "status": event_type, "amount": 0.005}
+
+    with patch("tradeengine.dispatcher.execution_event_publisher") as pub:
+        pub.publish = AsyncMock(return_value=True)
+        await dispatcher._emit_execution_event_from_order(
+            order,
+            result,
+            event_type=event_type,
+            reason=reason,
+        )
+
+    pub.publish.assert_awaited_once()
+    kw = pub.publish.await_args.kwargs
+    assert kw["event_type"] == event_type
+    assert kw["reason"] == reason
+    assert kw["strategy_id"] == "momentum_v2"
+    assert kw["decision_id"] == "dec-MOM"
+    # Exchange-assigned id is preferred over local fallback
+    assert kw["order_id"] == "binance-7777"
+    assert kw["extra"]["symbol"] == "BTCUSDT"
+    assert kw["extra"]["side"] == "buy"
+    assert kw["extra"]["qty"] == 0.01
+
+
+@pytest.mark.asyncio
+async def test_emit_from_order_falls_back_to_local_order_id(dispatcher):
+    """If the exchange didn't assign an id (e.g. simulated), use the local one."""
+    order = _build_order()
+    result = {"order_id": None, "status": "pending"}
+    with patch("tradeengine.dispatcher.execution_event_publisher") as pub:
+        pub.publish = AsyncMock(return_value=True)
+        await dispatcher._emit_execution_event_from_order(
+            order, result, event_type="placed", reason="simulated_placed"
+        )
+    kw = pub.publish.await_args.kwargs
+    assert kw["order_id"] == "local-order-1"
+
+
+@pytest.mark.asyncio
+async def test_emit_handles_publisher_exception_gracefully(dispatcher):
+    """Publisher errors must NOT propagate up — order path stays alive."""
+    signal = _build_signal()
+    with patch("tradeengine.dispatcher.execution_event_publisher") as pub:
+        pub.publish = AsyncMock(side_effect=RuntimeError("nats down"))
+        # Should not raise
+        await dispatcher._emit_execution_event_from_signal(
+            signal, event_type="rejected", reason="any"
+        )
+    dispatcher.logger.warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_strips_unknown_fields_from_signal_decision_id(dispatcher):
+    """A signal with no decision_id (legacy ta-bot path) emits with None decision_id."""
+    signal = _build_signal(decision_id=None)
+    with patch("tradeengine.dispatcher.execution_event_publisher") as pub:
+        pub.publish = AsyncMock(return_value=True)
+        await dispatcher._emit_execution_event_from_signal(
+            signal, event_type="rejected", reason="restricted_mode"
+        )
+    assert pub.publish.await_args.kwargs["decision_id"] is None

--- a/tests/test_execution_event_publisher.py
+++ b/tests/test_execution_event_publisher.py
@@ -1,0 +1,243 @@
+"""
+Unit tests for ExecutionEventPublisher (PetroSa2/petrosa_k8s#586, P0.2c).
+
+Covers:
+- subject construction with strategy_id
+- payload schema (required keys + types)
+- decision_id propagation from inbound signal
+- all four lifecycle event_types: placed, filled, partial_fill, rejected
+- NATS-disabled mode (publisher is no-op-safe)
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tradeengine.services.execution_event_publisher import (
+    ExecutionEventPublisher,
+)
+
+
+@pytest.fixture
+def publisher():
+    return ExecutionEventPublisher()
+
+
+@pytest.fixture
+def fake_nats_client():
+    """A NATS client whose publish() records calls."""
+    client = MagicMock()
+    client.is_connected = True
+    client.publish = AsyncMock()
+    return client
+
+
+# ---------- subject construction ----------
+
+
+def test_build_subject_appends_strategy_id():
+    with patch("tradeengine.services.execution_event_publisher.settings") as s:
+        s.nats_topic_execution_events = "execution.events"
+        subj = ExecutionEventPublisher._build_subject("rsi_reversal")
+    assert subj == "execution.events.rsi_reversal"
+
+
+def test_build_subject_strips_wildcard_suffix():
+    # If operator misconfigures the env with a subscription pattern.
+    with patch("tradeengine.services.execution_event_publisher.settings") as s:
+        s.nats_topic_execution_events = "execution.events.>"
+        subj = ExecutionEventPublisher._build_subject("macd_cross")
+    assert subj == "execution.events.macd_cross"
+
+
+def test_build_subject_unknown_strategy_id_falls_back():
+    with patch("tradeengine.services.execution_event_publisher.settings") as s:
+        s.nats_topic_execution_events = "execution.events"
+        subj = ExecutionEventPublisher._build_subject("")
+    assert subj == "execution.events.unknown"
+
+
+# ---------- payload schema ----------
+
+
+def test_build_payload_has_all_required_fields():
+    payload = ExecutionEventPublisher._build_payload(
+        decision_id="dec-abc",
+        strategy_id="rsi_reversal",
+        order_id="ord-123",
+        event_type="placed",
+        reason="binance_accepted",
+    )
+    for required in (
+        "decision_id",
+        "strategy_id",
+        "order_id",
+        "event_type",
+        "timestamp",
+        "reason",
+    ):
+        assert required in payload, f"missing {required}"
+    assert payload["decision_id"] == "dec-abc"
+    assert payload["strategy_id"] == "rsi_reversal"
+    assert payload["order_id"] == "ord-123"
+    assert payload["event_type"] == "placed"
+    assert payload["reason"] == "binance_accepted"
+    # ISO-8601 string
+    assert isinstance(payload["timestamp"], str)
+    assert "T" in payload["timestamp"]
+
+
+def test_build_payload_merges_extra_without_clobbering():
+    payload = ExecutionEventPublisher._build_payload(
+        decision_id="dec-xyz",
+        strategy_id="s1",
+        order_id="o1",
+        event_type="filled",
+        reason="binance_filled",
+        extra={
+            "symbol": "BTCUSDT",
+            "side": "buy",
+            "qty": 0.01,
+            # Should NOT overwrite the required event_type:
+            "event_type": "rejected",
+        },
+    )
+    assert payload["event_type"] == "filled"  # not clobbered
+    assert payload["symbol"] == "BTCUSDT"
+    assert payload["side"] == "buy"
+    assert payload["qty"] == 0.01
+
+
+# ---------- publish behaviour ----------
+
+
+@pytest.mark.asyncio
+async def test_publish_emits_to_correct_subject(publisher, fake_nats_client):
+    with patch("tradeengine.services.execution_event_publisher.settings") as s:
+        s.nats_enabled = True
+        s.nats_servers = "nats://localhost:4222"
+        s.nats_topic_execution_events = "execution.events"
+        publisher.set_client(fake_nats_client)
+        ok = await publisher.publish(
+            event_type="placed",
+            strategy_id="rsi_reversal",
+            order_id="ord-9",
+            reason="binance_accepted",
+            decision_id="dec-1",
+        )
+
+    assert ok is True
+    assert fake_nats_client.publish.await_count == 1
+    args, _ = fake_nats_client.publish.call_args
+    subject, encoded = args
+    assert subject == "execution.events.rsi_reversal"
+    body = json.loads(encoded.decode())
+    assert body["event_type"] == "placed"
+    assert body["decision_id"] == "dec-1"
+    assert body["order_id"] == "ord-9"
+    assert body["strategy_id"] == "rsi_reversal"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event_type,reason",
+    [
+        ("placed", "binance_accepted"),
+        ("filled", "binance_filled"),
+        ("partial_fill", "partial_5_of_10"),
+        ("rejected", "risk_position_limit"),
+    ],
+)
+async def test_publish_all_four_event_types(
+    publisher, fake_nats_client, event_type, reason
+):
+    with patch("tradeengine.services.execution_event_publisher.settings") as s:
+        s.nats_enabled = True
+        s.nats_servers = "nats://localhost:4222"
+        s.nats_topic_execution_events = "execution.events"
+        publisher.set_client(fake_nats_client)
+        ok = await publisher.publish(
+            event_type=event_type,
+            strategy_id="strat",
+            order_id="ord-1",
+            reason=reason,
+            decision_id="dec-1",
+        )
+    assert ok is True
+    body = json.loads(fake_nats_client.publish.call_args[0][1].decode())
+    assert body["event_type"] == event_type
+    assert body["reason"] == reason
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_unknown_event_type(publisher, fake_nats_client):
+    publisher.set_client(fake_nats_client)
+    ok = await publisher.publish(
+        event_type="liquidated",  # type: ignore[arg-type]
+        strategy_id="strat",
+        order_id="o",
+        reason="nope",
+    )
+    assert ok is False
+    fake_nats_client.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publish_propagates_decision_id_to_payload(publisher, fake_nats_client):
+    with patch("tradeengine.services.execution_event_publisher.settings") as s:
+        s.nats_enabled = True
+        s.nats_servers = "nats://localhost:4222"
+        s.nats_topic_execution_events = "execution.events"
+        publisher.set_client(fake_nats_client)
+        await publisher.publish(
+            event_type="filled",
+            strategy_id="momentum_v2",
+            order_id="exch-7777",
+            reason="binance_filled",
+            decision_id="decision-uuid-deadbeef",
+        )
+    body = json.loads(fake_nats_client.publish.call_args[0][1].decode())
+    assert body["decision_id"] == "decision-uuid-deadbeef"
+
+
+@pytest.mark.asyncio
+async def test_publish_noop_when_nats_disabled(publisher, fake_nats_client):
+    """When NATS is disabled, publisher returns False without raising."""
+    with patch("tradeengine.services.execution_event_publisher.settings") as s:
+        s.nats_enabled = False
+        s.nats_servers = None
+        s.nats_topic_execution_events = "execution.events"
+        # Don't inject a client — let _ensure_connected short-circuit.
+        ok = await publisher.publish(
+            event_type="placed",
+            strategy_id="strat",
+            order_id="o1",
+            reason="binance_accepted",
+            decision_id="d1",
+        )
+    assert ok is False
+    fake_nats_client.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publish_swallows_nats_errors(publisher):
+    """A broken NATS publish must not raise — order path keeps going."""
+    bad_client = MagicMock()
+    bad_client.is_connected = True
+    bad_client.publish = AsyncMock(side_effect=RuntimeError("conn closed"))
+    with patch("tradeengine.services.execution_event_publisher.settings") as s:
+        s.nats_enabled = True
+        s.nats_servers = "nats://localhost:4222"
+        s.nats_topic_execution_events = "execution.events"
+        publisher.set_client(bad_client)
+        ok = await publisher.publish(
+            event_type="rejected",
+            strategy_id="s",
+            order_id="o",
+            reason="risk_x",
+            decision_id="d",
+        )
+    assert ok is False  # signalled, but no exception raised

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -23,6 +23,10 @@ from tradeengine.metrics import (
 )
 from tradeengine.order_manager import OrderManager
 from tradeengine.position_manager import PositionManager
+from tradeengine.services.execution_event_publisher import (
+    EventType as ExecutionEventType,
+    execution_event_publisher,
+)
 from tradeengine.services.heartbeat_monitor import HeartbeatMonitor
 from tradeengine.signal_aggregator import SignalAggregator
 from tradeengine.strategy_position_manager import strategy_position_manager
@@ -1610,6 +1614,11 @@ class Dispatcher:
                                 "RESTRICTED_MODE: CIO Heartbeat Lost",
                             )
                         )
+                        await self._emit_execution_event_from_signal(
+                            signal,
+                            event_type="rejected",
+                            reason="restricted_mode_cio_heartbeat_lost",
+                        )
                         return {
                             "status": "aborted",
                             "reason": "RESTRICTED_MODE: CIO heartbeat lost, opening new positions is strictly forbidden.",
@@ -1643,6 +1652,12 @@ class Dispatcher:
                                 trace.StatusCode.ERROR,
                                 f"Unauthorized source: {signal.source}",
                             )
+                        )
+                        await self._emit_execution_event_from_signal(
+                            signal,
+                            event_type="rejected",
+                            reason="cio_enforcement_unauthorized_source",
+                            extra={"source": signal.source},
                         )
                         return {
                             "status": "rejected",
@@ -1737,6 +1752,12 @@ class Dispatcher:
                                     "rejection.reason", "accumulation_cooldown"
                                 )
                                 span.set_status(trace.Status(trace.StatusCode.OK))
+                                await self._emit_execution_event_from_signal(
+                                    signal,
+                                    event_type="rejected",
+                                    reason="accumulation_cooldown",
+                                    extra={"remaining_sec": int(remaining)},
+                                )
                                 return {
                                     "status": "rejected",
                                     "reason": f"Accumulation cooldown active ({remaining:.0f}s/{ACCUMULATION_COOLDOWN_SECONDS}s)",
@@ -1855,6 +1876,13 @@ class Dispatcher:
                     signals_processed.labels(
                         status="rejected", action=signal.action
                     ).inc()
+                    await self._emit_execution_event_from_signal(
+                        signal,
+                        event_type="rejected",
+                        reason=str(result.get("reason", "risk_or_signal_rejected"))[
+                            :128
+                        ],
+                    )
                 else:
                     self.logger.warning(
                         f"⚠️  SIGNAL VALIDATION FAILED: {signal.strategy_id} | "
@@ -2178,6 +2206,82 @@ class Dispatcher:
         except Exception as e:
             self.logger.error(f"Order execution with consensus error: {e}")
             return {"status": "error", "error": str(e)}
+
+    async def _emit_execution_event_from_signal(
+        self,
+        signal: Signal,
+        *,
+        event_type: ExecutionEventType,
+        reason: str,
+        order_id: str = "",
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit an execution.events.<strategy_id> message keyed off a Signal."""
+        merged_extra: dict[str, Any] = {
+            "symbol": getattr(signal, "symbol", None),
+            "side": getattr(signal, "action", None),
+        }
+        if extra:
+            merged_extra.update(extra)
+        try:
+            await execution_event_publisher.publish(
+                event_type=event_type,
+                strategy_id=signal.strategy_id,
+                order_id=order_id,
+                reason=reason,
+                decision_id=signal.decision_id,
+                extra=merged_extra,
+            )
+        except Exception as emit_err:
+            self.logger.warning(
+                "execution_event emit (signal-keyed) failed for %s: %s",
+                signal.strategy_id,
+                emit_err,
+            )
+
+    async def _emit_execution_event_from_order(
+        self,
+        order: TradeOrder,
+        result: dict[str, Any],
+        *,
+        event_type: ExecutionEventType,
+        reason: str,
+    ) -> None:
+        """Emit an execution.events.<strategy_id> message keyed off an executed TradeOrder."""
+        strategy_meta = order.strategy_metadata or {}
+        strategy_id = strategy_meta.get("strategy_id") or "unknown"
+        decision_id = strategy_meta.get("decision_id")
+        # Prefer exchange order_id (Binance numeric id) when present; fall back to internal id.
+        exchange_order_id = result.get("order_id") if isinstance(result, dict) else None
+        order_id = str(exchange_order_id or order.order_id or "")
+
+        fill_qty = None
+        if isinstance(result, dict):
+            # Binance fills carry total filled qty; partial_fill needs this to be meaningful.
+            fill_qty = result.get("amount") or result.get("filled") or None
+
+        extra: dict[str, Any] = {
+            "symbol": order.symbol,
+            "side": order.side,
+            "qty": order.amount,
+        }
+        if fill_qty is not None:
+            extra["fill_qty"] = fill_qty
+        try:
+            await execution_event_publisher.publish(
+                event_type=event_type,
+                strategy_id=strategy_id,
+                order_id=order_id,
+                reason=reason,
+                decision_id=decision_id,
+                extra=extra,
+            )
+        except Exception as emit_err:
+            self.logger.warning(
+                "execution_event emit (order-keyed) failed for %s: %s",
+                order.order_id,
+                emit_err,
+            )
 
     def _signal_to_order(
         self, signal: Signal, order_params: dict[str, Any] | None = None
@@ -2510,6 +2614,51 @@ class Dispatcher:
                 if result.get("fill_price"):
                     span.set_attribute("order.fill_price", result.get("fill_price"))
                 span.set_status(trace.Status(trace.StatusCode.OK))
+
+                # Emit execution.events.<strategy_id> for order lifecycle (#586 AC2/AC4).
+                # Mapping Binance/exchange statuses onto our four-event vocabulary.
+                exch_status_raw = str(result.get("status", "")).lower()
+                mapped_event: ExecutionEventType | None = None
+                emit_reason = ""
+                if exch_status_raw in ("filled",):
+                    mapped_event = "filled"
+                    emit_reason = "binance_filled"
+                elif exch_status_raw in ("partially_filled", "partial", "partial_fill"):
+                    mapped_event = "partial_fill"
+                    fq = result.get("amount") or 0
+                    emit_reason = f"partial_{fq}_of_{order.amount}"
+                elif exch_status_raw in (
+                    "new",
+                    "pending",
+                    "accepted",
+                    "open",
+                    "working",
+                ):
+                    mapped_event = "placed"
+                    emit_reason = (
+                        "binance_accepted" if not order.simulate else "simulated_placed"
+                    )
+                elif exch_status_raw in (
+                    "rejected",
+                    "expired",
+                    "cancelled",
+                    "canceled",
+                    "failed",
+                    "error",
+                ):
+                    mapped_event = "rejected"
+                    err = result.get("error")
+                    emit_reason = f"exchange_{exch_status_raw}" + (
+                        f": {str(err)[:80]}" if err else ""
+                    )
+
+                if mapped_event is not None:
+                    await self._emit_execution_event_from_order(
+                        order,
+                        result,
+                        event_type=mapped_event,
+                        reason=emit_reason,
+                    )
                 return result
 
             except Exception as e:
@@ -2527,6 +2676,12 @@ class Dispatcher:
                     )
                 span.set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
                 span.record_exception(e)
+                await self._emit_execution_event_from_order(
+                    order,
+                    {"status": "error", "error": str(e)},
+                    event_type="rejected",
+                    reason=f"order_execution_exception: {str(e)[:80]}",
+                )
                 return {"status": "error", "error": str(e)}
 
     def get_cio_state(self, symbol: str) -> dict[str, Any]:

--- a/tradeengine/services/execution_event_publisher.py
+++ b/tradeengine/services/execution_event_publisher.py
@@ -1,0 +1,234 @@
+"""
+Execution event publisher (PetroSa2/petrosa_k8s#586, P0.2c).
+
+Emits one NATS message per order lifecycle event on the subject
+``execution.events.<strategy_id>``. The prefix (`execution.events`) is sourced
+from settings.nats_topic_execution_events; strategy_id is appended at publish
+time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+from typing import Any, Literal
+
+import nats
+import nats.aio.client
+from opentelemetry import trace
+from prometheus_client import Counter
+
+from shared.config import settings
+from shared.constants import UTC
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+EventType = Literal["placed", "filled", "rejected", "partial_fill"]
+_VALID_EVENT_TYPES: set[str] = {"placed", "filled", "rejected", "partial_fill"}
+
+
+execution_events_published = Counter(
+    "tradeengine_execution_events_published_total",
+    "Total execution lifecycle events published to NATS",
+    ["event_type", "strategy_id", "result"],
+)
+
+
+class ExecutionEventPublisher:
+    """Lazy-connect publisher for execution.events.<strategy_id>.
+
+    Owns its own NATS connection so it stays available even when the consumer
+    is disabled (e.g. one-shot HTTP-driven flows in tests).
+    """
+
+    def __init__(self) -> None:
+        self._nc: nats.aio.client.Client | None = None
+        self._connect_lock = asyncio.Lock()
+
+    async def _ensure_connected(self) -> nats.aio.client.Client | None:
+        if not settings.nats_enabled or not settings.nats_servers:
+            return None
+        if self._nc is not None and self._nc.is_connected:
+            return self._nc
+        async with self._connect_lock:
+            if self._nc is not None and self._nc.is_connected:
+                return self._nc
+            from shared.constants import (
+                NATS_CONNECT_TIMEOUT,
+                NATS_MAX_RECONNECT_ATTEMPTS,
+                NATS_RECONNECT_TIME_WAIT,
+            )
+
+            try:
+                self._nc = await nats.connect(
+                    servers=settings.nats_servers,
+                    connect_timeout=NATS_CONNECT_TIMEOUT,
+                    max_reconnect_attempts=NATS_MAX_RECONNECT_ATTEMPTS,
+                    reconnect_time_wait=NATS_RECONNECT_TIME_WAIT,
+                    allow_reconnect=True,
+                    name="petrosa-tradeengine-execution-events",
+                )
+                logger.info(
+                    "ExecutionEventPublisher connected to NATS at %s",
+                    settings.nats_servers,
+                )
+            except Exception as e:
+                logger.error("ExecutionEventPublisher failed to connect to NATS: %s", e)
+                self._nc = None
+        return self._nc
+
+    def set_client(self, nc: nats.aio.client.Client | None) -> None:
+        """Inject an existing NATS client (e.g. consumer's) to avoid double-connect."""
+        self._nc = nc
+
+    async def close(self) -> None:
+        if self._nc is not None:
+            try:
+                await self._nc.close()
+            except Exception:
+                pass
+            self._nc = None
+
+    @staticmethod
+    def _build_subject(strategy_id: str) -> str:
+        prefix = settings.nats_topic_execution_events or "execution.events"
+        # If operator overrode env to a wildcard subscription pattern, strip it.
+        prefix = prefix.rstrip(".*>").rstrip(".")
+        safe_strategy = (strategy_id or "unknown").strip() or "unknown"
+        return f"{prefix}.{safe_strategy}"
+
+    @staticmethod
+    def _build_payload(
+        *,
+        decision_id: str | None,
+        strategy_id: str,
+        order_id: str,
+        event_type: EventType,
+        reason: str,
+        timestamp: datetime | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        ts = (timestamp or datetime.now(UTC)).astimezone(UTC).isoformat()
+        payload: dict[str, Any] = {
+            "decision_id": decision_id or "",
+            "strategy_id": strategy_id or "unknown",
+            "order_id": order_id or "",
+            "event_type": event_type,
+            "timestamp": ts,
+            "reason": reason or "",
+        }
+        if extra:
+            # Skip keys that would clobber required fields.
+            for k, v in extra.items():
+                if k not in payload and v is not None:
+                    payload[k] = v
+        return payload
+
+    async def publish(
+        self,
+        *,
+        event_type: EventType,
+        strategy_id: str,
+        order_id: str,
+        reason: str,
+        decision_id: str | None = None,
+        timestamp: datetime | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> bool:
+        """Emit one execution event. Returns True on success, False otherwise.
+
+        Non-fatal — failures are logged but never raised; the order path must
+        not break if the observability bus is unhealthy.
+        """
+        if event_type not in _VALID_EVENT_TYPES:
+            logger.error("Refusing to publish unknown event_type=%s", event_type)
+            return False
+
+        subject = self._build_subject(strategy_id)
+        payload = self._build_payload(
+            decision_id=decision_id,
+            strategy_id=strategy_id,
+            order_id=order_id,
+            event_type=event_type,
+            reason=reason,
+            timestamp=timestamp,
+            extra=extra,
+        )
+
+        with tracer.start_as_current_span(
+            "execution_event.publish",
+            kind=trace.SpanKind.PRODUCER,
+        ) as span:
+            span.set_attribute("messaging.system", "nats")
+            span.set_attribute("messaging.destination", subject)
+            span.set_attribute("messaging.operation", "publish")
+            span.set_attribute("execution.event_type", event_type)
+            span.set_attribute("strategy.id", payload["strategy_id"])
+            if decision_id:
+                span.set_attribute("decision.decision_id", decision_id)
+            if order_id:
+                span.set_attribute("order.id", order_id)
+
+            nc = await self._ensure_connected()
+            if nc is None:
+                # Publisher is best-effort: NATS-disabled mode is not an error.
+                logger.info(
+                    "execution_event.skipped subject=%s event_type=%s strategy_id=%s "
+                    "order_id=%s decision_id=%s reason=%s (nats disabled or unavailable)",
+                    subject,
+                    event_type,
+                    payload["strategy_id"],
+                    order_id,
+                    decision_id,
+                    reason,
+                )
+                execution_events_published.labels(
+                    event_type=event_type,
+                    strategy_id=payload["strategy_id"],
+                    result="skipped",
+                ).inc()
+                return False
+
+            try:
+                await nc.publish(subject, json.dumps(payload).encode())
+                logger.info(
+                    "execution_event.published subject=%s event_type=%s "
+                    "strategy_id=%s order_id=%s decision_id=%s reason=%s",
+                    subject,
+                    event_type,
+                    payload["strategy_id"],
+                    order_id,
+                    decision_id,
+                    reason,
+                )
+                execution_events_published.labels(
+                    event_type=event_type,
+                    strategy_id=payload["strategy_id"],
+                    result="ok",
+                ).inc()
+                span.set_status(trace.Status(trace.StatusCode.OK))
+                return True
+            except Exception as e:
+                logger.error(
+                    "execution_event.failed subject=%s event_type=%s error=%s",
+                    subject,
+                    event_type,
+                    e,
+                    exc_info=True,
+                )
+                execution_events_published.labels(
+                    event_type=event_type,
+                    strategy_id=payload["strategy_id"],
+                    result="error",
+                ).inc()
+                span.set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
+                span.record_exception(e)
+                return False
+
+
+# Module-level singleton — dispatcher imports and calls this directly.
+execution_event_publisher = ExecutionEventPublisher()


### PR DESCRIPTION
## Summary

- New publisher `tradeengine/services/execution_event_publisher.py` emits one NATS message per order lifecycle event on subject `execution.events.<strategy_id>` (prefix from `NATS_TOPIC_EXECUTION_EVENTS`, ConfigMap key landed in PetroSa2/petrosa_k8s#628).
- Hooks added in `tradeengine/dispatcher.py` for the four event types: **placed** / **filled** / **partial_fill** / **rejected** — covering Binance lifecycle statuses and the signal-rejection paths (restricted_mode, CIO enforcement, accumulation cooldown, generic signal/risk rejection).
- Payload carries `decision_id` (propagated per P0.1b contract, PetroSa2/petrosa_k8s#579), `strategy_id`, `order_id`, `event_type`, `timestamp` (ISO-8601 UTC), `reason`, plus cheap context (symbol/side/qty/fill_qty). Each emit creates a PRODUCER child span on the parent decision trace.

## Related

- Issue: PetroSa2/petrosa_k8s#586 (AC2 + AC4 slice)
- ConfigMap PR (k8s slice): PetroSa2/petrosa_k8s#628
- Decision-id contract (P0.1b): PetroSa2/petrosa_k8s#579

## Test plan

- [x] `pytest tests/test_execution_event_publisher.py` — subject, payload schema, all four event_types, decision_id propagation, NATS-disabled no-op, error swallow
- [x] `pytest tests/test_dispatcher_execution_events.py` — dispatcher signal-keyed + order-keyed emit helpers, decision_id forwarding, exception graceful-handling
- [x] Full suite: `pytest --no-cov` → 1353 passed, 13 skipped
- [ ] Manual sanity: in-cluster, confirm `nats sub 'execution.events.>'` receives events for a real signal

Refs PetroSa2/petrosa_k8s#586 (AC2, AC4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)