### PR TITLE
fix: #404 — fall back to total_wallet_balance when availableBalance absent from Binance account info

### DIFF
--- a/tests/test_position_manager_comprehensive.py
+++ b/tests/test_position_manager_comprehensive.py
@@ -1193,3 +1193,46 @@ class TestSymbolWhitelist:
             result = await position_manager.check_position_limits(sample_long_order)
 
         assert result is True
+
+
+# ============================================================================
+# Portfolio Value Refresh — #404 regression
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_refresh_portfolio_value_available_balance_present(position_manager):
+    """Normal path: available_balance in response sets total_portfolio_value."""
+    position_manager.exchange.get_account_info = AsyncMock(
+        return_value={"available_balance": 3957.93, "total_wallet_balance": 3593.72}
+    )
+    result = await position_manager._refresh_portfolio_value()
+    assert result is True
+    assert position_manager.total_portfolio_value == pytest.approx(3957.93)
+
+
+@pytest.mark.asyncio
+async def test_refresh_portfolio_value_fallback_to_wallet_balance(position_manager):
+    """Fallback path (#404): available_balance absent, total_wallet_balance used.
+
+    Reproduces the production incident where availableBalance was missing from
+    the Binance Futures account response while the account was fully funded but
+    all margin committed to open positions, causing total_portfolio_value to
+    stay at 0.0 and every order to be rejected with source=balance.
+    """
+    position_manager.exchange.get_account_info = AsyncMock(
+        return_value={"total_wallet_balance": 3593.72, "maker_commission": 2}
+    )
+    result = await position_manager._refresh_portfolio_value()
+    assert result is True
+    assert position_manager.total_portfolio_value == pytest.approx(3593.72)
+
+
+@pytest.mark.asyncio
+async def test_refresh_portfolio_value_both_absent_returns_false(position_manager):
+    """Error path: neither available_balance nor total_wallet_balance returns False."""
+    position_manager.exchange.get_account_info = AsyncMock(
+        return_value={"maker_commission": 2, "can_trade": True}
+    )
+    result = await position_manager._refresh_portfolio_value()
+    assert result is False

--- a/tradeengine/position_manager.py
+++ b/tradeengine/position_manager.py
@@ -109,7 +109,9 @@ class PositionManager:
     async def _refresh_portfolio_value(self) -> bool:
         """Fetch real-time availableBalance from Binance exchange.
 
-        Uses availableBalance (Wallet Balance - Initial Margin - Open Order Margin).
+        Primary: availableBalance (Wallet Balance - Initial Margin - Open Order Margin).
+        Fallback: totalWalletBalance when availableBalance is absent (e.g. all margin
+        committed to open positions — the account is funded, just fully allocated).
         Implements a 5s cache duration.
         Returns True if update succeeded, False otherwise.
         """
@@ -137,11 +139,26 @@ class PositionManager:
                         f"Dynamic portfolio value updated: ${self.total_portfolio_value:,.2f} (available balance)"
                     )
                     return True
-                else:
-                    logger.error(
-                        "Failed to extract available_balance from Binance account info"
+
+                # availableBalance absent from Binance response — fall back to
+                # totalWalletBalance so a fully-margined account isn't treated as
+                # empty and every order rejected. (#404)
+                total_wallet = account_info.get("total_wallet_balance")
+                if total_wallet is not None:
+                    self.total_portfolio_value = float(total_wallet)
+                    self.portfolio_value_last_update = now
+                    logger.warning(
+                        "available_balance absent from Binance account info — "
+                        f"using total_wallet_balance=${self.total_portfolio_value:,.2f} as fallback. "
+                        f"Keys present: {sorted(account_info.keys())}"
                     )
-                    return False
+                    return True
+
+                logger.error(
+                    "Failed to extract available_balance or total_wallet_balance from "
+                    f"Binance account info. Keys present: {sorted(account_info.keys())}"
+                )
+                return False
             except Exception as e:
                 logger.error(f"Error fetching portfolio value from Binance: {e}")
                 return False


### PR DESCRIPTION
## Summary

Fixes the P0 production halt described in #404.

**Root cause:** `_refresh_portfolio_value` read `available_balance` from the Binance Futures account response. When `availableBalance` was absent (e.g. all margin committed to open positions), the function returned `False` without updating `total_portfolio_value`, leaving it at its default `0.0`. Every pre-trade risk check then failed with `source=balance / reason=insufficient_margin`, silently halting the platform for 9+ hours despite the account holding ~$8.5K of capital.

## Changes

- **`tradeengine/position_manager.py`**: After the primary `available_balance` lookup, fall back to `total_wallet_balance` (already surfaced by `get_account_info`). Emits a WARNING log with the keys present so future Binance API response-shape shifts are diagnosable without `kubectl exec`. (AC2 + AC4)
- **`tests/test_position_manager_comprehensive.py`**: Three new regression tests: normal path (available_balance present), fallback path (#404 scenario — total_wallet_balance used when available_balance absent), and error path (both absent → returns False). (AC1)

## Acceptance criteria status

- [x] AC1 — Regression test: `total_portfolio_value > 0` when given realistic Binance Futures response with no `available_balance`
- [x] AC2 — Fix: `total_portfolio_value` now reads correctly from `total_wallet_balance` fallback
- [ ] AC3 — Post-deploy: verify zero `source=balance` rejections after deploy (requires deployment)
- [x] AC4 — Defensive log: WARNING with present keys when primary field absent
- [ ] AC5 — Post-deploy: CIO signals start receiving non-rejected outcomes (requires deployment)
- [x] AC6 — Memory file written (tracked separately)

## Test results

```
1342 passed, 13 skipped — 77.5% coverage
```

Closes #404