### PR TITLE
[BUG] Consumer crash loop on NATS ConnectionClosedError — 97 restarts/32h, ~3 min cycle

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -789,3 +789,49 @@ class TestStaleSignalRefusal:
             await consumer._message_handler(mock_msg)
 
         mock_dispatcher.dispatch.assert_called_once()
+
+
+# Regression tests for #402 — NATS consumer crash loop on ConnectionClosedError
+
+
+@pytest.mark.asyncio
+async def test_stop_consuming_guards_against_closed_connection() -> None:
+    """stop_consuming() must not raise when the NATS connection is already closed.
+
+    Regression: previously, subscription.unsubscribe() raised ConnectionClosedError
+    from inside the finally block of start_consuming(), masking the original error
+    and crashing the lifespan task (97 restarts in 32h, exitCode=0, ~3 min cycle).
+    """
+    import nats.errors
+
+    consumer = SignalConsumer()
+    mock_nc = AsyncMock()
+    mock_sub = AsyncMock()
+    mock_sub.unsubscribe.side_effect = nats.errors.ConnectionClosedError()
+    consumer.nc = mock_nc
+    consumer.subscription = mock_sub
+
+    # Must complete without raising
+    await consumer.stop_consuming()
+
+    assert consumer.nc is None, (
+        "nc must be reset to None so next start triggers re-init"
+    )
+    assert consumer.subscription is None
+
+
+@pytest.mark.asyncio
+async def test_stop_consuming_resets_state_on_clean_close() -> None:
+    """stop_consuming() resets nc and subscription to None on a normal close."""
+    consumer = SignalConsumer()
+    mock_nc = AsyncMock()
+    mock_sub = AsyncMock()
+    consumer.nc = mock_nc
+    consumer.subscription = mock_sub
+
+    await consumer.stop_consuming()
+
+    assert consumer.nc is None
+    assert consumer.subscription is None
+    mock_sub.unsubscribe.assert_awaited_once()
+    mock_nc.close.assert_awaited_once()

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any
 
+import nats.errors
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Query
 from fastapi.responses import PlainTextResponse
 from opentelemetry import trace
@@ -198,6 +199,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             def task_done_callback(task: asyncio.Task) -> None:  # type: ignore[type-arg]
                 try:
                     task.result()  # This will raise any exception that occurred
+                except nats.errors.ConnectionClosedError as e:
+                    logger.error(
+                        f"❌ NATS consumer connection closed: {e}", exc_info=True
+                    )
+                    logger.info("Reconnecting NATS consumer...")
+                    # nc is already None after stop_consuming() reset it; belt-and-suspenders
+                    signal_consumer.nc = None
+                    try:
+                        new_task = asyncio.create_task(
+                            signal_consumer.start_consuming()
+                        )
+                        app.state.consumer_task = new_task
+                        new_task.add_done_callback(task_done_callback)
+                        logger.info("✅ NATS consumer reconnect+restart scheduled")
+                    except Exception as restart_error:
+                        logger.error(
+                            f"❌ Failed to restart NATS consumer: {restart_error}"
+                        )
                 except Exception as e:
                     logger.error(f"❌ NATS consumer task failed: {e}", exc_info=True)
                     # Try to restart the consumer on failure

--- a/tradeengine/consumer.py
+++ b/tradeengine/consumer.py
@@ -491,12 +491,20 @@ class SignalConsumer:
         self.running = False
 
         if self.subscription:
-            await self.subscription.unsubscribe()
-            logger.info("NATS subscription closed")
+            try:
+                await self.subscription.unsubscribe()
+                logger.info("NATS subscription closed")
+            except nats.errors.ConnectionClosedError:
+                logger.info("NATS subscription already closed (connection was dropped)")
+            self.subscription = None
 
         if self.nc:
-            await self.nc.close()
-            logger.info("NATS consumer stopped")
+            try:
+                await self.nc.close()
+                logger.info("NATS consumer stopped")
+            except Exception:
+                pass
+            self.nc = None
 
 
 # Global consumer instance


### PR DESCRIPTION
## Summary

Fixes the NATS consumer crash loop (97 pod restarts in 32h, ~3 min cycle, exitCode=0) caused by a double `ConnectionClosedError` raise in the cleanup path.

## Root cause

When `ConnectionClosedError` fired at `nc.subscribe()` in `start_consuming()`, the `finally` block called `stop_consuming()`, which unconditionally called `subscription.unsubscribe()` on an already-closed connection — raising a second `ConnectionClosedError` that was NOT caught, propagating out of the task and causing the pod to exit.

## Changes

### `tradeengine/consumer.py` — AC1
- Wrapped `subscription.unsubscribe()` in `try/except nats.errors.ConnectionClosedError` in `stop_consuming()`
- Also guarded `nc.close()` against generic exceptions
- Reset `self.nc = None` and `self.subscription = None` after cleanup so next `start_consuming()` call triggers `initialize()` for a fresh reconnect

### `tradeengine/api.py` — AC2
- Added `import nats.errors`
- In `task_done_callback`: catch `ConnectionClosedError` specifically, explicitly reset `signal_consumer.nc = None` before scheduling restart (belt-and-suspenders with the consumer-side reset)

### `tests/test_consumer.py` — AC3
- `test_stop_consuming_guards_against_closed_connection`: asserts `stop_consuming()` completes without raising when `unsubscribe()` raises `ConnectionClosedError`
- `test_stop_consuming_resets_state_on_clean_close`: asserts `nc` and `subscription` are `None` after a normal stop

## Verification

```
tests/test_consumer.py — 32 passed (including 2 new regression tests)
ruff — all checks passed
bandit — passed
```

Closes #402
Umbrella: PetroSa2/petrosa_k8s#679