### PR TITLE
feat: tradeengine evaluator producer — publish evaluator.tradeengine.verdict (#417)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ opentelemetry-instrumentation-urllib3>=0.41b0
 opentelemetry-sdk>=1.20.0
 opentelemetry-semantic-conventions>=0.41b0
 passlib[bcrypt]==1.7.4
-petrosa-otel[all]>=1.0.6
+petrosa-otel[all]>=1.1.0
 prometheus-client==0.23.1
 pydantic==2.12.4
 pydantic-settings==2.12.0

--- a/tests/unit/test_health_evaluator.py
+++ b/tests/unit/test_health_evaluator.py
@@ -1,0 +1,276 @@
+"""Unit tests for TradeEngineHealthEvaluator (#417, P2.7 AC5).
+
+Note: several other test modules in this repo install
+``sys.modules["petrosa_otel"] = MagicMock()`` at module-import time
+(test_consumer.py, test_nats_trace_propagation.py, test_api_lifespan_integration.py,
+test_issue_355_exchange_failed_status.py). To avoid colliding with that global
+pollution under any collection order, this module performs its
+``petrosa_otel.evaluators`` imports **inside the test bodies** (after the
+autouse fixture below has restored the real package), never at module top.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _real_petrosa_otel():
+    """Save any mock stub, force-load the real package, restore on teardown."""
+    saved = {k: v for k, v in sys.modules.items() if k.startswith("petrosa_otel")}
+    for key in list(saved):
+        del sys.modules[key]
+    importlib.import_module("petrosa_otel")
+    importlib.import_module("petrosa_otel.evaluators")
+    yield
+    for key in list(sys.modules):
+        if (
+            key.startswith("petrosa_otel")
+            or key == "tradeengine.evaluators"
+            or key.startswith("tradeengine.evaluators.")
+        ):
+            del sys.modules[key]
+    sys.modules.update(saved)
+
+
+class FakeClock:
+    def __init__(self, start: datetime, step: timedelta) -> None:
+        self._t = start
+        self._step = step
+
+    def __call__(self) -> datetime:
+        now = self._t
+        self._t = self._t + self._step
+        return now
+
+
+class MetricsSource:
+    def __init__(self) -> None:
+        self.snap: dict[str, Any] = {
+            "risk_checks": 0.0,
+            "risk_rejections": 0.0,
+            "order_latency_sum": 0.0,
+            "order_latency_count": 0.0,
+            "divergences": 0.0,
+        }
+
+    def __call__(self) -> dict[str, Any]:
+        return dict(self.snap)
+
+
+class FakeNats:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, bytes]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.messages.append((subject, payload))
+
+
+def _make(source, clock, *, publisher=None, n: int = 1):
+    from petrosa_otel.evaluators import ConsecutiveSamplesHysteresis
+
+    from tradeengine.evaluators import TradeEngineHealthEvaluator
+
+    return TradeEngineHealthEvaluator(
+        metrics_source=source,
+        publisher=publisher,
+        hysteresis=ConsecutiveSamplesHysteresis(n=n),
+        time_source=clock,
+    )
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock(datetime(2026, 5, 28, 0, 0, 0, tzinfo=UTC), timedelta(seconds=15))
+
+
+@pytest.mark.asyncio
+async def test_first_sample_is_unknown(clock):
+    ev = _make(MetricsSource(), clock)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unknown"
+    assert "baseline" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_metrics_progress_within_thresholds(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    src.snap.update(
+        {
+            "risk_checks": 10.0,
+            "risk_rejections": 1.0,
+            "order_latency_sum": 5.0,  # 10 orders @ 0.5s
+            "order_latency_count": 10.0,
+        }
+    )
+    verdict, reason = await ev.evaluate()
+    assert verdict == "healthy"
+    assert "checks 10" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_on_position_divergence(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    src.snap["divergences"] = 3.0
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "divergence" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_on_high_order_latency(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    # 5 orders averaging 15s — above the 10s threshold.
+    src.snap.update({"order_latency_sum": 75.0, "order_latency_count": 5.0})
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "latency" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_on_zero_pre_trade_pass_rate(clock):
+    """The #404 scenario: every pre-trade check rejected."""
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    src.snap.update({"risk_checks": 10.0, "risk_rejections": 10.0})
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "pass rate 0%" in reason
+
+
+@pytest.mark.asyncio
+async def test_rejection_check_dormant_below_volume(clock):
+    """A handful of rejections with low check volume must not trip the verdict."""
+    src = MetricsSource()
+    ev = _make(src, clock)
+    await ev.evaluate()
+    src.snap.update({"risk_checks": 2.0, "risk_rejections": 2.0})
+    verdict, _ = await ev.evaluate()
+    assert verdict == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_counter_reset_returns_unknown(clock):
+    src = MetricsSource()
+    ev = _make(src, clock)
+    src.snap["risk_checks"] = 500.0
+    await ev.evaluate()
+    src.snap["risk_checks"] = 5.0  # pod restart resets the counter
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unknown"
+    assert "reset" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_publishes_on_tradeengine_subject(clock):
+    from petrosa_otel.evaluators.publisher import (
+        EVALUATOR_SUBJECT_TEMPLATE,
+        NatsVerdictPublisher,
+    )
+
+    src = MetricsSource()
+    nats = FakeNats()
+    ev = _make(src, clock, publisher=NatsVerdictPublisher(nats_client=nats), n=1)
+
+    await ev.tick()  # unknown baseline
+    src.snap.update({"risk_checks": 5.0, "order_latency_count": 5.0})
+    await ev.tick()  # healthy
+
+    assert nats.messages, "evaluator did not publish"
+    subject, payload = nats.messages[-1]
+    assert subject == "evaluator.tradeengine.verdict"
+    assert subject == EVALUATOR_SUBJECT_TEMPLATE.format(subsystem="tradeengine")
+    body = json.loads(payload.decode())
+    assert body["subsystem"] == "tradeengine"
+    assert body["verdict"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_hysteresis_suppresses_single_flap(clock):
+    src = MetricsSource()
+    ev = _make(src, clock, n=3)
+
+    await ev.tick()  # unknown baseline
+    for _ in range(3):
+        src.snap["risk_checks"] = src.snap["risk_checks"] + 5.0
+        v = await ev.tick()
+    assert v.verdict == "healthy"
+
+    # One divergence sample must NOT flip the committed verdict (n=3).
+    src.snap["divergences"] = src.snap["divergences"] + 1.0
+    v = await ev.tick()
+    assert v.verdict == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_start_stop_without_nats_does_not_crash(clock):
+    src = MetricsSource()
+    ev = _make(src, clock, n=1)
+    await ev.start()
+    await asyncio.sleep(0.01)
+    await ev.stop()
+    await ev.stop()  # idempotent
+
+
+def test_build_returns_none_when_nats_disabled():
+    from tradeengine.evaluators import build_tradeengine_health_evaluator
+
+    assert build_tradeengine_health_evaluator(nats_servers=None) is None
+    assert build_tradeengine_health_evaluator(nats_servers="") is None
+
+
+def test_counter_total_aggregates_labels():
+    from tradeengine.evaluators.health_evaluator import (
+        _counter_total,
+        _histogram_sum_count,
+    )
+
+    class _Family:
+        def __init__(self, samples):
+            self.samples = samples
+
+    class _Sample:
+        def __init__(self, name, value):
+            self.name = name
+            self.value = value
+
+    class _Metric:
+        def __init__(self, samples):
+            self._samples = samples
+
+        def collect(self):
+            return [_Family(self._samples)]
+
+    counter = _Metric(
+        [
+            _Sample("foo_total", 3.0),
+            _Sample("foo_total", 7.0),
+            _Sample("foo_created", 0.0),  # ignored
+        ]
+    )
+    assert _counter_total(counter) == 10.0
+
+    histogram = _Metric(
+        [
+            _Sample("foo_sum", 12.5),
+            _Sample("foo_count", 5.0),
+            _Sample("foo_sum", 2.5),
+            _Sample("foo_count", 1.0),
+            _Sample("foo_bucket", 99.0),  # ignored
+        ]
+    )
+    assert _histogram_sum_count(histogram) == (15.0, 6.0)

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -266,6 +266,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         else:
             logger.warning("⚠️ NATS consumer not initialized (likely disabled)")
 
+        # Start health evaluator (publishes evaluator.tradeengine.verdict).
+        # Read-only over existing Prometheus metrics. Guarded so an older
+        # petrosa-otel that lacks the evaluators framework degrades gracefully.
+        try:
+            from tradeengine.evaluators import build_tradeengine_health_evaluator
+
+            _evaluator = build_tradeengine_health_evaluator(
+                nats_servers=_te_settings.nats_servers
+            )
+            if _evaluator is not None:
+                await _evaluator.start()
+                app.state.health_evaluator = _evaluator
+                logger.info("✅ Health evaluator started")
+        except ImportError:
+            logger.warning(
+                "petrosa_otel.evaluators unavailable; health evaluator disabled"
+            )
+
         logger.info("Trading engine startup completed successfully")
 
     except Exception as e:
@@ -302,6 +320,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 await consumer_task
             except asyncio.CancelledError:
                 logger.info("NATS consumer task cancelled successfully")
+
+        # Stop health evaluator
+        if hasattr(app.state, "health_evaluator"):
+            await app.state.health_evaluator.stop()
+            logger.info("✅ Health evaluator stopped")
 
         # Stop position reconciler
         if hasattr(app.state, "position_reconciler"):

--- a/tradeengine/evaluators/__init__.py
+++ b/tradeengine/evaluators/__init__.py
@@ -1,0 +1,18 @@
+"""tradeengine subsystem evaluator (P2.7, petrosa_k8s#697 AC5 / #417).
+
+Adopts the shared `petrosa_otel.evaluators` framework (P2.1) so tradeengine
+publishes a structured health verdict on ``evaluator.tradeengine.verdict``,
+closing the last of the five "silent service" gaps that keep
+FR17 / FR23 / FR32 at YELLOW. Read-only over existing Prometheus metrics —
+this module never touches the order / risk / position logic.
+"""
+
+from tradeengine.evaluators.health_evaluator import (
+    TradeEngineHealthEvaluator,
+    build_tradeengine_health_evaluator,
+)
+
+__all__ = [
+    "TradeEngineHealthEvaluator",
+    "build_tradeengine_health_evaluator",
+]

--- a/tradeengine/evaluators/health_evaluator.py
+++ b/tradeengine/evaluators/health_evaluator.py
@@ -1,0 +1,334 @@
+"""tradeengine health evaluator (P2.7, petrosa_k8s#697 AC5 / #417).
+
+Emits ``evaluator.tradeengine.verdict`` via the shared P2.1 framework
+(:mod:`petrosa_otel.evaluators`) so the operator dashboard's evaluator strip
+counts tradeengine among the reporting subsystems (FR17 / FR23 / FR32).
+
+The verdict is sourced **read-only** from existing Prometheus instruments
+already exported by tradeengine — this module deliberately does not touch the
+order / risk / position-tracking code. Three signals are sampled on each tick:
+
+1. **Pre-trade-check pass rate** — `tradeengine_risk_rejections_total` /
+   `tradeengine_risk_checks_total`. A sustained high rejection rate (per #404
+   the realistic failure is *all* checks failing → 0% pass rate) trips the
+   verdict; a small delta below the minimum-volume guard keeps the check
+   dormant on quiet windows.
+2. **Order-placement latency** — `tradeengine_order_execution_latency_seconds`
+   histogram. Mean over the tick (`Δsum / Δcount`) above the threshold trips
+   the verdict.
+3. **Position-tracker consistency** — `tradeengine_position_reconciliation_
+   divergences_total` (FR65). Any sustained increase per tick means the local
+   position state has drifted from Binance.
+
+Verdict vocabulary is the framework's locked three-state contract
+(``healthy`` / ``unhealthy`` / ``unknown``); any breached signal maps to
+``unhealthy`` with a single-line reason naming the tripped signal (NFR-O5).
+
+Hysteresis / cadence (AC4 / AC7, FR18 per-evaluator ``decision_window``):
+emits every ``EMIT_INTERVAL_S`` (15s) with `ConsecutiveSamplesHysteresis(n=3)`
+→ ~45s decision window. Documented at module scope to keep the verdict stable
+under bursty traffic while a sustained problem surfaces within ~45s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from collections.abc import Callable
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+import nats
+from petrosa_otel.evaluators import (
+    ConsecutiveSamplesHysteresis,
+    Evaluator,
+    NatsVerdictPublisher,
+)
+
+if TYPE_CHECKING:
+    from petrosa_otel.evaluators.base import HysteresisPolicy
+    from petrosa_otel.evaluators.publisher import VerdictPublisher
+
+logger = logging.getLogger(__name__)
+
+SUBSYSTEM = "tradeengine"
+
+# Cadence + smoothing (documented per AC4 / AC7).
+EMIT_INTERVAL_S = 15.0
+HYSTERESIS_SAMPLES = 3
+
+# Pre-trade-check: rejection rate above this fraction over a tick trips
+# unhealthy. 0.5 is conservative — catches the #404 zero-pass-rate case (100%
+# rejections) without flapping on a handful of normal rejections.
+DEFAULT_REJECTION_RATE_THRESHOLD = 0.5
+# Minimum risk-check delta within a tick before the rejection-rate check may
+# trip. Avoids false positives at very low order volume.
+DEFAULT_MIN_RISK_CHECKS = 4
+# Order-placement latency: mean per tick above this trips unhealthy. Binance
+# orders should complete in ≤ a couple of seconds; sustained >10s signals
+# exchange/network degradation rather than a single slow order.
+DEFAULT_LATENCY_THRESHOLD_S = 10.0
+# Rolling window for the rejection-rate baseline (8 ticks ≈ 2 min at 15s).
+DEFAULT_BASELINE_WINDOW = 8
+
+
+def _counter_total(metric: Any) -> float:
+    """Sum a Prometheus Counter across all label permutations."""
+    total = 0.0
+    for family in metric.collect():
+        for sample in family.samples:
+            if sample.name.endswith("_total"):
+                total += sample.value
+    return total
+
+
+def _histogram_sum_count(metric: Any) -> tuple[float, float]:
+    """Return ``(sum, count)`` aggregated across all label permutations."""
+    s = 0.0
+    c = 0.0
+    for family in metric.collect():
+        for sample in family.samples:
+            if sample.name.endswith("_sum"):
+                s += sample.value
+            elif sample.name.endswith("_count"):
+                c += sample.value
+    return s, c
+
+
+class TradeEngineHealthEvaluator(Evaluator):
+    """Subsystem evaluator for tradeengine risk/latency/position health."""
+
+    def __init__(
+        self,
+        *,
+        metrics_source: Callable[[], dict[str, Any]],
+        publisher: VerdictPublisher | None = None,
+        nats_servers: str | None = None,
+        hysteresis: HysteresisPolicy | None = None,
+        rejection_rate_threshold: float = DEFAULT_REJECTION_RATE_THRESHOLD,
+        min_risk_checks: int = DEFAULT_MIN_RISK_CHECKS,
+        latency_threshold_s: float = DEFAULT_LATENCY_THRESHOLD_S,
+        baseline_window: int = DEFAULT_BASELINE_WINDOW,
+        emit_interval_s: float = EMIT_INTERVAL_S,
+        time_source: Callable[[], datetime] | None = None,
+    ) -> None:
+        super().__init__(
+            subsystem=SUBSYSTEM,
+            publisher=publisher,
+            hysteresis=hysteresis or ConsecutiveSamplesHysteresis(n=HYSTERESIS_SAMPLES),
+        )
+        self._metrics_source = metrics_source
+        self._nats_servers = nats_servers
+        self._owns_publisher = publisher is None and nats_servers is not None
+        self._rejection_rate_threshold = rejection_rate_threshold
+        self._min_risk_checks = max(1, min_risk_checks)
+        self._latency_threshold_s = latency_threshold_s
+        self._emit_interval_s = emit_interval_s
+        self._time = time_source or (lambda: datetime.now(UTC))
+
+        self._rejection_rate_baseline: deque[float] = deque(
+            maxlen=max(1, baseline_window)
+        )
+        self._prev_checks: float | None = None
+        self._prev_rejections: float = 0.0
+        self._prev_latency_sum: float = 0.0
+        self._prev_latency_count: float = 0.0
+        self._prev_divergences: float = 0.0
+        self._prev_sample_at: datetime | None = None
+
+        self._own_nc: nats.aio.client.Client | None = None
+        self._emit_task: asyncio.Task[Any] | None = None
+
+    # ----- lifecycle -----
+
+    async def start(self) -> None:
+        """Connect (if owning the publisher) and start the periodic emit loop."""
+        if self._emit_task is not None:
+            return
+        if self._owns_publisher and self._publisher is None and self._nats_servers:
+            try:
+                self._own_nc = await nats.connect(
+                    servers=self._nats_servers,
+                    name="petrosa-tradeengine-evaluator",
+                    allow_reconnect=True,
+                )
+                self._publisher = NatsVerdictPublisher(nats_client=self._own_nc)
+                logger.info(
+                    "tradeengine_health_evaluator NATS connected",
+                    extra={"servers": self._nats_servers},
+                )
+            except Exception as exc:  # noqa: BLE001 — degrade, never crash startup
+                logger.warning(
+                    "tradeengine_health_evaluator NATS connect failed: %s — "
+                    "evaluator will tick without publishing",
+                    exc,
+                )
+                self._own_nc = None
+        self._emit_task = asyncio.create_task(self._emit_loop())
+        logger.info(
+            "tradeengine_health_evaluator_started",
+            extra={"subsystem": SUBSYSTEM, "emit_interval_s": self._emit_interval_s},
+        )
+
+    async def stop(self) -> None:
+        """Stop the emit loop and close the owned NATS connection (if any)."""
+        if self._emit_task is not None:
+            self._emit_task.cancel()
+            try:
+                await self._emit_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"tradeengine_health_evaluator stop error: {exc}")
+            self._emit_task = None
+        if self._own_nc is not None:
+            try:
+                await self._own_nc.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"tradeengine_health_evaluator close error: {exc}")
+            self._own_nc = None
+            self._publisher = None
+
+    async def _emit_loop(self) -> None:
+        while True:
+            try:
+                await self.tick()
+            except Exception as exc:  # noqa: BLE001 — never crash the loop
+                logger.warning(
+                    "tradeengine_health_evaluator_tick_failed",
+                    extra={"error": str(exc)},
+                )
+            await asyncio.sleep(self._emit_interval_s)
+
+    # ----- framework hook -----
+
+    async def evaluate(self) -> tuple[str, str]:
+        """Compute the raw ``(verdict, reason)`` sample for the current state."""
+        snapshot = self._metrics_source()
+        now = self._time()
+
+        checks = float(snapshot.get("risk_checks", 0.0) or 0.0)
+        rejections = float(snapshot.get("risk_rejections", 0.0) or 0.0)
+        latency_sum = float(snapshot.get("order_latency_sum", 0.0) or 0.0)
+        latency_count = float(snapshot.get("order_latency_count", 0.0) or 0.0)
+        divergences = float(snapshot.get("divergences", 0.0) or 0.0)
+
+        prev_checks = self._prev_checks
+        prev_rejections = self._prev_rejections
+        prev_latency_sum = self._prev_latency_sum
+        prev_latency_count = self._prev_latency_count
+        prev_divergences = self._prev_divergences
+        prev_at = self._prev_sample_at
+
+        self._prev_checks = checks
+        self._prev_rejections = rejections
+        self._prev_latency_sum = latency_sum
+        self._prev_latency_count = latency_count
+        self._prev_divergences = divergences
+        self._prev_sample_at = now
+
+        if prev_checks is None or prev_at is None:
+            return "unknown", "establishing baseline (first sample)"
+
+        if (
+            checks < prev_checks
+            or rejections < prev_rejections
+            or latency_sum < prev_latency_sum
+            or latency_count < prev_latency_count
+            or divergences < prev_divergences
+        ):
+            self._rejection_rate_baseline.clear()
+            return "unknown", "counter reset detected; rebaselining"
+
+        d_divergences = divergences - prev_divergences
+        d_checks = checks - prev_checks
+        d_rejections = rejections - prev_rejections
+        d_latency_sum = latency_sum - prev_latency_sum
+        d_latency_count = latency_count - prev_latency_count
+
+        # 1) Position-tracker consistency — any new divergence is unhealthy.
+        if d_divergences > 0:
+            return (
+                "unhealthy",
+                f"position-tracker divergence: +{int(d_divergences)} in last "
+                f"{int(self._emit_interval_s)}s",
+            )
+
+        # 2) Order-placement latency.
+        if d_latency_count > 0:
+            mean_latency = d_latency_sum / d_latency_count
+            if mean_latency > self._latency_threshold_s:
+                return (
+                    "unhealthy",
+                    f"order-placement latency {mean_latency:.2f}s mean > "
+                    f"{self._latency_threshold_s:.1f}s threshold",
+                )
+
+        # 3) Pre-trade-check pass rate.
+        if d_checks >= self._min_risk_checks:
+            rejection_rate = d_rejections / d_checks if d_checks > 0 else 0.0
+            self._rejection_rate_baseline.append(rejection_rate)
+            if rejection_rate > self._rejection_rate_threshold:
+                pass_pct = (1.0 - rejection_rate) * 100
+                return (
+                    "unhealthy",
+                    f"pre-trade-check pass rate {pass_pct:.0f}% — "
+                    f"{int(d_rejections)}/{int(d_checks)} rejected",
+                )
+
+        return (
+            "healthy",
+            f"checks {int(d_checks)}, rejections {int(d_rejections)}, "
+            f"latency_count {int(d_latency_count)}",
+        )
+
+
+def build_tradeengine_health_evaluator(
+    *,
+    nats_servers: str | None = None,
+) -> TradeEngineHealthEvaluator | None:
+    """Construct an evaluator wired to tradeengine's existing Prometheus metrics.
+
+    The evaluator owns a dedicated NATS connection for publishing verdicts
+    (lazy: opened in ``start()``; closed in ``stop()``). Returns ``None`` when
+    ``nats_servers`` is empty (NATS disabled).
+    """
+    if not nats_servers:
+        logger.info(
+            "tradeengine_health_evaluator not started: NATS disabled (no servers)"
+        )
+        return None
+
+    # Import metric objects lazily so this module is importable without
+    # tradeengine.metrics side effects in tests.
+    from tradeengine.metrics import (
+        order_execution_latency_seconds,
+        risk_checks_total,
+        risk_rejections_total,
+    )
+    from tradeengine.position_reconciler import reconciliation_divergences_total
+
+    def _snapshot() -> dict[str, Any]:
+        latency_sum, latency_count = _histogram_sum_count(
+            order_execution_latency_seconds
+        )
+        return {
+            "risk_checks": _counter_total(risk_checks_total),
+            "risk_rejections": _counter_total(risk_rejections_total),
+            "order_latency_sum": latency_sum,
+            "order_latency_count": latency_count,
+            "divergences": _counter_total(reconciliation_divergences_total),
+        }
+
+    return TradeEngineHealthEvaluator(
+        metrics_source=_snapshot,
+        nats_servers=nats_servers,
+    )


### PR DESCRIPTION
## Summary

Adopts the shared **P2.1 evaluator framework** (`petrosa_otel.evaluators`) so `petrosa-tradeengine` publishes a structured health verdict on **`evaluator.tradeengine.verdict`** — closing the **last** of the five "silent service" gaps that keep **FR17 / FR23 / FR32** at 🟡 YELLOW (parent EPIC [petrosa_k8s#697](https://github.com/PetroSa2/petrosa_k8s/issues/697), AC5).

Implements [#417](https://github.com/PetroSa2/petrosa-tradeengine/issues/417). Completes the P2.7 sweep: socket-client #123 ✅, realtime-strategies #175 ✅, bot-ta-analysis #248 ✅, **tradeengine #417 (this PR)** — only data-extractor #259 remains (CronJob nuance).

## What changed

- **`TradeEngineHealthEvaluator`** (`tradeengine/evaluators/health_evaluator.py`) is **read-only** over existing Prometheus instruments — it deliberately does not touch the order, risk, or position-tracking code paths. Three signals (per #697 AC5):
  - **Pre-trade-check pass rate** — `tradeengine_risk_checks_total` + `tradeengine_risk_rejections_total`. Sustained rejection rate above 50% trips it; per #404 the realistic failure is 100% rejection → 0% pass rate. Guarded by a minimum-volume threshold so a handful of normal rejections in a quiet window stays healthy.
  - **Order-placement latency** — `tradeengine_order_execution_latency_seconds` histogram. Mean per tick (`Δsum/Δcount`) above 10s trips it.
  - **Position-tracker consistency** — `tradeengine_position_reconciliation_divergences_total` (FR65). Any new divergence per tick trips it.
- Publishes via the framework `NatsVerdictPublisher` on `evaluator.tradeengine.verdict`. The evaluator **owns its own dedicated NATS connection** (lazy: opened in `start()`, closed in `stop()`), mirroring the self-owned pattern in `tradeengine/services/execution_event_publisher.py`. No coupling to the consumer's connection.
- **Hysteresis (AC4 / AC7):** `ConsecutiveSamplesHysteresis(n=3)` over 15s → ~45s decision window (documented in the module docstring).
- **Lifecycle:** wired in `tradeengine/api.py` lifespan — start after the NATS consumer is up, stop before the position reconciler. Guarded so an older `petrosa-otel` degrades gracefully (ImportError → evaluator disabled).
- **Dependency:** `petrosa-otel` pin `>=1.0.6` → `>=1.1.0` (first published version shipping the evaluators framework).

### Test-isolation note (pre-existing repo hazard)
Four test modules (`test_consumer.py`, `test_nats_trace_propagation.py`, `test_api_lifespan_integration.py`, `test_issue_355_exchange_failed_status.py`) install `sys.modules["petrosa_otel"] = MagicMock()` at module-import time. The new test module avoids this collision by performing `petrosa_otel.evaluators` imports **inside test bodies** (after an autouse fixture restores the real package via the same save/evict/restore pattern as the existing `real_petrosa_otel` fixture in `tests/conftest.py`).

### Verdict vocabulary note
The framework's `EvaluatorVerdict` enforces the locked three-state contract `healthy | unhealthy | unknown` (no `degraded`). Any breached signal maps to **`unhealthy`** with a single-line reason naming the tripped signal (NFR-O5). Consistent with all shipped producers.

## Acceptance criteria

- [x] **AC1** — `TradeEngineHealthEvaluator(petrosa_otel.evaluators.Evaluator)` exists and is started/stopped in the service lifecycle (api.py lifespan).
- [x] **AC2** — Publishes `evaluator.tradeengine.verdict` via the framework publisher with verdict + reason.
- [x] **AC3** — The three health signals feed the raw verdict.
- [x] **AC4** — Hysteresis applied; threshold/window documented.
- [x] **AC5** — Unit test covers verdict transitions, including the pre-trade-check-pass-rate=0% → UNHEALTHY case.
- [x] **AC6** — CI (ruff / mypy / tests) — validated locally; see test plan.

## Test plan

- [x] `pytest tests/unit/test_health_evaluator.py` — 12 tests: unknown-on-first-sample, healthy path, unhealthy on position divergence / high latency / zero pre-trade pass rate, dormant guard below volume, counter-reset rebaseline, publish-subject assertion (`evaluator.tradeengine.verdict`), hysteresis flap suppression, start/stop without NATS, `build_*` returns None when NATS disabled, and Prometheus aggregation helpers (`_counter_total`, `_histogram_sum_count`).
- [x] Full suite green: **1449 passed, 13 skipped** under the repo's `--cov-fail-under=20%` gate.
- [x] `ruff check` clean; `ruff format` clean; bandit `-ll` 0 issues.

Closes #417
