### PR TITLE
feat(419): tradeengine halt-suspected alert (P8-AC7, FR66 extension)

### DIFF
--- a/tests/test_halt_suspected_detector.py
+++ b/tests/test_halt_suspected_detector.py
@@ -1,0 +1,209 @@
+"""Tests for the halt-suspected detector (#419, FR66 extension)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from shared.constants import UTC
+from tradeengine.services.halt_suspected_detector import HaltSuspectedDetector
+
+
+class _StubPublisher:
+    """Captures publish calls in-order so the test can assert exact emits."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def publish(
+        self,
+        *,
+        alert_name: str,
+        severity: str,
+        payload: dict[str, Any],
+        timestamp: datetime | None = None,
+    ) -> bool:
+        self.calls.append(
+            {
+                "alert_name": alert_name,
+                "severity": severity,
+                "payload": payload,
+                "timestamp": timestamp,
+            }
+        )
+        return True
+
+
+class _ManualClock:
+    def __init__(self, start: datetime) -> None:
+        self.now_value = start
+
+    def __call__(self) -> datetime:
+        return self.now_value
+
+    def advance(self, seconds: float) -> None:
+        self.now_value = self.now_value + timedelta(seconds=seconds)
+
+
+def _make_detector(
+    *,
+    window_seconds: int = 300,
+    count_threshold: int = 10,
+) -> tuple[HaltSuspectedDetector, _StubPublisher, _ManualClock]:
+    publisher = _StubPublisher()
+    clock = _ManualClock(datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC))
+    detector = HaltSuspectedDetector(
+        publisher=publisher,
+        now=clock,
+        window_seconds=window_seconds,
+        count_threshold=count_threshold,
+    )
+    return detector, publisher, clock
+
+
+@pytest.mark.asyncio
+async def test_emit_when_count_threshold_exceeded_within_window():
+    """AC7.a trigger A: >10 balance rejections inside the 5-min window."""
+
+    detector, publisher, clock = _make_detector()
+
+    # 11 balance rejections inside a 5-minute window must trip the threshold.
+    for i in range(11):
+        await detector.on_rejection(
+            rejection_source="balance",
+            decision_id=f"d-{i}",
+        )
+        clock.advance(10)
+
+    halt_calls = [c for c in publisher.calls if c["alert_name"] == "halt_suspected"]
+    assert len(halt_calls) == 1, publisher.calls
+    assert halt_calls[0]["severity"] == "critical"
+    payload = halt_calls[0]["payload"]
+    assert payload["rejected_count"] == 11
+    assert payload["last_10_decision_ids"] == [f"d-{i}" for i in range(1, 11)]
+    assert detector.is_halt_active is True
+
+
+@pytest.mark.asyncio
+async def test_emit_when_window_duration_exceeded_with_all_rejected():
+    """AC7.a trigger B: continuous rejections spanning more than the window."""
+
+    detector, publisher, clock = _make_detector(
+        window_seconds=300,
+        count_threshold=999,  # disable trigger A so we exercise trigger B
+    )
+
+    # 6 rejections spread across >5 minutes, with no successful completion in between.
+    await detector.on_rejection(rejection_source="balance", decision_id="d-0")
+    for i in range(1, 7):
+        clock.advance(60)  # one minute apart
+        await detector.on_rejection(rejection_source="balance", decision_id=f"d-{i}")
+
+    halt_calls = [c for c in publisher.calls if c["alert_name"] == "halt_suspected"]
+    assert len(halt_calls) == 1, publisher.calls
+    assert detector.is_halt_active is True
+
+
+@pytest.mark.asyncio
+async def test_non_balance_completion_clears_halt_state():
+    """AC7.c: a non-balance-rejected completion emits halt_cleared and resets state."""
+
+    detector, publisher, clock = _make_detector()
+
+    for i in range(11):
+        await detector.on_rejection(
+            rejection_source="balance",
+            decision_id=f"d-{i}",
+        )
+        clock.advance(5)
+
+    assert detector.is_halt_active is True
+
+    # A fill arrives — emits halt_cleared and resets the ledger.
+    clock.advance(5)
+    await detector.on_completion()
+
+    cleared_calls = [c for c in publisher.calls if c["alert_name"] == "halt_cleared"]
+    assert len(cleared_calls) == 1
+    assert cleared_calls[0]["severity"] == "info"
+    assert detector.is_halt_active is False
+    assert detector.tracked_rejection_count == 0
+
+
+@pytest.mark.asyncio
+async def test_repeat_threshold_crossings_dedup_until_cleared():
+    """While halt is active, subsequent threshold crossings must not re-emit."""
+
+    detector, publisher, clock = _make_detector()
+
+    for i in range(15):
+        await detector.on_rejection(
+            rejection_source="balance",
+            decision_id=f"d-{i}",
+        )
+        clock.advance(5)
+
+    halt_calls = [c for c in publisher.calls if c["alert_name"] == "halt_suspected"]
+    assert len(halt_calls) == 1, "halt_suspected must dedup until cleared"
+
+
+@pytest.mark.asyncio
+async def test_non_balance_rejection_resets_ledger_without_emitting_cleared():
+    """A non-balance rejection on a *cold* detector resets the ledger silently."""
+
+    detector, publisher, clock = _make_detector()
+
+    # Three balance rejections, not enough to trigger.
+    for i in range(3):
+        await detector.on_rejection(rejection_source="balance", decision_id=f"d-{i}")
+        clock.advance(5)
+
+    # A risk_check rejection arrives — counts as non-balance, resets ledger.
+    await detector.on_rejection(rejection_source="risk_check", decision_id="d-risk")
+
+    assert detector.tracked_rejection_count == 0
+    # halt was never active, so no halt_cleared either.
+    assert publisher.calls == []
+
+
+@pytest.mark.asyncio
+async def test_below_both_thresholds_does_not_emit():
+    """A short burst that misses both triggers must stay silent.
+
+    5 balance rejections spread across 240 s: count is well under
+    ``count_threshold=10`` AND the run is shorter than
+    ``window_seconds=300``, so neither trigger A nor trigger B fires.
+    """
+
+    detector, publisher, clock = _make_detector(
+        window_seconds=300,
+        count_threshold=10,
+    )
+
+    for i in range(5):
+        await detector.on_rejection(rejection_source="balance", decision_id=f"d-{i}")
+        clock.advance(60)
+
+    halt_calls = [c for c in publisher.calls if c["alert_name"] == "halt_suspected"]
+    assert halt_calls == []
+    assert detector.is_halt_active is False
+
+
+@pytest.mark.asyncio
+async def test_halt_payload_carries_last_10_decision_ids():
+    """AC7.b: payload includes the most recent 10 balance-rejected decision_ids."""
+
+    detector, publisher, clock = _make_detector()
+
+    for i in range(15):
+        await detector.on_rejection(rejection_source="balance", decision_id=f"d-{i}")
+        clock.advance(2)
+
+    halt_calls = [c for c in publisher.calls if c["alert_name"] == "halt_suspected"]
+    assert len(halt_calls) == 1
+    payload = halt_calls[0]["payload"]
+    # The first trigger fires at the 11th rejection (i=10), so last_10
+    # at trigger time is d-1..d-10.
+    assert payload["last_10_decision_ids"] == [f"d-{i}" for i in range(1, 11)]

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -28,6 +28,7 @@ from tradeengine.services.execution_event_publisher import (
     EventType as ExecutionEventType,
     execution_event_publisher,
 )
+from tradeengine.services.halt_suspected_detector import halt_suspected_detector
 from tradeengine.services.heartbeat_monitor import HeartbeatMonitor
 from tradeengine.signal_aggregator import SignalAggregator
 from tradeengine.strategy_position_manager import strategy_position_manager
@@ -2417,6 +2418,12 @@ class Dispatcher:
                 emit_err,
             )
 
+        await self._feed_halt_detector(
+            event_type=event_type,
+            rejection_source=rejection_source,
+            decision_id=signal.decision_id,
+        )
+
     async def _emit_execution_event_from_order(
         self,
         order: TradeOrder,
@@ -2470,6 +2477,39 @@ class Dispatcher:
                 "execution_event emit (order-keyed) failed for %s: %s",
                 order.order_id,
                 emit_err,
+            )
+
+        await self._feed_halt_detector(
+            event_type=event_type,
+            rejection_source=order.rejection_source,
+            decision_id=decision_id,
+        )
+
+    async def _feed_halt_detector(
+        self,
+        *,
+        event_type: ExecutionEventType,
+        rejection_source: str | None,
+        decision_id: str | None,
+    ) -> None:
+        """Hand one execution event off to the halt-suspected detector.
+
+        Best-effort: never raises into the caller — the order / rejection
+        path tolerates an unhealthy observability subsystem.
+        """
+        try:
+            if event_type == "rejected":
+                await halt_suspected_detector.on_rejection(
+                    rejection_source=rejection_source,
+                    decision_id=decision_id,
+                )
+            elif event_type in ("placed", "filled", "partial_fill"):
+                await halt_suspected_detector.on_completion()
+        except Exception as exc:
+            self.logger.warning(
+                "halt_suspected_detector hook failed for event_type=%s: %s",
+                event_type,
+                exc,
             )
 
     def _signal_to_order(

--- a/tradeengine/services/alert_publisher.py
+++ b/tradeengine/services/alert_publisher.py
@@ -1,0 +1,174 @@
+"""Alert publisher for tradeengine operational alerts.
+
+Emits messages on the ``alerts.tradeengine.<event>`` family of NATS subjects.
+Best-effort: failures are logged but never raise into the caller (the order
+or rejection path must not break if the observability bus is unhealthy).
+
+This mirrors the shape of :mod:`tradeengine.services.execution_event_publisher`
+intentionally — same lazy-connect, same NATS-disabled bail-out semantics —
+so operators can reason about one publishing pattern, not two.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+import nats
+import nats.aio.client
+from opentelemetry import trace
+from prometheus_client import Counter
+
+from shared.config import settings
+from shared.constants import UTC
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+
+tradeengine_alerts_published = Counter(
+    "tradeengine_alerts_published_total",
+    "Total operational alerts published to NATS",
+    ["alert_name", "severity", "result"],
+)
+
+
+class AlertPublisher:
+    """Lazy-connect publisher for ``alerts.tradeengine.<event>`` subjects."""
+
+    def __init__(self) -> None:
+        self._nc: nats.aio.client.Client | None = None
+        self._connect_lock = asyncio.Lock()
+
+    async def _ensure_connected(self) -> nats.aio.client.Client | None:
+        if not settings.nats_enabled or not settings.nats_servers:
+            return None
+        if self._nc is not None and self._nc.is_connected:
+            return self._nc
+        async with self._connect_lock:
+            if self._nc is not None and self._nc.is_connected:
+                return self._nc
+            from shared.constants import (
+                NATS_CONNECT_TIMEOUT,
+                NATS_MAX_RECONNECT_ATTEMPTS,
+                NATS_RECONNECT_TIME_WAIT,
+            )
+
+            try:
+                self._nc = await nats.connect(
+                    servers=settings.nats_servers,
+                    connect_timeout=NATS_CONNECT_TIMEOUT,
+                    max_reconnect_attempts=NATS_MAX_RECONNECT_ATTEMPTS,
+                    reconnect_time_wait=NATS_RECONNECT_TIME_WAIT,
+                    allow_reconnect=True,
+                    name="petrosa-tradeengine-alerts",
+                )
+                logger.info(
+                    "AlertPublisher connected to NATS at %s",
+                    settings.nats_servers,
+                )
+            except Exception as e:
+                logger.error("AlertPublisher failed to connect to NATS: %s", e)
+                self._nc = None
+        return self._nc
+
+    def set_client(self, nc: nats.aio.client.Client | None) -> None:
+        """Inject an existing NATS client (e.g. the dispatcher's) to avoid double-connect."""
+        self._nc = nc
+
+    async def close(self) -> None:
+        if self._nc is not None:
+            try:
+                await self._nc.close()
+            except Exception:
+                pass
+            self._nc = None
+
+    async def publish(
+        self,
+        *,
+        alert_name: str,
+        severity: str,
+        payload: dict[str, Any],
+        timestamp: datetime | None = None,
+    ) -> bool:
+        """Emit one alert. Returns True on success, False otherwise.
+
+        Never raises — the alert path must not break the caller (rejection
+        / fill flow). NATS-disabled mode is a non-error skip.
+        """
+        if not alert_name:
+            logger.error("Refusing to publish alert with empty alert_name")
+            return False
+
+        subject = f"alerts.tradeengine.{alert_name}"
+        ts = (timestamp or datetime.now(UTC)).astimezone(UTC).isoformat()
+        body: dict[str, Any] = {
+            "alert_name": alert_name,
+            "severity": severity,
+            "timestamp": ts,
+            **payload,
+        }
+
+        with tracer.start_as_current_span(
+            "tradeengine_alert.publish",
+            kind=trace.SpanKind.PRODUCER,
+        ) as span:
+            span.set_attribute("messaging.system", "nats")
+            span.set_attribute("messaging.destination", subject)
+            span.set_attribute("messaging.operation", "publish")
+            span.set_attribute("alert.name", alert_name)
+            span.set_attribute("alert.severity", severity)
+
+            nc = await self._ensure_connected()
+            if nc is None:
+                logger.info(
+                    "tradeengine_alert.skipped subject=%s severity=%s "
+                    "(nats disabled or unavailable)",
+                    subject,
+                    severity,
+                )
+                tradeengine_alerts_published.labels(
+                    alert_name=alert_name,
+                    severity=severity,
+                    result="skipped",
+                ).inc()
+                return False
+
+            try:
+                await nc.publish(subject, json.dumps(body).encode())
+                logger.info(
+                    "tradeengine_alert.published subject=%s severity=%s",
+                    subject,
+                    severity,
+                )
+                tradeengine_alerts_published.labels(
+                    alert_name=alert_name,
+                    severity=severity,
+                    result="ok",
+                ).inc()
+                span.set_status(trace.Status(trace.StatusCode.OK))
+                return True
+            except Exception as e:
+                logger.error(
+                    "tradeengine_alert.failed subject=%s severity=%s error=%s",
+                    subject,
+                    severity,
+                    e,
+                    exc_info=True,
+                )
+                tradeengine_alerts_published.labels(
+                    alert_name=alert_name,
+                    severity=severity,
+                    result="error",
+                ).inc()
+                span.set_status(
+                    trace.Status(trace.StatusCode.ERROR, description=str(e))
+                )
+                return False
+
+
+alert_publisher = AlertPublisher()

--- a/tradeengine/services/halt_suspected_detector.py
+++ b/tradeengine/services/halt_suspected_detector.py
@@ -1,0 +1,214 @@
+"""Tradeengine halt-suspected detector (#419, FR66 extension).
+
+Watches the rejection stream for the pattern that produced the silent
+9-hour halt on 2026-05-22→23 (root-caused in #404 / fixed in #406): a
+burst of ``source=balance`` rejections with no successful order in
+between. When that pattern crosses the configured threshold the detector
+emits ``alerts.tradeengine.halt_suspected``; a single non-balance-rejected
+completion clears the state and emits ``alerts.tradeengine.halt_cleared``.
+
+The detector is wired into the two centralized event-emit helpers in
+``tradeengine.dispatcher`` so every rejection / fill path feeds it
+exactly once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections import deque
+from collections.abc import Callable
+from datetime import datetime, timedelta
+
+from shared.constants import UTC
+from tradeengine.services.alert_publisher import alert_publisher
+
+logger = logging.getLogger(__name__)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r — falling back to default=%s", name, raw, default)
+        return default
+
+
+# AC7.a — operator-tunable; defaults match the ticket spec.
+WINDOW_SECONDS = _env_int("TRADEENGINE_HALT_WINDOW_SECONDS", 300)
+COUNT_THRESHOLD = _env_int("TRADEENGINE_HALT_COUNT_THRESHOLD", 10)
+
+
+class HaltSuspectedDetector:
+    """Sliding-window detector + dedup state machine for halt alerts.
+
+    Trigger logic (AC7.a):
+      - count of ``source="balance"`` rejections inside the trailing
+        ``WINDOW_SECONDS`` window exceeds ``COUNT_THRESHOLD``, OR
+      - the entire trailing ``WINDOW_SECONDS`` window contains rejections
+        only and the oldest rejection is older than ``WINDOW_SECONDS``
+        (i.e. the duration with all-rejected has exceeded the window).
+
+    Dedup (AC7.b/c):
+      - while ``halt_suspected`` is active, repeat triggers do not re-emit.
+      - the first non-balance-rejected completion (fill / placed / a
+        non-balance rejection) resets the state and emits
+        ``halt_cleared``.
+    """
+
+    def __init__(
+        self,
+        *,
+        publisher=alert_publisher,
+        now: Callable[[], datetime] | None = None,
+        window_seconds: int | None = None,
+        count_threshold: int | None = None,
+    ) -> None:
+        self._publisher = publisher
+        self._now = now or (lambda: datetime.now(UTC))
+        self._window_seconds = (
+            window_seconds if window_seconds is not None else WINDOW_SECONDS
+        )
+        self._count_threshold = (
+            count_threshold if count_threshold is not None else COUNT_THRESHOLD
+        )
+        # deque of (timestamp, decision_id) for source=balance rejections only.
+        self._balance_rejections: deque[tuple[datetime, str]] = deque()
+        self._halt_active: bool = False
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Internals
+
+    def _should_emit(self, now: datetime) -> bool:
+        """Decide whether to fire halt_suspected at ``now``.
+
+        The ledger is the full run of consecutive balance rejections since
+        the last non-balance completion (a fill / placed / non-balance
+        rejection clears it via :meth:`on_completion`). Two triggers:
+
+        - **A (count)**: more than ``count_threshold`` rejections inside
+          the trailing ``window_seconds`` slice.
+        - **B (duration)**: the run has lasted more than
+          ``window_seconds`` end-to-end (oldest-to-newest), regardless
+          of count.
+        """
+        if not self._balance_rejections:
+            return False
+
+        # Trigger B is checked against the un-pruned ledger so a slow,
+        # continuous all-rejected stream still trips. (Pruning before
+        # this check would always make the oldest survivor `>= now -
+        # window`, defeating the trigger.)
+        oldest = self._balance_rejections[0][0]
+        if (now - oldest).total_seconds() > self._window_seconds:
+            return True
+
+        # Trigger A: how many rejections fall inside the trailing window?
+        cutoff = now - timedelta(seconds=self._window_seconds)
+        in_window = sum(1 for ts, _ in self._balance_rejections if ts >= cutoff)
+        return in_window > self._count_threshold
+
+    # ------------------------------------------------------------------
+    # Public hooks (called from dispatcher emit helpers)
+
+    async def on_rejection(
+        self,
+        *,
+        rejection_source: str | None,
+        decision_id: str | None,
+    ) -> None:
+        """Record one rejection. Triggers halt-suspected if thresholds cross."""
+        async with self._lock:
+            now = self._now()
+            if rejection_source != "balance":
+                # A non-balance rejection counts as a non-balance completion
+                # — same semantics as a fill from the detector's POV.
+                await self._maybe_clear(now)
+                return
+
+            self._balance_rejections.append((now, decision_id or ""))
+
+            if self._halt_active or not self._should_emit(now):
+                return
+
+            await self._emit_halt_suspected(now)
+
+    async def on_completion(self) -> None:
+        """A non-balance-rejected order completed (fill / placed / partial)."""
+        async with self._lock:
+            await self._maybe_clear(self._now())
+
+    # ------------------------------------------------------------------
+    # Emit paths
+
+    async def _emit_halt_suspected(self, now: datetime) -> None:
+        # Last-10 reflects the most recent rejections at trigger time.
+        # We slice from the un-pruned ledger so the alert payload mirrors
+        # the operator's mental model of "what happened just before".
+        recent = [d_id for _, d_id in self._balance_rejections if d_id]
+        last_ten = recent[-10:]
+        payload = {
+            "window_seconds": self._window_seconds,
+            "count_threshold": self._count_threshold,
+            "rejected_count": len(self._balance_rejections),
+            "last_10_decision_ids": last_ten,
+            "first_rejected_at": self._balance_rejections[0][0]
+            .astimezone(UTC)
+            .isoformat(),
+            "detected_at": now.astimezone(UTC).isoformat(),
+        }
+        self._halt_active = True
+        try:
+            await self._publisher.publish(
+                alert_name="halt_suspected",
+                severity="critical",
+                payload=payload,
+                timestamp=now,
+            )
+            logger.warning(
+                "halt_suspected emitted: rejected_count=%s window_seconds=%s",
+                payload["rejected_count"],
+                self._window_seconds,
+            )
+        except Exception as exc:  # pragma: no cover — publisher is best-effort
+            logger.error("halt_suspected emit failed: %s", exc, exc_info=True)
+
+    async def _maybe_clear(self, now: datetime) -> None:
+        # A non-balance completion always resets the rejection ledger so we
+        # do not double-count rejections that preceded a recovery period.
+        self._balance_rejections.clear()
+        if not self._halt_active:
+            return
+        self._halt_active = False
+        payload = {
+            "cleared_at": now.astimezone(UTC).isoformat(),
+        }
+        try:
+            await self._publisher.publish(
+                alert_name="halt_cleared",
+                severity="info",
+                payload=payload,
+                timestamp=now,
+            )
+            logger.info("halt_cleared emitted")
+        except Exception as exc:  # pragma: no cover — best-effort
+            logger.error("halt_cleared emit failed: %s", exc, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Test introspection (kept narrow on purpose)
+
+    @property
+    def is_halt_active(self) -> bool:
+        return self._halt_active
+
+    @property
+    def tracked_rejection_count(self) -> int:
+        return len(self._balance_rejections)
+
+
+halt_suspected_detector = HaltSuspectedDetector()


### PR DESCRIPTION
## Summary
- Closes #419. Implements the detection that #404's 9-hour silent halt lacked: a sliding-window watcher for `source=balance` rejections that emits `alerts.tradeengine.halt_suspected` (severity `critical`) once the run crosses configured thresholds, and `alerts.tradeengine.halt_cleared` on the first non-balance completion.
- New `tradeengine/services/alert_publisher.py` (lazy-connect, best-effort, mirrors `execution_event_publisher`'s shape) owns the `alerts.tradeengine.*` subject family.
- New `tradeengine/services/halt_suspected_detector.py` implements the state machine.
- Wired into both centralized event-emit helpers in `tradeengine/dispatcher.py` via `_feed_halt_detector`, so every rejection / fill / placed / partial-fill path feeds the detector exactly once.

## AC traceability
- [x] **AC7.a — Detection.** Two trigger paths in `_should_emit`:
  - **(A) count**: more than `TRADEENGINE_HALT_COUNT_THRESHOLD` (default 10) balance rejections fall inside the trailing `TRADEENGINE_HALT_WINDOW_SECONDS` (default 300) slice.
  - **(B) duration**: the consecutive-rejection run spans end-to-end longer than the window, regardless of count.
- [x] **AC7.b — Alert emit.** `alerts.tradeengine.halt_suspected` carries `severity=critical`, `last_10_decision_ids`, `rejected_count`, `first_rejected_at`, `detected_at`, `window_seconds`, `count_threshold`.
- [x] **AC7.c — Recovery emit.** First non-balance completion (`filled` / `placed` / `partial_fill`, or a non-balance rejection) clears the state and emits `alerts.tradeengine.halt_cleared` (`severity=info`, `cleared_at`).
- [x] **AC7.d — Test.** `tests/test_halt_suspected_detector.py` drives a stubbed publisher with a manual clock: exercises both trigger paths, dedup, recovery, and the below-threshold safety case.

## Operator notes
- Thresholds are env-tunable: `TRADEENGINE_HALT_WINDOW_SECONDS` and `TRADEENGINE_HALT_COUNT_THRESHOLD`. Defaults match the ticket spec.
- Publisher is best-effort: NATS-disabled / unreachable does not break the order path. Failures are logged + counted via `tradeengine_alerts_published_total`.

## Test plan
- [x] `pytest tests/test_halt_suspected_detector.py tests/test_dispatcher.py tests/test_execution_event_publisher.py` → 58 passed.
- [x] Full repo suite (excluding `tests/integration`) → 1408 passed / 13 skipped.
- [x] `ruff check --fix` + `ruff format` clean.

## References
- Parent epic: [petrosa_k8s#693](https://github.com/PetroSa2/petrosa_k8s/issues/693)
- Motivating incident: [petrosa-tradeengine#404](https://github.com/PetroSa2/petrosa-tradeengine/issues/404) (root cause fixed in #406; this PR is the *detection* the original incident lacked).

🤖 BMAD ticket-orchestrator (auto-chain, execution phase)