### PR TITLE
feat(risk): FR30 drawdown comparator + DrawdownBreachEmitter (#431)

### DIFF
--- a/tests/test_drawdown_enforcer.py
+++ b/tests/test_drawdown_enforcer.py
@@ -1,0 +1,235 @@
+"""Tests for ``tradeengine/risk/drawdown_enforcer.py`` (FR30, #431)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tradeengine.risk.drawdown_enforcer import (
+    DRAWDOWN_BREACH_SUBJECT_PREFIX,
+    Breach,
+    DrawdownBreachEmitter,
+    check_and_emit,
+    check_drawdown_breach,
+    get_stub_envelope_value,
+)
+
+# ─── comparator ─────────────────────────────────────────────────────────────
+
+
+def test_breach_returned_when_observed_strictly_exceeds_envelope() -> None:
+    breach = check_drawdown_breach(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=8.0,
+        envelope_value_pct=5.0,
+    )
+    assert breach is not None
+    assert breach.strategy_id == "momentum-v3"
+    assert breach.observed_drawdown_pct == 8.0
+    assert breach.envelope_value_pct == 5.0
+    assert breach.exceeded_by_pct == pytest.approx(3.0)
+
+
+def test_no_breach_when_observed_equals_envelope() -> None:
+    """Equality is the one-tick grace window — same convention as
+    PortfolioTracker.would_breach_ceiling."""
+    result = check_drawdown_breach(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=5.0,
+        envelope_value_pct=5.0,
+    )
+    assert result is None
+
+
+def test_no_breach_when_observed_below_envelope() -> None:
+    result = check_drawdown_breach(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=3.0,
+        envelope_value_pct=5.0,
+    )
+    assert result is None
+
+
+def test_empty_strategy_id_returns_none() -> None:
+    result = check_drawdown_breach(
+        strategy_id="",
+        observed_drawdown_pct=10.0,
+        envelope_value_pct=5.0,
+    )
+    assert result is None
+
+
+# ─── stub envelope source ───────────────────────────────────────────────────
+
+
+def test_stub_envelope_returns_max_daily_loss_pct(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tradeengine.risk.drawdown_enforcer as mod
+
+    fake_settings = MagicMock()
+    fake_settings.max_daily_loss_pct = 6.5
+    monkeypatch.setattr(mod, "settings", fake_settings)
+    assert get_stub_envelope_value("momentum-v3") == 6.5
+
+
+def test_stub_envelope_returns_zero_when_setting_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tradeengine.risk.drawdown_enforcer as mod
+
+    class _NoAttr:
+        pass
+
+    monkeypatch.setattr(mod, "settings", _NoAttr())
+    assert get_stub_envelope_value("anything") == 0.0
+
+
+# ─── DrawdownBreachEmitter ──────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeNatsClient:
+    published: list[tuple[str, bytes]] = field(default_factory=list)
+
+    async def publish(self, subject: str, body: bytes) -> None:
+        self.published.append((subject, body))
+
+
+@dataclass
+class _FakeAlertPublisher:
+    nc: Any | None = None
+
+    async def _ensure_connected(self) -> Any | None:
+        return self.nc
+
+
+def _make_breach(
+    *,
+    strategy_id: str = "momentum-v3",
+    observed: float = 8.0,
+    envelope: float = 5.0,
+) -> Breach:
+    from datetime import datetime
+
+    from shared.constants import UTC
+
+    return Breach(
+        strategy_id=strategy_id,
+        observed_drawdown_pct=observed,
+        envelope_value_pct=envelope,
+        exceeded_by_pct=observed - envelope,
+        detected_at=datetime.now(UTC),
+    )
+
+
+def test_emit_publishes_to_per_strategy_subject_when_nats_available() -> None:
+    nc = _FakeNatsClient()
+    publisher = _FakeAlertPublisher(nc=nc)
+    emitter = DrawdownBreachEmitter(alert_publisher=publisher)
+    breach = _make_breach(strategy_id="momentum-v3")
+    rc = asyncio.run(emitter.emit(breach))
+    assert rc is True
+    assert len(nc.published) == 1
+    subject, body = nc.published[0]
+    assert subject == f"{DRAWDOWN_BREACH_SUBJECT_PREFIX}.momentum-v3"
+    payload = json.loads(body.decode("utf-8"))
+    assert payload["strategy_id"] == "momentum-v3"
+    assert payload["observed_drawdown_pct"] == 8.0
+    assert payload["envelope_value_pct"] == 5.0
+    assert payload["exceeded_by_pct"] == pytest.approx(3.0)
+    # Envelope provenance fields default NULL — #422 will populate them.
+    assert payload["envelope_version"] is None
+    assert payload["envelope_source"] is None
+
+
+def test_emit_returns_false_when_no_alert_publisher_attached() -> None:
+    emitter = DrawdownBreachEmitter(alert_publisher=None)
+    rc = asyncio.run(emitter.emit(_make_breach()))
+    assert rc is False
+
+
+def test_emit_returns_false_when_nats_unavailable() -> None:
+    publisher = _FakeAlertPublisher(nc=None)
+    emitter = DrawdownBreachEmitter(alert_publisher=publisher)
+    rc = asyncio.run(emitter.emit(_make_breach()))
+    assert rc is False
+
+
+def test_set_alert_publisher_updates_emitter() -> None:
+    emitter = DrawdownBreachEmitter()
+    assert emitter._alert_publisher is None  # noqa: SLF001
+    nc = _FakeNatsClient()
+    emitter.set_alert_publisher(_FakeAlertPublisher(nc=nc))
+    rc = asyncio.run(emitter.emit(_make_breach()))
+    assert rc is True
+    assert len(nc.published) == 1
+
+
+# ─── check_and_emit integration point ───────────────────────────────────────
+
+
+def test_check_and_emit_fires_when_breach_detected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dispatcher-call-site path: comparator fires AND emitter publishes."""
+    nc = _FakeNatsClient()
+    publisher = _FakeAlertPublisher(nc=nc)
+    emitter = DrawdownBreachEmitter(alert_publisher=publisher)
+    breach = asyncio.run(
+        check_and_emit(
+            strategy_id="momentum-v3",
+            observed_drawdown_pct=10.0,
+            emitter=emitter,
+            envelope_value_pct=5.0,
+        )
+    )
+    assert breach is not None
+    assert breach.exceeded_by_pct == pytest.approx(5.0)
+    assert len(nc.published) == 1
+
+
+def test_check_and_emit_skips_emission_when_no_breach() -> None:
+    nc = _FakeNatsClient()
+    publisher = _FakeAlertPublisher(nc=nc)
+    emitter = DrawdownBreachEmitter(alert_publisher=publisher)
+    breach = asyncio.run(
+        check_and_emit(
+            strategy_id="momentum-v3",
+            observed_drawdown_pct=3.0,
+            emitter=emitter,
+            envelope_value_pct=5.0,
+        )
+    )
+    assert breach is None
+    assert nc.published == []
+
+
+def test_check_and_emit_falls_back_to_stub_envelope_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When envelope_value_pct is not supplied, get_stub_envelope_value is used."""
+    import tradeengine.risk.drawdown_enforcer as mod
+
+    fake_settings = MagicMock()
+    fake_settings.max_daily_loss_pct = 4.0
+    monkeypatch.setattr(mod, "settings", fake_settings)
+
+    nc = _FakeNatsClient()
+    emitter = DrawdownBreachEmitter(alert_publisher=_FakeAlertPublisher(nc=nc))
+    breach = asyncio.run(
+        check_and_emit(
+            strategy_id="momentum-v3",
+            observed_drawdown_pct=7.0,
+            emitter=emitter,
+            # envelope_value_pct omitted on purpose
+        )
+    )
+    assert breach is not None
+    assert breach.envelope_value_pct == 4.0
+    assert breach.exceeded_by_pct == pytest.approx(3.0)

--- a/tradeengine/risk/__init__.py
+++ b/tradeengine/risk/__init__.py
@@ -1,0 +1,1 @@
+"""Risk management primitives — drawdown enforcement (FR30, #431)."""

--- a/tradeengine/risk/drawdown_enforcer.py
+++ b/tradeengine/risk/drawdown_enforcer.py
@@ -1,0 +1,184 @@
+"""FR30 — per-strategy drawdown enforcement (petrosa-tradeengine#431).
+
+Three pieces:
+
+* :func:`check_drawdown_breach` — pure comparator. Given the current observed
+  drawdown for a strategy and the configured envelope value, decide whether
+  a breach has occurred. No I/O. Easy to unit-test.
+
+* :func:`get_stub_envelope_value` — temporary envelope source backed by
+  ``settings.max_daily_loss_pct`` (the legacy per-account global value).
+  When the envelope-fetcher wiring lands in [petrosa-tradeengine#421](https://github.com/PetroSa2/petrosa-tradeengine/issues/421)
+  this stub is replaced with the HTTP client to data-manager's
+  ``GET /api/envelopes/active/{key}`` — same function signature so the call
+  sites in this leaf do not need to change.
+
+* :class:`DrawdownBreachEmitter` — wraps the existing
+  :class:`~tradeengine.services.alert_publisher.AlertPublisher` NATS
+  connection but publishes to the cross-service subject
+  ``alerts.drawdown.breach.{strategy_id}`` (matching the cio convention at
+  ``petrosa-cio/cio/core/alerting/fr66_alerts.py:252``). **Envelope fields
+  (``envelope_version``, ``envelope_source``) are NULL in this leaf** —
+  those land in [petrosa-tradeengine#422](https://github.com/PetroSa2/petrosa-tradeengine/issues/422)'s
+  schema extension.
+
+The dispatcher integration is left to the existing per-tick reconciliation
+path; this module exposes :func:`check_and_emit` as the integration point so
+the dispatcher call site is one line.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from shared.config import settings
+from shared.constants import UTC
+
+logger = logging.getLogger(__name__)
+
+DRAWDOWN_BREACH_SUBJECT_PREFIX = "alerts.drawdown.breach"
+
+
+@dataclass(frozen=True)
+class Breach:
+    """A drawdown-breach event prior to NATS publication."""
+
+    strategy_id: str
+    observed_drawdown_pct: float
+    envelope_value_pct: float
+    exceeded_by_pct: float
+    detected_at: datetime
+
+
+def check_drawdown_breach(
+    *,
+    strategy_id: str,
+    observed_drawdown_pct: float,
+    envelope_value_pct: float,
+) -> Breach | None:
+    """Return a :class:`Breach` iff ``observed_drawdown_pct > envelope_value_pct``.
+
+    Inputs are percentages expressed as positive floats (e.g. ``5.0`` means
+    5%). The comparator treats equality as "not yet breached" to give the
+    operator one tick of grace before alerting — matches the convention in
+    ``PortfolioTracker.would_breach_ceiling`` where the cluster passes the
+    test until it strictly exceeds the ceiling.
+    """
+    if not strategy_id:
+        return None
+    if observed_drawdown_pct <= envelope_value_pct:
+        return None
+    return Breach(
+        strategy_id=strategy_id,
+        observed_drawdown_pct=float(observed_drawdown_pct),
+        envelope_value_pct=float(envelope_value_pct),
+        exceeded_by_pct=float(observed_drawdown_pct - envelope_value_pct),
+        detected_at=datetime.now(UTC),
+    )
+
+
+def get_stub_envelope_value(strategy_id: str) -> float:
+    """Return the configured envelope value for a strategy.
+
+    **Stub source** — returns ``settings.max_daily_loss_pct`` regardless of
+    ``strategy_id``. The full implementation in [petrosa-tradeengine#421](https://github.com/PetroSa2/petrosa-tradeengine/issues/421)
+    swaps this for an HTTP call to ``petrosa-data-manager`` via the
+    EnvelopeFetcher pattern from [petrosa-cio#155](https://github.com/PetroSa2/petrosa-cio/pull/155).
+
+    Same signature so the call sites in this leaf are unchanged after #421
+    lands. Returns 0.0 if the setting is unavailable.
+    """
+    _ = strategy_id  # Future: will key the lookup
+    value = getattr(settings, "max_daily_loss_pct", None)
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+class DrawdownBreachEmitter:
+    """Publish drawdown-breach events to NATS subject ``alerts.drawdown.breach.{strategy_id}``.
+
+    Uses the AlertPublisher's NATS client when present (avoiding a duplicate
+    connection); falls back to "log only, do not raise" when NATS is
+    unavailable. Never throws — the order/dispatch path must not break on
+    an observability bus outage.
+    """
+
+    def __init__(self, alert_publisher: Any | None = None) -> None:
+        self._alert_publisher = alert_publisher
+
+    def set_alert_publisher(self, alert_publisher: Any) -> None:
+        self._alert_publisher = alert_publisher
+
+    async def emit(self, breach: Breach) -> bool:
+        """Publish one breach event. Returns ``True`` iff the publish succeeded."""
+        subject = f"{DRAWDOWN_BREACH_SUBJECT_PREFIX}.{breach.strategy_id}"
+        payload: dict[str, Any] = {
+            "strategy_id": breach.strategy_id,
+            "observed_drawdown_pct": breach.observed_drawdown_pct,
+            "envelope_value_pct": breach.envelope_value_pct,
+            "exceeded_by_pct": breach.exceeded_by_pct,
+            "detected_at": breach.detected_at.astimezone(UTC).isoformat(),
+            # FR62 envelope fields land in #422; NULL here so the schema is
+            # forward-compatible.
+            "envelope_version": None,
+            "envelope_source": None,
+        }
+        if self._alert_publisher is None:
+            logger.info(
+                "drawdown_breach.skipped subject=%s payload=%s (no AlertPublisher attached)",
+                subject,
+                payload,
+            )
+            return False
+        nc = await self._alert_publisher._ensure_connected()  # noqa: SLF001
+        if nc is None:
+            logger.info(
+                "drawdown_breach.skipped subject=%s (nats disabled or unavailable)",
+                subject,
+            )
+            return False
+        try:
+            await nc.publish(subject, json.dumps(payload).encode("utf-8"))
+            logger.warning(
+                "drawdown_breach.published subject=%s strategy_id=%s exceeded_by=%.4f",
+                subject,
+                breach.strategy_id,
+                breach.exceeded_by_pct,
+            )
+            return True
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.error(
+                "drawdown_breach.publish_failed subject=%s err=%s", subject, exc
+            )
+            return False
+
+
+async def check_and_emit(
+    *,
+    strategy_id: str,
+    observed_drawdown_pct: float,
+    emitter: DrawdownBreachEmitter,
+    envelope_value_pct: float | None = None,
+) -> Breach | None:
+    """Run the comparator and emit a breach event on positive detection.
+
+    Dispatcher integration point — call this from the existing per-tick
+    reconciliation loop (or order-acceptance path). Returns the breach
+    that fired, or ``None`` when no breach was detected. The emitter
+    failure mode (NATS down) is logged but not propagated.
+    """
+    if envelope_value_pct is None:
+        envelope_value_pct = get_stub_envelope_value(strategy_id)
+    breach = check_drawdown_breach(
+        strategy_id=strategy_id,
+        observed_drawdown_pct=observed_drawdown_pct,
+        envelope_value_pct=envelope_value_pct,
+    )
+    if breach is not None:
+        await emitter.emit(breach)
+    return breach


### PR DESCRIPTION
Closes #431 (FR30 precursor — unblocks petrosa-tradeengine#421/#422/#423).

## What

Adds `tradeengine/risk/drawdown_enforcer.py` with three pieces:

1. **`check_drawdown_breach`** — pure comparator. `Breach | None` when `observed_drawdown_pct > envelope_value_pct` (strict — equality is one tick of grace, matching `PortfolioTracker.would_breach_ceiling`).
2. **`get_stub_envelope_value(strategy_id)`** — temporary envelope source backed by `settings.max_daily_loss_pct`. #421 will swap this for an HTTP fetcher against data-manager — same signature, so call sites do not change.
3. **`DrawdownBreachEmitter`** — publishes breach events to NATS subject `alerts.drawdown.breach.{strategy_id}` (matches cio convention at `petrosa-cio/cio/core/alerting/fr66_alerts.py:252`). Reuses the existing `AlertPublisher` NATS connection. Never raises — observability bus outage is logged-only.

Envelope provenance fields (`envelope_version`, `envelope_source`) emit **NULL** in this leaf — schema extension is #422.

`check_and_emit` is the one-line dispatcher integration point.

## Tests

`tests/test_drawdown_enforcer.py` — 13 tests covering:
- comparator (above / equal / below threshold + empty strategy_id)
- stub envelope source (present + missing setting)
- emitter (NATS available / unavailable / no publisher / late-attached publisher)
- `check_and_emit` (fires on breach / skips when no breach / falls back to stub source)

Full tradeengine suite: **1469/1469 passing**.

## Scope guard

- Dispatcher tick-loop wiring (AC4) is deliberately left as a one-line call site rather than landing here. #421 sequences the wiring alongside the HTTP envelope source so the comparator goes live with the real envelope value, not the stub.
- No changes to `AlertPublisher` — emitter borrows its NATS client.
- No changes to existing risk paths (`max_daily_loss_pct` legacy check still functions).

Unblocks: #421, #422, #423.