### PR TITLE
fix(oco): cancel surviving leg on partial OCO failure (#425)

### DIFF
--- a/tests/test_oco_manager.py
+++ b/tests/test_oco_manager.py
@@ -1,0 +1,148 @@
+"""Tests for `OCOManager` partial-failure handling.
+
+Covers AC1 of petrosa-tradeengine#425 (RC#1 of #424): when one leg posts
+successfully and the other fails, `place_oco_orders` MUST cancel the
+surviving leg on Binance before returning ``{"status": "failed"}``.
+
+Equivalent to ``test_h1_surviving_sl_leg_is_cancelled_when_tp_leg_fails``
+in ``petrosa_k8s/_bmad-output/incidents/2026-05-30/reproduction_test.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tradeengine.dispatcher import OCOManager
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test-oco-manager-425")
+
+
+def _make_exchange(sl_ok: bool, tp_ok: bool) -> AsyncMock:
+    """Build an exchange double whose `execute` returns success/failure per leg.
+
+    The execute mock returns an order_id only when that leg is configured to
+    succeed; otherwise it returns ``order_id: None``. `client._request_futures_api`
+    is a `MagicMock` so call kwargs can be asserted.
+    """
+    exch = AsyncMock()
+    exch.client = MagicMock()
+
+    sl_id = "1000000091274545"
+    tp_id = "1000000091274546"
+
+    async def execute(order: Any) -> dict[str, Any]:
+        if str(order.type) in ("OrderType.STOP", "stop"):
+            return {
+                "order_id": sl_id if sl_ok else None,
+                "status": "NEW" if sl_ok else "failed",
+            }
+        return {
+            "order_id": tp_id if tp_ok else None,
+            "status": "NEW" if tp_ok else "failed",
+        }
+
+    exch.execute = execute
+    return exch
+
+
+@pytest.mark.asyncio
+async def test_surviving_sl_leg_is_cancelled_when_tp_leg_fails(
+    logger: logging.Logger,
+) -> None:
+    """SL posts → TP fails → SL algoId must be sent to algoOrder DELETE."""
+    exch = _make_exchange(sl_ok=True, tp_ok=False)
+    oco = OCOManager(exchange=exch, logger=logger)
+
+    result = await oco.place_oco_orders(
+        position_id="ac1-sl-orphan",
+        symbol="BCHUSDT",
+        position_side="LONG",
+        quantity=0.22,
+        stop_loss_price=300.0,
+        take_profit_price=310.0,
+    )
+
+    assert result["status"] == "failed"
+    assert exch.client._request_futures_api.call_count == 1
+    call = exch.client._request_futures_api.call_args
+    assert call.args[0] == "delete"
+    assert call.args[1] == "algoOrder"
+    assert call.kwargs["data"] == {"symbol": "BCHUSDT", "algoId": "1000000091274545"}
+
+
+@pytest.mark.asyncio
+async def test_surviving_tp_leg_is_cancelled_when_sl_leg_fails(
+    logger: logging.Logger,
+) -> None:
+    """TP posts → SL fails → TP algoId must be sent to algoOrder DELETE."""
+    exch = _make_exchange(sl_ok=False, tp_ok=True)
+    oco = OCOManager(exchange=exch, logger=logger)
+
+    result = await oco.place_oco_orders(
+        position_id="ac1-tp-orphan",
+        symbol="BCHUSDT",
+        position_side="SHORT",
+        quantity=0.22,
+        stop_loss_price=310.0,
+        take_profit_price=300.0,
+    )
+
+    assert result["status"] == "failed"
+    assert exch.client._request_futures_api.call_count == 1
+    call = exch.client._request_futures_api.call_args
+    assert call.kwargs["data"] == {"symbol": "BCHUSDT", "algoId": "1000000091274546"}
+
+
+@pytest.mark.asyncio
+async def test_both_legs_fail_does_not_call_cancel(
+    logger: logging.Logger,
+) -> None:
+    """No surviving leg → no cancel attempt."""
+    exch = _make_exchange(sl_ok=False, tp_ok=False)
+    oco = OCOManager(exchange=exch, logger=logger)
+
+    result = await oco.place_oco_orders(
+        position_id="ac1-both-fail",
+        symbol="BCHUSDT",
+        position_side="LONG",
+        quantity=0.22,
+        stop_loss_price=300.0,
+        take_profit_price=310.0,
+    )
+
+    assert result["status"] == "failed"
+    assert exch.client._request_futures_api.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_orphan_counter_increments_when_cancel_raises(
+    logger: logging.Logger,
+) -> None:
+    """When the cancel itself raises, ``oco_orphan_leg_total`` MUST tick."""
+    from tradeengine.metrics import oco_orphan_leg_total
+
+    exch = _make_exchange(sl_ok=True, tp_ok=False)
+    exch.client._request_futures_api.side_effect = RuntimeError("binance down")
+    oco = OCOManager(exchange=exch, logger=logger)
+
+    sample = oco_orphan_leg_total.labels(symbol="BCHUSDT", side="LONG", leg="SL")
+    before = sample._value.get()
+    result = await oco.place_oco_orders(
+        position_id="ac1-cancel-failed",
+        symbol="BCHUSDT",
+        position_side="LONG",
+        quantity=0.22,
+        stop_loss_price=300.0,
+        take_profit_price=310.0,
+    )
+    after = sample._value.get()
+
+    assert result["status"] == "failed"
+    assert after - before == 1.0

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -283,6 +283,46 @@ class OCOManager:
                     "status": "success",
                 }
             else:
+                # #425 (RC#1 of #424): partial OCO failure — one leg posted, the other did not.
+                # Cancel the surviving leg on Binance before returning to prevent an orphan
+                # blocking the next placement attempt with -4130 ("open stop/TP already exists").
+                surviving_leg: tuple[str, str] | None = None
+                if sl_order_id and not tp_order_id:
+                    surviving_leg = ("SL", sl_order_id)
+                elif tp_order_id and not sl_order_id:
+                    surviving_leg = ("TP", tp_order_id)
+
+                if surviving_leg is not None:
+                    leg_label, surviving_id = surviving_leg
+                    self.logger.error(
+                        f"⚠️ PARTIAL OCO FAILURE: {leg_label} leg posted "
+                        f"(algoId={surviving_id}) but counterparty failed for "
+                        f"{symbol} {position_side}. Cancelling surviving leg."
+                    )
+                    try:
+                        self.exchange.client._request_futures_api(
+                            "delete",
+                            "algoOrder",
+                            signed=True,
+                            force_params=True,
+                            data={"symbol": symbol, "algoId": surviving_id},
+                        )
+                        self.logger.info(
+                            f"✅ Cancelled orphan {leg_label} algoId={surviving_id} "
+                            f"for {symbol} {position_side}"
+                        )
+                    except Exception as cancel_err:
+                        from tradeengine.metrics import oco_orphan_leg_total
+
+                        self.logger.error(
+                            f"❌ FAILED to cancel orphan {leg_label} "
+                            f"algoId={surviving_id} for {symbol} {position_side}: "
+                            f"{cancel_err}"
+                        )
+                        oco_orphan_leg_total.labels(
+                            symbol=symbol, side=position_side, leg=leg_label
+                        ).inc()
+
                 self.logger.error("❌ FAILED TO PLACE OCO ORDERS")
                 self.logger.error(f"  SL Result: {sl_result}")
                 self.logger.error(f"  TP Result: {tp_result}")

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -142,6 +142,15 @@ active_oco_pairs_per_position = Gauge(
     ["symbol", "position_side", "exchange"],
 )
 
+# #425 (RC#1 of #424): orphan leg from partial OCO failure that could not be cancelled.
+# Incremented when one leg posts, the counterpart fails, and the surviving-leg cancel
+# attempt itself errors — i.e., the position remains unhedged on Binance.
+oco_orphan_leg_total = Counter(
+    "petrosa_tradeengine_oco_orphan_leg_total",
+    "OCO partial-failure events where the surviving leg could not be cancelled",
+    ["symbol", "side", "leg"],
+)
+
 # ========================================
 # Business Metrics for Trade Execution Monitoring
 # ========================================


### PR DESCRIPTION
## Summary

AC1 of P0 incident #424 (2026-05-30 — 11 of 12 live positions unhedged). Implements the fix decomposed in #425.

## What changed

- `tradeengine/dispatcher.py` — `OCOManager.place_oco_orders` now detects the asymmetric-result case (one leg posts, the other fails) and cancels the surviving leg on Binance using the same algo-order DELETE endpoint as `cancel_oco_pair`. Failure to cancel is logged at ERROR and increments the new counter.
- `tradeengine/metrics.py` — new `tradeengine_oco_orphan_leg_total{symbol,side,leg}` Counter.
- `tests/test_oco_manager.py` — new test module: 4 cases covering SL-survives, TP-survives, both-fail (no cancel), and cancel-raises (counter increments).

## Acceptance Criteria

- [x] `OCOManager.place_oco_orders` cancels the successfully-placed leg on Binance before returning `status: failed` when one leg posts and the other fails.
- [x] Cancellation uses the existing algo-order delete path; failure to cancel is logged at ERROR and increments `petrosa_tradeengine_oco_orphan_leg_total{symbol,side,leg}`.
- [x] `tests/test_oco_manager.py` adds a test asserting the cancel path is invoked with the surviving leg's `algoId` — equivalent to `test_h1_surviving_sl_leg_is_cancelled_when_tp_leg_fails` in the 2026-05-30 reproduction package.

## Out of scope (other leaves of #424)
AC2 (atomic-rollback fallback) → #426; AC3 (stops-health Binance verification) → #427; AC4 (price-adjustment floor) → #428; AC5 (reconciler unhedged divergence) → #429; AC6 (runbook + remediation script) → #430.

Closes #425.