### PR TITLE
fix(rollback): close position on AC2 rollback fallbacks + rollback_failed alert (#426)

### DIFF
--- a/tests/test_atomic_rollback.py
+++ b/tests/test_atomic_rollback.py
@@ -110,6 +110,192 @@ async def test_oco_timeout_causes_rollback(dispatcher):
 
 
 @pytest.mark.asyncio
+async def test_rollback_falls_back_when_position_id_none(dispatcher):
+    """
+    AC2/H2 of #424: when order.position_id is None, the rollback path MUST
+    still issue a MARKET reduceOnly close via close_position_with_cleanup
+    using (symbol, position_side, quantity). Pre-fix, this branch
+    early-returned 'rolled_back_partial' WITHOUT touching Binance — the
+    164× cascade in the 2026-05-30 incident.
+    """
+    order = TradeOrder(
+        symbol="BTCUSDT",
+        side="buy",
+        type="market",
+        amount=0.001,
+        order_id="test_order_h2_1",
+        position_id=None,  # ← the bug
+        position_side="LONG",
+        simulate=False,
+    )
+
+    dispatcher._place_risk_management_orders = AsyncMock(
+        side_effect=Exception("OCO Placement Failed")
+    )
+    dispatcher.close_position_with_cleanup = AsyncMock(
+        return_value={"status": "success", "position_closed": True}
+    )
+
+    with patch("tradeengine.dispatcher.strategy_position_manager") as mock_spm:
+        mock_spm.create_strategy_position = AsyncMock(return_value=None)
+        result = await dispatcher._execute_order_with_consensus(order)
+
+    dispatcher.close_position_with_cleanup.assert_called_once()
+    _, kwargs = dispatcher.close_position_with_cleanup.call_args
+    assert kwargs["symbol"] == "BTCUSDT"
+    assert kwargs["position_side"] == "LONG"
+    assert kwargs["quantity"] == 0.001
+    # 'partial' label is retained to flag that no local position record
+    # existed — but the Binance position WAS closed.
+    assert result["status"] == "rolled_back_partial"
+
+
+@pytest.mark.asyncio
+async def test_rollback_refetches_qty_from_binance_when_filled_zero(dispatcher):
+    """
+    AC2/H2: when filled_qty<=0, the rollback path MUST re-derive the
+    position from Binance positionRisk before skipping. Only skip when
+    Binance also reports zero.
+    """
+    order = TradeOrder(
+        symbol="BTCUSDT",
+        side="buy",
+        type="market",
+        amount=0.0,
+        order_id="test_order_h2_2",
+        position_id="pos_h2_2",
+        position_side="LONG",
+        simulate=False,
+    )
+
+    dispatcher._place_risk_management_orders = AsyncMock(
+        side_effect=Exception("OCO Placement Failed")
+    )
+    # result.amount is also 0 → fallback to Binance MUST trigger
+    dispatcher.exchange.execute = AsyncMock(
+        return_value={
+            "status": "filled",
+            "order_id": "entry_order_zero",
+            "fill_price": 50000.0,
+            "amount": 0.0,
+        }
+    )
+    dispatcher.exchange.get_position_info = AsyncMock(
+        return_value=[
+            {"symbol": "BTCUSDT", "positionSide": "LONG", "positionAmt": "0.5"},
+            {"symbol": "ETHUSDT", "positionSide": "LONG", "positionAmt": "1.0"},
+        ]
+    )
+    dispatcher.close_position_with_cleanup = AsyncMock(
+        return_value={"status": "success", "position_closed": True}
+    )
+
+    with patch("tradeengine.dispatcher.strategy_position_manager") as mock_spm:
+        mock_spm.create_strategy_position = AsyncMock(return_value="strat_pos_h2_2")
+        result = await dispatcher._execute_order_with_consensus(order)
+
+    dispatcher.close_position_with_cleanup.assert_called_once()
+    _, kwargs = dispatcher.close_position_with_cleanup.call_args
+    # Quantity MUST come from Binance positionRisk, not the zero local state
+    assert kwargs["quantity"] == 0.5
+    assert result["status"] == "rolled_back"
+
+
+@pytest.mark.asyncio
+async def test_rollback_skipped_only_when_binance_also_zero(dispatcher):
+    """
+    AC2/H2: when local filled_qty<=0 AND Binance positionRisk reports zero
+    for the same (symbol, position_side), the SKIP branch is the correct
+    outcome — there is no position to roll back.
+    """
+    order = TradeOrder(
+        symbol="BTCUSDT",
+        side="buy",
+        type="market",
+        amount=0.0,
+        order_id="test_order_h2_3",
+        position_id="pos_h2_3",
+        position_side="LONG",
+        simulate=False,
+    )
+
+    dispatcher._place_risk_management_orders = AsyncMock(
+        side_effect=Exception("OCO Placement Failed")
+    )
+    dispatcher.exchange.execute = AsyncMock(
+        return_value={
+            "status": "filled",
+            "order_id": "entry_order_zero",
+            "fill_price": 50000.0,
+            "amount": 0.0,
+        }
+    )
+    # Binance also reports zero — skip is correct
+    dispatcher.exchange.get_position_info = AsyncMock(return_value=[])
+    dispatcher.close_position_with_cleanup = AsyncMock()
+
+    with patch("tradeengine.dispatcher.strategy_position_manager") as mock_spm:
+        mock_spm.create_strategy_position = AsyncMock(return_value="strat_pos_h2_3")
+        result = await dispatcher._execute_order_with_consensus(order)
+
+    dispatcher.close_position_with_cleanup.assert_not_called()
+    assert result["status"] == "rolled_back_skipped"
+    assert "binance_zero" in result.get("rollback_skipped_reason", "")
+
+
+@pytest.mark.asyncio
+async def test_rollback_failed_emits_alert_and_counter(dispatcher):
+    """
+    AC2: when the rollback path itself fails, the dispatcher MUST emit
+    alerts.tradeengine.rollback_failed.<symbol> and increment
+    petrosa_tradeengine_atomic_rollback_failed_total{symbol,reason} so
+    ops can see the unhedged-position state even when the order-result
+    return value is consumed silently.
+    """
+    order = TradeOrder(
+        symbol="BTCUSDT",
+        side="buy",
+        type="market",
+        amount=0.001,
+        order_id="test_order_h2_4",
+        position_id="pos_h2_4",
+        position_side="LONG",
+        simulate=False,
+    )
+
+    dispatcher._place_risk_management_orders = AsyncMock(
+        side_effect=Exception("OCO Placement Failed")
+    )
+    dispatcher.close_position_with_cleanup = AsyncMock(
+        side_effect=RuntimeError("Binance reduceOnly rejected")
+    )
+
+    with (
+        patch("tradeengine.dispatcher.alert_publisher") as mock_publisher,
+        patch("tradeengine.dispatcher.atomic_rollback_failed_total") as mock_counter,
+        patch("tradeengine.dispatcher.strategy_position_manager") as mock_spm,
+    ):
+        mock_publisher.publish = AsyncMock(return_value=True)
+        mock_spm.create_strategy_position = AsyncMock(return_value="strat_pos_h2_4")
+        result = await dispatcher._execute_order_with_consensus(order)
+
+    assert result["status"] == "rollback_failed"
+    assert "Binance reduceOnly rejected" in result["rollback_error"]
+
+    mock_counter.labels.assert_called_with(symbol="BTCUSDT", reason="RuntimeError")
+    mock_counter.labels.return_value.inc.assert_called_once()
+
+    mock_publisher.publish.assert_awaited_once()
+    _, pub_kwargs = mock_publisher.publish.call_args
+    assert pub_kwargs["alert_name"] == "rollback_failed.BTCUSDT"
+    assert pub_kwargs["severity"] == "critical"
+    payload = pub_kwargs["payload"]
+    assert payload["symbol"] == "BTCUSDT"
+    assert payload["rollback_reason"] == "atomic_rollback_oco_failure"
+    assert "Binance reduceOnly rejected" in payload["rollback_error"]
+
+
+@pytest.mark.asyncio
 async def test_rollback_failure_is_handled(dispatcher):
     """
     Test that if close_position_with_cleanup itself fails during rollback,

--- a/tests/test_atomic_rollback.py
+++ b/tests/test_atomic_rollback.py
@@ -55,9 +55,11 @@ async def test_oco_failure_causes_rollback(dispatcher):
         side_effect=Exception("OCO Placement Failed")
     )
 
-    # Mock close_position_with_cleanup
+    # Mock close_position_with_cleanup — mirror the real return shape:
+    # position_closed=True signals the exchange-side close actually
+    # succeeded (per its docstring at dispatcher.py:close_position_with_cleanup).
     dispatcher.close_position_with_cleanup = AsyncMock(
-        return_value={"status": "success"}
+        return_value={"status": "success", "position_closed": True}
     )
 
     # Mock strategy_position_manager
@@ -92,9 +94,10 @@ async def test_oco_timeout_causes_rollback(dispatcher):
     # Mock _place_risk_management_orders to timeout
     dispatcher._place_risk_management_orders = AsyncMock(side_effect=TimeoutError())
 
-    # Mock close_position_with_cleanup
+    # Mock close_position_with_cleanup — position_closed=True mirrors the
+    # real return shape and is now required for the rollback success path.
     dispatcher.close_position_with_cleanup = AsyncMock(
-        return_value={"status": "success"}
+        return_value={"status": "success", "position_closed": True}
     )
 
     # Mock strategy_position_manager
@@ -293,6 +296,83 @@ async def test_rollback_failed_emits_alert_and_counter(dispatcher):
     assert payload["symbol"] == "BTCUSDT"
     assert payload["rollback_reason"] == "atomic_rollback_oco_failure"
     assert "Binance reduceOnly rejected" in payload["rollback_error"]
+
+
+@pytest.mark.asyncio
+async def test_rollback_failed_when_close_returns_position_closed_false(dispatcher):
+    """
+    Copilot review of #434: ``close_position_with_cleanup`` catches the
+    exchange execute() exception internally and returns
+    ``{"status": "failed", "position_closed": False}`` without raising.
+    The rollback path MUST treat that as a failure — otherwise the
+    position stays open on Binance while we log "rollback successful".
+    """
+    order = TradeOrder(
+        symbol="BTCUSDT",
+        side="buy",
+        type="market",
+        amount=0.001,
+        order_id="test_order_h2_returns_false",
+        position_id="pos_returns_false",
+        position_side="LONG",
+        simulate=False,
+    )
+
+    dispatcher._place_risk_management_orders = AsyncMock(
+        side_effect=Exception("OCO Placement Failed")
+    )
+    # Real-shape return for the failure mode: no raise, but position_closed=False.
+    dispatcher.close_position_with_cleanup = AsyncMock(
+        return_value={
+            "position_closed": False,
+            "oco_cancelled": False,
+            "close_result": None,
+            "status": "failed",
+            "error": "Binance execute() returned status=REJECTED",
+        }
+    )
+
+    with (
+        patch("tradeengine.dispatcher.alert_publisher") as mock_publisher,
+        patch("tradeengine.dispatcher.atomic_rollback_failed_total") as mock_counter,
+        patch("tradeengine.dispatcher.strategy_position_manager") as mock_spm,
+    ):
+        mock_publisher.publish = AsyncMock(return_value=True)
+        mock_spm.create_strategy_position = AsyncMock(
+            return_value="strat_pos_returns_false"
+        )
+        result = await dispatcher._execute_order_with_consensus(order)
+
+    assert result["status"] == "rollback_failed"
+    assert "did not close position" in result["rollback_error"]
+    mock_counter.labels.assert_called_with(symbol="BTCUSDT", reason="RuntimeError")
+    mock_counter.labels.return_value.inc.assert_called_once()
+    mock_publisher.publish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_binance_position_qty_one_way_mode_respects_sign(dispatcher):
+    """
+    Copilot review of #434: in one-way mode Binance returns
+    ``positionSide="BOTH"`` for every position. A LONG rollback request
+    must NOT match a BOTH row whose ``positionAmt`` is negative (= the
+    account is actually short) — otherwise close_position_with_cleanup
+    would send a sell reduceOnly on the wrong direction.
+    """
+    dispatcher.exchange.get_position_info = AsyncMock(
+        return_value=[
+            # ONE-WAY mode: a single BOTH row, negative => account is SHORT.
+            {"symbol": "BTCUSDT", "positionSide": "BOTH", "positionAmt": "-0.3"},
+        ]
+    )
+
+    # LONG target: must NOT match the SHORT BOTH row → returns 0.0
+    qty_long = await dispatcher._fetch_binance_position_qty("BTCUSDT", "LONG")
+    assert qty_long == 0.0
+
+    # SHORT target: matches the BOTH row → returns abs(positionAmt)
+    qty_short = await dispatcher._fetch_binance_position_qty("BTCUSDT", "SHORT")
+    assert qty_short == 0.3
 
 
 @pytest.mark.asyncio

--- a/tests/test_atomic_rollback_zero_qty.py
+++ b/tests/test_atomic_rollback_zero_qty.py
@@ -143,11 +143,17 @@ async def test_atomic_rollback_skips_when_total_quantity_is_zero(
     ):
         final_result = await dispatcher._execute_order_with_consensus(order)
 
-    # 5. Verify rollback was skipped
+    # 5. Verify rollback was skipped (AC2/RC#2 of #424: only after the
+    # Binance positionRisk fallback also reports zero — see
+    # dispatcher._fetch_binance_position_qty).
     dispatcher.close_position_with_cleanup.assert_not_called()
     assert final_result["status"] == "rolled_back_skipped"
     assert "Risk management failure" in final_result["error"]
-    assert final_result["rollback_skipped_reason"] == "non_positive_filled_qty: 0.0"
+    assert (
+        final_result["rollback_skipped_reason"]
+        == "non_positive_filled_qty_and_binance_zero: local=0.0"
+    )
     dispatcher.logger.warning.assert_any_call(
-        "⚠️ Skipping atomic rollback for BTCUSDT: calculated filled_qty is 0.0"
+        "⚠️ Skipping atomic rollback for BTCUSDT: "
+        "filled_qty=0.0 and Binance reports zero position"
     )

--- a/tests/test_atomic_rollback_zero_qty.py
+++ b/tests/test_atomic_rollback_zero_qty.py
@@ -56,9 +56,13 @@ async def test_atomic_rollback_prioritizes_order_amount_when_result_amount_is_ze
         side_effect=Exception("OCO placement failed")
     )
 
-    # 4. Mock close_position_with_cleanup to capture the quantity passed to it
+    # 4. Mock close_position_with_cleanup to capture the quantity passed to it.
+    # AC2 (#426): the rollback path now requires position_closed=True in the
+    # return dict — close_position_with_cleanup catches its internal exchange
+    # errors and returns position_closed=False instead of raising, so the
+    # rollback path inspects the dict to detect real-world failures.
     dispatcher.close_position_with_cleanup = AsyncMock(
-        return_value={"status": "success"}
+        return_value={"status": "success", "position_closed": True}
     )
 
     # 5. Call the method that contains the rollback logic

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -16,6 +16,7 @@ from shared.distributed_lock import distributed_lock_manager
 from shared.logger import get_logger
 from tradeengine.leverage_bound_guard import LeverageBoundGuard
 from tradeengine.metrics import (
+    atomic_rollback_failed_total,
     order_execution_latency_seconds,
     order_failures_total,
     orders_executed_by_type,
@@ -24,6 +25,7 @@ from tradeengine.metrics import (
 )
 from tradeengine.order_manager import OrderManager
 from tradeengine.position_manager import PositionManager
+from tradeengine.services.alert_publisher import alert_publisher
 from tradeengine.services.execution_event_publisher import (
     EventType as ExecutionEventType,
     execution_event_publisher,
@@ -2320,70 +2322,89 @@ class Dispatcher:
                         self.logger.error(
                             f"[CRITICAL] OCO placement failed. Initiating atomic rollback for symbol {order.symbol}: {e}"
                         )
-                        # Atomic Rollback: Close the position immediately using a MARKET order
+                        # Atomic Rollback (AC2 / RC#2 of #424): close the position immediately
+                        # via a MARKET reduceOnly order. When local state is incomplete
+                        # (no position_id, filled_qty<=0) we fall back to Binance positionRisk
+                        # so the position cannot be left unhedged on the exchange.
+                        rollback_reason = "atomic_rollback_oco_failure"
+                        rollback_position_id = getattr(order, "position_id", None)
+                        filled_qty: float = 0.0
                         try:
-                            # Use filled amount from result if available, otherwise order amount
-                            # CRITICAL FIX: Prioritize non-zero order.amount if result.amount is zero
+                            # Prefer the executed amount from result; fall back to the order
+                            # amount when result.amount is missing or zero.
                             result_qty = result.get("amount", 0.0)
                             if isinstance(result_qty, str):
                                 try:
                                     result_qty = float(result_qty)
                                 except (ValueError, TypeError):
                                     result_qty = 0.0
+                            filled_qty = (
+                                float(result_qty)
+                                if result_qty and result_qty > 0
+                                else float(order.amount or 0.0)
+                            )
 
-                            filled_qty = result_qty if result_qty > 0 else order.amount
-
-                            # Guard: Ensure filled_qty > 0 before initiating rollback
-                            if not filled_qty or filled_qty <= 0:
-                                self.logger.warning(
-                                    f"⚠️ Skipping atomic rollback for {order.symbol}: "
-                                    f"calculated filled_qty is {filled_qty}"
+                            if filled_qty <= 0:
+                                # RC#2: re-derive from Binance positionRisk before skipping —
+                                # the exchange is ground truth, the local result dict is not.
+                                derived_qty = await self._fetch_binance_position_qty(
+                                    order.symbol, order.position_side
                                 )
-                                result["status"] = "rolled_back_skipped"
-                                # Maintain consistent error enrichment so callers see the OCO failure reason
-                                result["error"] = f"Risk management failure: {e}"
-                                # Provide a more specific reason for why rollback was skipped
-                                result["rollback_skipped_reason"] = (
-                                    f"non_positive_filled_qty: {filled_qty}"
-                                )
-                                return result
-
-                            rollback_position_id = getattr(order, "position_id", None)
-                            if rollback_position_id:
-                                rollback_result = (
-                                    await self.close_position_with_cleanup(
-                                        position_id=rollback_position_id,
-                                        symbol=order.symbol,
-                                        position_side=order.position_side,
-                                        quantity=filled_qty,
-                                        reason="atomic_rollback_oco_failure",
+                                if derived_qty > 0:
+                                    self.logger.warning(
+                                        f"⚠️ filled_qty non-positive ({filled_qty}); derived "
+                                        f"rollback qty {derived_qty} from Binance positionRisk for {order.symbol}"
                                     )
-                                )
-                                self.logger.info(
-                                    f"✅ Atomic rollback successful for {order.symbol}"
-                                )
-
-                                # Log critical event to audit trail
-                                if audit_logger.enabled:
-                                    audit_logger.log_trade(
-                                        {
-                                            "event": "atomic_rollback",
-                                            "symbol": order.symbol,
-                                            "position_id": rollback_position_id,
-                                            "reason": "risk_management_failure",
-                                            "error": str(e),
-                                            "rollback_result": rollback_result,
-                                        }
+                                    filled_qty = derived_qty
+                                else:
+                                    self.logger.warning(
+                                        f"⚠️ Skipping atomic rollback for {order.symbol}: "
+                                        f"filled_qty={filled_qty} and Binance reports zero position"
                                     )
+                                    result["status"] = "rolled_back_skipped"
+                                    result["error"] = f"Risk management failure: {e}"
+                                    result["rollback_skipped_reason"] = (
+                                        f"non_positive_filled_qty_and_binance_zero: local={filled_qty}"
+                                    )
+                                    return result
 
-                                # Return result with rolled_back status
-                                result["status"] = "rolled_back"
-                            else:
-                                self.logger.warning(
-                                    f"⚠️ Skipping position-based atomic rollback for {order.symbol}: "
-                                    "no position_id set on order"
+                            # RC#2: close_position_with_cleanup reaches the exchange via
+                            # (symbol, position_side, quantity); position_id is only used
+                            # for OCO-cancel + local position-record cleanup, both of which
+                            # short-circuit cleanly when it is absent.
+                            rollback_result = await self.close_position_with_cleanup(
+                                position_id=rollback_position_id or "",
+                                symbol=order.symbol,
+                                position_side=order.position_side,
+                                quantity=filled_qty,
+                                reason=rollback_reason,
+                            )
+                            self.logger.info(
+                                f"✅ Atomic rollback successful for {order.symbol}"
+                            )
+
+                            # Log critical event to audit trail
+                            if audit_logger.enabled:
+                                audit_logger.log_trade(
+                                    {
+                                        "event": "atomic_rollback",
+                                        "symbol": order.symbol,
+                                        "position_id": rollback_position_id,
+                                        "reason": "risk_management_failure",
+                                        "error": str(e),
+                                        "rollback_result": rollback_result,
+                                    }
                                 )
-                                result["status"] = "rolled_back_partial"
+
+                            # rolled_back: full path with position_id (OCO + record cleared).
+                            # rolled_back_partial: position closed on Binance but no local
+                            # position record existed — surfaces the missing-link so ops
+                            # can reconcile without leaving the position open.
+                            result["status"] = (
+                                "rolled_back"
+                                if rollback_position_id
+                                else "rolled_back_partial"
+                            )
 
                         except Exception as rollback_error:
                             self.logger.error(
@@ -2391,6 +2412,39 @@ class Dispatcher:
                             )
                             result["status"] = "rollback_failed"
                             result["rollback_error"] = str(rollback_error)
+
+                            # RC#2: surface to ops via metric + NATS alert so the
+                            # unhedged-on-Binance state is observable. Both wrapped in
+                            # try/except — the alert path must never break the caller.
+                            reason_label = type(rollback_error).__name__
+                            try:
+                                atomic_rollback_failed_total.labels(
+                                    symbol=order.symbol,
+                                    reason=reason_label,
+                                ).inc()
+                            except Exception:
+                                self.logger.debug(
+                                    "atomic_rollback_failed metric inc failed",
+                                    exc_info=True,
+                                )
+                            try:
+                                await alert_publisher.publish(
+                                    alert_name=f"rollback_failed.{order.symbol}",
+                                    severity="critical",
+                                    payload={
+                                        "symbol": order.symbol,
+                                        "position_side": order.position_side,
+                                        "filled_qty": filled_qty,
+                                        "rollback_reason": rollback_reason,
+                                        "rollback_error": str(rollback_error),
+                                        "oco_failure_error": str(e),
+                                    },
+                                )
+                            except Exception:
+                                self.logger.debug(
+                                    "rollback_failed alert publish failed",
+                                    exc_info=True,
+                                )
 
                         # Return result with appropriate error status
                         result["error"] = f"Risk management failure: {e}"
@@ -3723,6 +3777,46 @@ class Dispatcher:
         except Exception as e:
             self.logger.error(f"Failed to place take profit order: {e}", exc_info=True)
             raise
+
+    async def _fetch_binance_position_qty(
+        self, symbol: str, position_side: str | None
+    ) -> float:
+        """Return |positionAmt| for (symbol, position_side) from Binance.
+
+        Best-effort: returns 0.0 when the exchange has no get_position_info,
+        the call raises, or the position is absent. Never raises into the
+        caller — this is invoked from the rollback fallback where the
+        observable contract is "give me a number; zero means skip".
+        """
+        if self.exchange is None or not hasattr(self.exchange, "get_position_info"):
+            return 0.0
+        try:
+            raw = await self.exchange.get_position_info()
+        except Exception:
+            self.logger.warning(
+                "get_position_info() failed during atomic-rollback fallback",
+                exc_info=True,
+            )
+            return 0.0
+        if not raw:
+            return 0.0
+        target_side = (position_side or "").upper()
+        for pos in raw:
+            if pos.get("symbol") != symbol:
+                continue
+            side = str(pos.get("positionSide", "BOTH")).upper()
+            # Hedge mode emits LONG/SHORT — only consider the matching leg.
+            # ONE-WAY mode returns BOTH; in that case we accept the row and
+            # trust the sign of positionAmt to reflect actual direction.
+            if side in ("LONG", "SHORT") and target_side and side != target_side:
+                continue
+            try:
+                qty = abs(float(pos.get("positionAmt", 0)))
+            except (TypeError, ValueError):
+                continue
+            if qty > 0:
+                return qty
+        return 0.0
 
     async def close_position_with_cleanup(
         self,

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -2379,6 +2379,28 @@ class Dispatcher:
                                 quantity=filled_qty,
                                 reason=rollback_reason,
                             )
+                            # close_position_with_cleanup catches internal exch errors
+                            # and returns status="failed"/"error" instead of raising —
+                            # so we MUST inspect the return value, otherwise a real
+                            # Binance failure would be reported as a successful rollback
+                            # while the position stays open (defeats AC2 entirely).
+                            if not rollback_result or not rollback_result.get(
+                                "position_closed"
+                            ):
+                                rollback_status = (
+                                    rollback_result.get("status", "unknown")
+                                    if rollback_result
+                                    else "no_result"
+                                )
+                                close_err = (
+                                    rollback_result.get("error", "")
+                                    if rollback_result
+                                    else ""
+                                )
+                                raise RuntimeError(
+                                    f"close_position_with_cleanup did not close position "
+                                    f"(status={rollback_status}, error={close_err!r})"
+                                )
                             self.logger.info(
                                 f"✅ Atomic rollback successful for {order.symbol}"
                             )
@@ -3805,15 +3827,25 @@ class Dispatcher:
             if pos.get("symbol") != symbol:
                 continue
             side = str(pos.get("positionSide", "BOTH")).upper()
-            # Hedge mode emits LONG/SHORT — only consider the matching leg.
-            # ONE-WAY mode returns BOTH; in that case we accept the row and
-            # trust the sign of positionAmt to reflect actual direction.
-            if side in ("LONG", "SHORT") and target_side and side != target_side:
-                continue
             try:
-                qty = abs(float(pos.get("positionAmt", 0)))
+                raw_amt = float(pos.get("positionAmt", 0))
             except (TypeError, ValueError):
                 continue
+            # ONE-WAY mode returns positionSide="BOTH"; derive the effective
+            # side from the sign of positionAmt (matches position_reconciler's
+            # _normalise_side). A LONG rollback against a BOTH row with
+            # negative positionAmt would otherwise send a sell reduceOnly on
+            # the wrong direction.
+            if side == "BOTH":
+                if raw_amt == 0:
+                    continue
+                effective_side = "LONG" if raw_amt > 0 else "SHORT"
+                if target_side and effective_side != target_side:
+                    continue
+            elif side in ("LONG", "SHORT"):
+                if target_side and side != target_side:
+                    continue
+            qty = abs(raw_amt)
             if qty > 0:
                 return qty
         return 0.0

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -151,6 +151,16 @@ oco_orphan_leg_total = Counter(
     ["symbol", "side", "leg"],
 )
 
+# #426 (RC#2 of #424): the atomic-rollback path itself failed — the
+# OCO-failure cleanup could not close the position on Binance, so the
+# position remains unhedged. Paired with the
+# alerts.tradeengine.rollback_failed.<symbol> NATS alert.
+atomic_rollback_failed_total = Counter(
+    "petrosa_tradeengine_atomic_rollback_failed_total",
+    "Atomic-rollback failures during OCO-failure cleanup (position left unhedged)",
+    ["symbol", "reason"],
+)
+
 # ========================================
 # Business Metrics for Trade Execution Monitoring
 # ========================================


### PR DESCRIPTION
## Summary

Implements **AC2 / RC#2 of #424** (OCO orphan-legs incident, 2026-05-30). The atomic rollback path had three early-return branches that left positions open on Binance.

## Closes

Closes #426

## What changed

`tradeengine/dispatcher.py` rollback block (around the OCO-failure handler in `_execute_order_with_consensus`):

- **`rolled_back_partial`** (no `order.position_id`): now calls `close_position_with_cleanup` with `(symbol, position_side, quantity)` even when `position_id` is absent. The function reaches the exchange via those three fields; `position_id` is only used for OCO-cancel + local position-record cleanup, both of which short-circuit cleanly when empty.
- **`rolled_back_skipped`** (`filled_qty<=0`): re-derives quantity from Binance `positionRisk` via new helper `_fetch_binance_position_qty` before skipping. Only skips when Binance also reports zero for the same `(symbol, position_side)`.
- **`rollback_failed`**: emits `alerts.tradeengine.rollback_failed.<symbol>` via `AlertPublisher` and increments `petrosa_tradeengine_atomic_rollback_failed_total{symbol, reason}`. Both wrapped in try/except — the alert path never breaks the caller (mirrors `halt_suspected_detector` convention).

`tradeengine/metrics.py`:
- New `atomic_rollback_failed_total` Counter (`petrosa_tradeengine_*` family, paired with the `oco_orphan_leg_total` counter shipped via #425).

## Tests

`tests/test_atomic_rollback.py` — 4 new H2 tests covering the three branches plus the alert-path assertion. Mirrors `test_h2_*` in `petrosa_k8s/_bmad-output/incidents/2026-05-30/reproduction_test.py`:

- `test_rollback_falls_back_when_position_id_none`
- `test_rollback_refetches_qty_from_binance_when_filled_zero`
- `test_rollback_skipped_only_when_binance_also_zero`
- `test_rollback_failed_emits_alert_and_counter`

`tests/test_atomic_rollback_zero_qty.py` — one string update for the new skip-reason contract (`non_positive_filled_qty_and_binance_zero: local=...`).

Local: 1477 passed, 13 skipped (full suite, mirrors CI).

## Evidence / context

- Investigation package: `petrosa_k8s/_bmad-output/incidents/2026-05-30/` (evidence.json, hypotheses.md, reproduction_test.py).
- RC#1 (cancel surviving leg) shipped via #425 / PR #433.
- RC#3–RC#6 still open: #427, #428, #429, #430.

## Out of scope

- Position reconciler unhedged-divergence detection (AC5 / #429).
- Runbook + remediation script (AC6 / #430).