### PR TITLE
fix(stops-health): verify stored sl/tp IDs against Binance + Pydantic ID validator (#427)

### DIFF
--- a/tests/test_position_stops_health.py
+++ b/tests/test_position_stops_health.py
@@ -34,7 +34,7 @@ def _pos(
     }
 
 
-def _mocks(memory=None, mysql=None, exchange_raises=False):
+def _mocks(memory=None, mysql=None, exchange_raises=False, binance_open_ids=None):
     spm = MagicMock()
     spm.get_all_open_strategy_positions.return_value = memory or []
     spm.close_strategy_position = AsyncMock()
@@ -47,6 +47,10 @@ def _mocks(memory=None, mysql=None, exchange_raises=False):
         exc.execute = AsyncMock(side_effect=Exception("exchange error"))
     else:
         exc.execute = AsyncMock(return_value={"order_id": "mock-order-id"})
+    # AC3 of #424: stops-health now verifies stored sl/tp ids against
+    # the on-Binance open-order set; tests must seed this explicitly so
+    # the verified-healthy path can be exercised.
+    exc.get_all_open_orders = AsyncMock(return_value=set(binance_open_ids or []))
 
     pub = MagicMock()
     pub.publish = AsyncMock(return_value=True)
@@ -56,8 +60,13 @@ def _mocks(memory=None, mysql=None, exchange_raises=False):
 
 @pytest.mark.asyncio
 async def test_all_healthy():
-    pos = _pos(sl_order_id="sl-1", tp_order_id="tp-1")
-    spm, pc, exc, pub = _mocks(memory=[pos])
+    # AC3 of #424: real Binance algo-order IDs (>=13 digit integers) AND
+    # both must be in the on-Binance open-orders set before stops-health
+    # may declare a position healthy.
+    real_sl = "1398104567890123"
+    real_tp = "1398104567890124"
+    pos = _pos(sl_order_id=real_sl, tp_order_id=real_tp)
+    spm, pc, exc, pub = _mocks(memory=[pos], binance_open_ids={real_sl, real_tp})
 
     resp = await check_position_stops(spm, pc, exc, pub)
 
@@ -66,6 +75,7 @@ async def test_all_healthy():
     assert resp.total_checked == 1
     assert resp.alarms_emitted == 0
     assert resp.positions[0].status == "healthy"
+    assert resp.divergences == []
     exc.execute.assert_not_called()
 
 
@@ -174,3 +184,170 @@ async def test_empty_no_open_positions():
     assert resp.violation_count == 0
     assert resp.alarms_emitted == 0
     assert len(resp.positions) == 0
+
+
+# ---------------------------------------------------------------------------
+# AC3 of #424 — Binance verification + divergences + Pydantic validator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_h3_price_string_ids_are_not_healthy():
+    """AC3 / H3 of #424: stored sl/tp IDs that are price strings (e.g.
+    "2022.6338") must NOT be reported healthy regardless of memory
+    state — they fail both the algo-ID shape check AND on-Binance
+    presence. Mirrors test_h3_stops_health_must_verify_against_binance
+    from the 2026-05-30 incident reproduction file."""
+    pos = _pos(
+        spid="repro-h3-1",
+        symbol="ETHUSDT",
+        side="LONG",
+        sl_order_id="2022.6338",
+        tp_order_id="2050.12",
+        stop_loss_price=1980.0,
+        take_profit_price=2060.0,
+        entry_quantity=0.05,
+        entry_price=2022.6338,
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos], binance_open_ids=set())
+
+    resp = await check_position_stops(spm, pc, exc, pub)
+
+    assert resp.healthy_count == 0
+    assert resp.violation_count == 1
+    assert len(resp.divergences) == 1
+
+    dv = resp.divergences[0]
+    assert dv.strategy_position_id == "repro-h3-1"
+    assert dv.symbol == "ETHUSDT"
+    assert dv.sl_id_is_real_algo_id is False
+    assert dv.tp_id_is_real_algo_id is False
+    assert dv.sl_present_on_binance is False
+    assert dv.tp_present_on_binance is False
+
+
+@pytest.mark.asyncio
+async def test_h3_real_ids_but_missing_on_binance_reports_divergence():
+    """AC3: even with proper-shape IDs, a position is NOT healthy when
+    Binance reports neither ID as open."""
+    real_sl = "1398104567890123"
+    real_tp = "1398104567890124"
+    pos = _pos(
+        sl_order_id=real_sl,
+        tp_order_id=real_tp,
+        stop_loss_price=45000.0,
+        take_profit_price=55000.0,
+    )
+    # Binance returns an unrelated open order — neither stored ID present.
+    spm, pc, exc, pub = _mocks(memory=[pos], binance_open_ids={"9999999999999"})
+
+    resp = await check_position_stops(spm, pc, exc, pub)
+
+    assert resp.healthy_count == 0
+    assert resp.violation_count == 1
+    assert len(resp.divergences) == 1
+    dv = resp.divergences[0]
+    assert dv.sl_id_is_real_algo_id is True
+    assert dv.tp_id_is_real_algo_id is True
+    assert dv.sl_present_on_binance is False
+    assert dv.tp_present_on_binance is False
+
+
+@pytest.mark.asyncio
+async def test_h3_only_one_side_on_binance_reports_partial_divergence():
+    """AC3: when only SL is on Binance and TP is missing, the position
+    is unhealthy with sl_present=True / tp_present=False."""
+    real_sl = "1398104567890123"
+    real_tp = "1398104567890124"
+    pos = _pos(
+        sl_order_id=real_sl,
+        tp_order_id=real_tp,
+        stop_loss_price=45000.0,
+        take_profit_price=55000.0,
+    )
+    # Only SL is on Binance.
+    spm, pc, exc, pub = _mocks(memory=[pos], binance_open_ids={real_sl})
+
+    resp = await check_position_stops(spm, pc, exc, pub)
+
+    assert resp.healthy_count == 0
+    assert len(resp.divergences) == 1
+    dv = resp.divergences[0]
+    assert dv.sl_present_on_binance is True
+    assert dv.tp_present_on_binance is False
+
+
+def test_risk_order_ids_validator_accepts_real_algo_ids():
+    """AC3: Pydantic validator MUST accept 13+ digit integer-string IDs
+    (Binance algo-order shape) and None."""
+    from tradeengine.position_health_guard import RiskOrderIds
+
+    ok = RiskOrderIds(sl_order_id="1398104567890123", tp_order_id=None)
+    assert ok.sl_order_id == "1398104567890123"
+    assert ok.tp_order_id is None
+
+
+def test_risk_order_ids_validator_rejects_price_string():
+    """AC3: Pydantic validator MUST reject price-shaped strings — the
+    exact failure mode that produced 366 falsely-healthy positions on
+    2026-05-30."""
+    from pydantic import ValidationError
+
+    from tradeengine.position_health_guard import RiskOrderIds
+
+    with pytest.raises(ValidationError) as sl_exc:
+        RiskOrderIds(sl_order_id="2022.6338", tp_order_id=None)
+    assert "Binance algo-order ID" in str(sl_exc.value)
+
+    with pytest.raises(ValidationError) as tp_exc:
+        RiskOrderIds(sl_order_id=None, tp_order_id="2050.12")
+    assert "Binance algo-order ID" in str(tp_exc.value)
+
+
+def test_risk_order_ids_validator_rejects_short_integers():
+    """AC3: a 5-digit number is shorter than any Binance algo-order ID
+    — reject as well so debug placeholders cannot leak through."""
+    from pydantic import ValidationError
+
+    from tradeengine.position_health_guard import RiskOrderIds
+
+    with pytest.raises(ValidationError) as exc:
+        RiskOrderIds(sl_order_id="12345", tp_order_id=None)
+    assert "Binance algo-order ID" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_set_strategy_position_orders_validates_via_pydantic():
+    """AC3: the StrategyPositionManager setter rejects non-algo IDs at
+    the boundary so future callers cannot reintroduce the bug."""
+    from pydantic import ValidationError
+
+    from tradeengine.strategy_position_manager import StrategyPositionManager
+
+    spm = StrategyPositionManager()
+    spm.strategy_positions = {
+        "spid-1": {
+            "strategy_position_id": "spid-1",
+            "symbol": "BTCUSDT",
+            "side": "LONG",
+            "sl_order_id": None,
+            "tp_order_id": None,
+        }
+    }
+
+    # Real-shape IDs accepted + persisted in memory
+    await spm.set_strategy_position_orders(
+        strategy_position_id="spid-1",
+        sl_order_id="1398104567890123",
+        tp_order_id="1398104567890124",
+    )
+    assert spm.strategy_positions["spid-1"]["sl_order_id"] == "1398104567890123"
+    assert spm.strategy_positions["spid-1"]["tp_order_id"] == "1398104567890124"
+
+    # Price-shaped value rejected at the boundary
+    with pytest.raises(ValidationError) as exc:
+        await spm.set_strategy_position_orders(
+            strategy_position_id="spid-1",
+            sl_order_id="2022.6338",
+        )
+    assert "Binance algo-order ID" in str(exc.value)

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -3397,6 +3397,32 @@ class Dispatcher:
                             stop_loss_order_id=oco_result.get("sl_order_id"),
                             take_profit_order_id=oco_result.get("tp_order_id"),
                         )
+
+                    # AC3 of #424 (2026-05-30 OCO incident): also propagate
+                    # the real Binance algo-order IDs into the
+                    # strategy_position record so stops-health verification
+                    # has the right values to check against the exchange.
+                    # set_strategy_position_orders validates the IDs via
+                    # RiskOrderIds, rejecting price-shaped strings.
+                    if strategy_position_id:
+                        try:
+                            await (
+                                strategy_position_manager.set_strategy_position_orders(
+                                    strategy_position_id=strategy_position_id,
+                                    sl_order_id=oco_result.get("sl_order_id"),
+                                    tp_order_id=oco_result.get("tp_order_id"),
+                                )
+                            )
+                        except Exception as exc:
+                            # Swallow validation/persistence errors here so
+                            # OCO-placement success is not undone by a
+                            # downstream record-keeping failure — but log
+                            # loudly so the bad-id case stays visible.
+                            self.logger.error(
+                                "set_strategy_position_orders failed for %s: %s",
+                                strategy_position_id,
+                                exc,
+                            )
                 elif oco_result.get("error") == "duplicate_oco":
                     # Position already has an active OCO pair — expected when multiple
                     # strategies accumulate into the same exchange position.

--- a/tradeengine/position_health_guard.py
+++ b/tradeengine/position_health_guard.py
@@ -1,13 +1,51 @@
 import logging
+import re
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from contracts.order import TradeOrder
 from shared.constants import UTC
 
 logger = logging.getLogger(__name__)
+
+
+# AC3 of #424: a Binance futures algo-order ID is a 13+ digit integer.
+# Anything else (price strings, sentinel placeholders, UUIDs) MUST be
+# rejected at the storage boundary so stops-health verification works.
+_BINANCE_ALGO_ID_RE = re.compile(r"^\d{13,}$")
+
+
+def _is_real_algo_id(value: Any) -> bool:
+    """True when value is a string that looks like a Binance algo order ID."""
+    if value is None:
+        return False
+    return bool(_BINANCE_ALGO_ID_RE.match(str(value)))
+
+
+class RiskOrderIds(BaseModel):
+    """Storage-side model for the SL/TP Binance algo-order IDs.
+
+    AC3 of #424: writers MUST go through this model so price-shaped
+    values (e.g. "2022.6338") cannot leak into the sl_order_id /
+    tp_order_id slots and pretend to be real algo orders.
+    """
+
+    sl_order_id: str | None = None
+    tp_order_id: str | None = None
+
+    @field_validator("sl_order_id", "tp_order_id")
+    @classmethod
+    def _must_be_binance_algo_id(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        s = str(v)
+        if not _BINANCE_ALGO_ID_RE.match(s):
+            raise ValueError(
+                f"order_id must be a Binance algo-order ID (>=13 digits); got {s!r}"
+            )
+        return s
 
 
 class PositionStopStatus(BaseModel):
@@ -33,6 +71,26 @@ class PositionStopStatus(BaseModel):
     source: Literal["memory", "mysql", "both"]
 
 
+class StopsDivergence(BaseModel):
+    """A position whose stored order IDs are not present on Binance.
+
+    Emitted for AC3 of #424 so the operator dashboard can list exactly
+    which positions diverge from the exchange — instead of a single
+    aggregate "violation_count" that hides the why.
+    """
+
+    strategy_position_id: str
+    symbol: str
+    side: str
+    stored_sl_order_id: str | None
+    stored_tp_order_id: str | None
+    sl_present_on_binance: bool
+    tp_present_on_binance: bool
+    sl_id_is_real_algo_id: bool
+    tp_id_is_real_algo_id: bool
+    detail: str
+
+
 class PositionStopsHealthResponse(BaseModel):
     timestamp: str
     total_checked: int
@@ -40,6 +98,7 @@ class PositionStopsHealthResponse(BaseModel):
     violation_count: int
     alarms_emitted: int
     positions: list[PositionStopStatus]
+    divergences: list[StopsDivergence] = []
 
 
 async def check_position_stops(
@@ -88,9 +147,39 @@ async def check_position_stops(
             source_map[pid] = "mysql"
 
     result_positions: list[PositionStopStatus] = []
+    divergences: list[StopsDivergence] = []
     healthy_count = 0
     violation_count = 0
     alarms_emitted = 0
+
+    # AC3 of #424: per-symbol cache of Binance open algo-order IDs. None
+    # signals "verification unavailable" (exchange call failed) — we then
+    # only fall back to a fail-open healthy verdict when the local IDs
+    # at least pass the shape check.
+    binance_open_by_symbol: dict[str, set[str] | None] = {}
+
+    async def _binance_ids_for(symbol: str) -> set[str] | None:
+        if symbol in binance_open_by_symbol:
+            return binance_open_by_symbol[symbol]
+        if exchange is None or not hasattr(exchange, "get_all_open_orders"):
+            binance_open_by_symbol[symbol] = None
+            return None
+        try:
+            raw = await exchange.get_all_open_orders(symbol=symbol)
+        except Exception as exc:
+            logger.warning(
+                "stops-health: get_all_open_orders(%s) failed: %s — verification unavailable",
+                symbol,
+                exc,
+            )
+            binance_open_by_symbol[symbol] = None
+            return None
+        if raw is None:
+            normalized: set[str] | None = set()
+        else:
+            normalized = {str(x) for x in raw}
+        binance_open_by_symbol[symbol] = normalized
+        return normalized
 
     for spid, pos in merged.items():
         sl_order_id = pos.get("sl_order_id")
@@ -98,24 +187,77 @@ async def check_position_stops(
         has_sl = sl_order_id is not None
         has_tp = tp_order_id is not None
         src = source_map.get(spid, "memory")
+        symbol_for_pos = pos.get("symbol", "unknown")
 
         if has_sl and has_tp:
-            result_positions.append(
-                PositionStopStatus(
+            # AC3 of #424: verify on Binance before declaring healthy.
+            # A position is healthy only when BOTH stored IDs look like
+            # Binance algo IDs AND are actually open on the exchange.
+            binance_ids = await _binance_ids_for(symbol_for_pos)
+            sl_real = _is_real_algo_id(sl_order_id)
+            tp_real = _is_real_algo_id(tp_order_id)
+            sl_present = (
+                binance_ids is not None and sl_real and str(sl_order_id) in binance_ids
+            )
+            tp_present = (
+                binance_ids is not None and tp_real and str(tp_order_id) in binance_ids
+            )
+
+            verified_healthy = binance_ids is not None and sl_present and tp_present
+            # Fail-open path: if Binance verification is unavailable, only
+            # accept the position as healthy when local IDs at least pass
+            # the shape check — otherwise the price-string bug stays hidden.
+            unverified_healthy = binance_ids is None and sl_real and tp_real
+
+            if verified_healthy or unverified_healthy:
+                result_positions.append(
+                    PositionStopStatus(
+                        strategy_position_id=spid,
+                        symbol=symbol_for_pos,
+                        side=pos.get("side", "unknown"),
+                        has_sl_order=True,
+                        has_tp_order=True,
+                        sl_order_id=str(sl_order_id),
+                        tp_order_id=str(tp_order_id),
+                        status="healthy",
+                        remediation_outcome="none",
+                        source=src,
+                    )
+                )
+                healthy_count += 1
+                continue
+
+            # Verification ran AND the stored IDs are not both present on
+            # Binance — record a divergence and fall through to remediation.
+            divergences.append(
+                StopsDivergence(
                     strategy_position_id=spid,
-                    symbol=pos.get("symbol", "unknown"),
+                    symbol=symbol_for_pos,
                     side=pos.get("side", "unknown"),
-                    has_sl_order=True,
-                    has_tp_order=True,
-                    sl_order_id=str(sl_order_id),
-                    tp_order_id=str(tp_order_id),
-                    status="healthy",
-                    remediation_outcome="none",
-                    source=src,
+                    stored_sl_order_id=(
+                        str(sl_order_id) if sl_order_id is not None else None
+                    ),
+                    stored_tp_order_id=(
+                        str(tp_order_id) if tp_order_id is not None else None
+                    ),
+                    sl_present_on_binance=bool(sl_present),
+                    tp_present_on_binance=bool(tp_present),
+                    sl_id_is_real_algo_id=sl_real,
+                    tp_id_is_real_algo_id=tp_real,
+                    detail=(
+                        f"sl_present={sl_present} tp_present={tp_present} "
+                        f"sl_real={sl_real} tp_real={tp_real}"
+                    ),
                 )
             )
-            healthy_count += 1
-            continue
+            # Rewrite local flags so the existing missing-* remediation
+            # block downstream treats the unverified side as missing.
+            has_sl = bool(sl_present)
+            has_tp = bool(tp_present)
+            if has_sl and has_tp:
+                # Defensive: should be unreachable given verified_healthy
+                # would have caught this; included for clarity.
+                continue
 
         violation_count += 1
         if not has_sl and not has_tp:
@@ -235,4 +377,5 @@ async def check_position_stops(
         violation_count=violation_count,
         alarms_emitted=alarms_emitted,
         positions=result_positions,
+        divergences=divergences,
     )

--- a/tradeengine/strategy_position_manager.py
+++ b/tradeengine/strategy_position_manager.py
@@ -130,8 +130,13 @@ class StrategyPositionManager:
                 "entry_order_id": entry_order_id,
                 "take_profit_price": take_profit_price,
                 "stop_loss_price": stop_loss_price,
-                "tp_order_id": order.take_profit,  # Will be set when OCO placed
-                "sl_order_id": order.stop_loss,  # Will be set when OCO placed
+                # AC3 of #424: these must hold real Binance algo-order IDs,
+                # not the price-shaped placeholders that surfaced in the
+                # 2026-05-30 incident. They are populated by the OCO-success
+                # path via set_strategy_position_orders() once the algo orders
+                # come back with their real IDs.
+                "tp_order_id": None,
+                "sl_order_id": None,
                 "status": "open",
                 "exchange_position_key": exchange_position_key,
                 "strategy_metadata": {
@@ -179,6 +184,37 @@ class StrategyPositionManager:
         except Exception as e:
             logger.error(f"Error creating strategy position: {e}")
             raise
+
+    async def set_strategy_position_orders(
+        self,
+        strategy_position_id: str,
+        sl_order_id: str | None = None,
+        tp_order_id: str | None = None,
+    ) -> None:
+        # AC3 of #424 (2026-05-30 OCO incident): the previous code stored
+        # price strings here as placeholders, which made the stops-health
+        # endpoint report 366 positions healthy while Binance had only 12
+        # positions and 2 close orders. IDs are validated against the
+        # Binance algo-order pattern via RiskOrderIds — non-matching values
+        # are rejected at the boundary so the bug cannot recur.
+        from tradeengine.position_health_guard import RiskOrderIds
+
+        validated = RiskOrderIds(
+            sl_order_id=sl_order_id,
+            tp_order_id=tp_order_id,
+        )
+
+        record = self.strategy_positions.get(strategy_position_id)
+        if record is None:
+            logger.warning(
+                "set_strategy_position_orders: %s not in memory — skipping in-memory update",
+                strategy_position_id,
+            )
+        else:
+            if validated.sl_order_id is not None:
+                record["sl_order_id"] = validated.sl_order_id
+            if validated.tp_order_id is not None:
+                record["tp_order_id"] = validated.tp_order_id
 
     async def close_strategy_position(
         self,


### PR DESCRIPTION
Implements **AC3 / RC#4 of #424** (OCO orphan-legs incident, 2026-05-30). `/positions/stops-health` reported 366 positions healthy while Binance had only 12 positions and 2 close orders — two coupled bugs:

1. The write site at `strategy_position_manager.py:133-134` stored the order TP/SL **prices** into the `sl_order_id`/`tp_order_id` slots as placeholders, and nothing updated them after the OCO came back.
2. `check_position_stops` marked positions healthy purely on `sl_order_id is not None`, never asking Binance.

## Closes
Closes #427

## What changed

### `tradeengine/position_health_guard.py`
- `RiskOrderIds` Pydantic model with `field_validator`: rejects anything that isn't `None` or a >=13-digit integer string (the Binance algo-order shape).
- `StopsDivergence` model + `divergences[]` response field listing exactly which positions diverge and why (sl/tp present-on-binance + id-shape flags).
- `check_position_stops` now calls `exchange.get_all_open_orders(symbol)` per unique symbol (cached) and marks a position healthy only when both stored IDs pass the shape check **AND** are present in the on-Binance set. Verification-unavailable falls open only when both IDs already pass the shape check.

### `tradeengine/strategy_position_manager.py`
- Write-site fix: `sl_order_id` / `tp_order_id` initialise to `None` instead of the order PRICES.
- New `set_strategy_position_orders` setter — validates via `RiskOrderIds` so the price-string bug cannot reappear from a future caller.

### `tradeengine/dispatcher.py`
- After a successful OCO placement, the dispatcher propagates the real Binance algo IDs into the strategy_position record via the new setter. Boundary errors are logged but never undo OCO success.

## Tests

5 new AC3 tests in `tests/test_position_stops_health.py` (price-string IDs, real-but-absent IDs, partial divergence, Pydantic validator x3, setter boundary). Pre-existing `test_all_healthy` widened to seed Binance with the real IDs the position references.

Full local suite: **1480 passed**, 13 skipped.

## Out of scope (RC#3 / RC#5 / RC#6)
- TE_MIN_SL_DISTANCE_PCT safety floor (AC4 / #428)
- Reconciler unhedged divergence alert (AC5 / #429)
- Unhedged-positions runbook (AC6 / #430)