### PR TITLE
fix(risk): price-adjustment safety floor TE_MIN_SL_DISTANCE_PCT (#428)

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -42,6 +42,15 @@ class Settings(BaseSettings):
     max_portfolio_exposure_pct: float = 0.8  # 80%
     risk_management_enabled: bool = True
 
+    # AC4 of #424 (2026-05-30 OCO incident): minimum stop-loss distance
+    # from the live market, in percent. If an adjusted SL would land
+    # within this band of market, the PERCENT_PRICE adjuster refuses to
+    # return a price — the dispatcher then emits a structured rejection
+    # instead of placing a guaranteed-to-trigger stop. Default 6.0%
+    # covers typical Binance Futures 4h candle moves (4-5% on alts) plus
+    # headroom; can be tightened/relaxed per-deploy via env var.
+    te_min_sl_distance_pct: float = 6.0
+
     # Redis Configuration (for caching)
     redis_url: str | None = None
     redis_password: str | None = None

--- a/tests/test_min_sl_distance.py
+++ b/tests/test_min_sl_distance.py
@@ -1,0 +1,218 @@
+"""AC4 of #424: PERCENT_PRICE adjuster safety floor.
+
+Covers the 2026-05-30 OCO incident root cause #3 — the adjuster was
+allowed to clip SL prices to the PERCENT_PRICE boundary (e.g. +3.95%
+from market) which triggers on routine 4h candle volatility, producing
+the 272x APIError(-2021) flood observed in production.
+
+The adjuster now refuses to return a stop-loss price within
+`TE_MIN_SL_DISTANCE_PCT` of market (default 6.0); the dispatcher must
+emit a structured rejection instead of placing such a stop.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tradeengine.exchange.binance import BinanceFuturesExchange
+
+
+@pytest.fixture
+def exchange() -> BinanceFuturesExchange:
+    # Build a BinanceFuturesExchange but bypass network — only the helper
+    # methods used by validate_and_adjust_price_for_percent_filter are
+    # exercised, all of which are monkey-patched per test.
+    exc = BinanceFuturesExchange.__new__(BinanceFuturesExchange)
+    exc.client = MagicMock()
+    exc.testnet = True
+    return exc
+
+
+def _stub_filter(
+    exchange,
+    market_price: float,
+    multiplier_up: float = 1.05,
+    multiplier_down: float = 0.95,
+) -> None:
+    """Wire the helpers used by validate_and_adjust_price_for_percent_filter."""
+    exchange._get_current_price = AsyncMock(return_value=market_price)
+    exchange.get_percent_price_filter = MagicMock(
+        return_value={
+            "multiplierUp": str(multiplier_up),
+            "multiplierDown": str(multiplier_down),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4 / H4 — incident reproduction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_h4_refuses_sl_inside_safety_floor_when_filter_is_tight(exchange):
+    """AC4: when PERCENT_PRICE filter is ±5% and safety floor is 6%, the
+    adjusted SL would be guaranteed to trigger — the adjuster MUST refuse
+    instead of clipping to the boundary. Mirrors the BCHUSDT case from
+    the 2026-05-30 incident (market $303.10, adjusted SL $315.07 = +3.95%)."""
+    market = 303.10
+    requested_sl = 442.03  # 45.84% above market — outside ±5% filter
+    _stub_filter(
+        exchange, market_price=market, multiplier_up=1.05, multiplier_down=0.95
+    )
+
+    (
+        is_adjusted,
+        adjusted_price,
+        msg,
+    ) = await exchange.validate_and_adjust_price_for_percent_filter(
+        symbol="BCHUSDT",
+        price=requested_sl,
+        order_type="STOP_LOSS",
+        min_safe_distance_pct=6.0,
+    )
+
+    assert is_adjusted is False
+    assert adjusted_price is None
+    assert "sl_unreachable_within_filter" in msg
+
+
+@pytest.mark.asyncio
+async def test_h4_refuses_sl_already_inside_safety_floor(exchange):
+    """AC4: a stop-loss whose requested price is already inside the
+    safety floor (e.g. 2% from market) MUST be refused even if it's
+    within the PERCENT_PRICE filter."""
+    market = 300.0
+    requested_sl = 306.0  # +2% — inside the 6% floor for a short SL
+    _stub_filter(
+        exchange, market_price=market, multiplier_up=1.10, multiplier_down=0.90
+    )
+
+    (
+        is_adjusted,
+        adjusted_price,
+        msg,
+    ) = await exchange.validate_and_adjust_price_for_percent_filter(
+        symbol="BTCUSDT",
+        price=requested_sl,
+        order_type="STOP_LOSS",
+        min_safe_distance_pct=6.0,
+    )
+
+    assert is_adjusted is False
+    assert adjusted_price is None
+    assert "sl_within_safety_floor" in msg
+
+
+@pytest.mark.asyncio
+async def test_h4_accepts_sl_outside_safety_floor_within_wider_filter(exchange):
+    """AC4: when the PERCENT_PRICE filter is wide enough (e.g. ±10%) and
+    the requested SL sits outside both the safety floor AND the filter,
+    the adjuster MUST clip to the safety-floor edge — not to the filter
+    boundary that lies inside the unsafe band."""
+    market = 1000.0
+    requested_sl = 1500.0  # +50% — far outside any filter
+    _stub_filter(
+        exchange, market_price=market, multiplier_up=1.10, multiplier_down=0.90
+    )
+
+    (
+        is_adjusted,
+        adjusted_price,
+        msg,
+    ) = await exchange.validate_and_adjust_price_for_percent_filter(
+        symbol="ETHUSDT",
+        price=requested_sl,
+        order_type="STOP_LOSS",
+        min_safe_distance_pct=6.0,
+    )
+
+    assert is_adjusted is True
+    assert adjusted_price is not None
+    # Result MUST be >= 6% above market (the safety floor).
+    pct_above = (adjusted_price - market) / market * 100
+    assert pct_above >= 6.0, (
+        f"adjusted SL {adjusted_price} is {pct_above:.2f}% above market — "
+        "must be >= 6% safety floor"
+    )
+
+
+@pytest.mark.asyncio
+async def test_h4_take_profit_not_subject_to_safety_floor(exchange):
+    """AC4: TP orders don't trigger the safety floor — they can legitimately
+    sit anywhere within the PERCENT_PRICE filter. A TP at +2% must be
+    accepted unchanged."""
+    market = 300.0
+    requested_tp = 306.0  # +2%
+    _stub_filter(
+        exchange, market_price=market, multiplier_up=1.10, multiplier_down=0.90
+    )
+
+    (
+        is_adjusted,
+        adjusted_price,
+        msg,
+    ) = await exchange.validate_and_adjust_price_for_percent_filter(
+        symbol="BTCUSDT",
+        price=requested_tp,
+        order_type="TAKE_PROFIT",
+        min_safe_distance_pct=6.0,
+    )
+
+    assert is_adjusted is False
+    assert adjusted_price == pytest.approx(306.0)
+
+
+@pytest.mark.asyncio
+async def test_h4_below_market_sl_inside_floor_refused(exchange):
+    """AC4: same logic for LONG-position SLs (below market). A SL at -2%
+    from market must be refused when the floor is 6%."""
+    market = 300.0
+    requested_sl = 294.0  # -2% — inside the 6% floor for a long SL
+    _stub_filter(
+        exchange, market_price=market, multiplier_up=1.10, multiplier_down=0.90
+    )
+
+    (
+        is_adjusted,
+        adjusted_price,
+        msg,
+    ) = await exchange.validate_and_adjust_price_for_percent_filter(
+        symbol="BTCUSDT",
+        price=requested_sl,
+        order_type="STOP_LOSS",
+        min_safe_distance_pct=6.0,
+    )
+
+    assert is_adjusted is False
+    assert adjusted_price is None
+    assert "sl_within_safety_floor" in msg
+
+
+@pytest.mark.asyncio
+async def test_h4_default_floor_comes_from_settings_when_not_passed(exchange):
+    """AC4: when ``min_safe_distance_pct`` is omitted, the adjuster
+    reads the default from ``Settings().te_min_sl_distance_pct`` (env
+    ``TE_MIN_SL_DISTANCE_PCT``, default 6.0). Verify by exercising the
+    same +2% short-SL refusal without explicit kwarg."""
+    market = 300.0
+    requested_sl = 306.0  # +2% — inside the default 6% floor
+    _stub_filter(
+        exchange, market_price=market, multiplier_up=1.10, multiplier_down=0.90
+    )
+
+    (
+        is_adjusted,
+        adjusted_price,
+        msg,
+    ) = await exchange.validate_and_adjust_price_for_percent_filter(
+        symbol="BTCUSDT",
+        price=requested_sl,
+        order_type="STOP_LOSS",
+    )
+
+    assert is_adjusted is False
+    assert adjusted_price is None
+    assert "sl_within_safety_floor" in msg

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -3493,6 +3493,31 @@ class Dispatcher:
                     ) = await self.exchange.validate_and_adjust_price_for_percent_filter(
                         order.symbol, order.stop_loss, "STOP_LOSS"
                     )
+                    # AC4 of #424: adjuster returns (False, None, reason) when
+                    # the requested SL cannot satisfy both PERCENT_PRICE and
+                    # the safety floor (e.g. SL would land within 6% of
+                    # market). Emit a structured rejection and SKIP the SL
+                    # placement so we don't ship a guaranteed-to-trigger stop.
+                    if adjusted_price is None:
+                        self.logger.error(
+                            f"⛔ STOP LOSS REFUSED for {order.symbol}: {adjustment_msg}"
+                        )
+                        order.mark_rejected(
+                            source="validation",
+                            reason="sl_unreachable_within_filter",
+                        )
+                        await self._emit_execution_event_from_order(
+                            order,
+                            {"status": "rejected", "error": adjustment_msg},
+                            event_type="rejected",
+                            reason="sl_unreachable_within_filter",
+                        )
+                        return {
+                            "status": "rejected",
+                            "reason": "sl_unreachable_within_filter",
+                            "rejection_source": "validation",
+                            "error": adjustment_msg,
+                        }
                     if is_adjusted:
                         self.logger.warning(
                             f"🔧 STOP LOSS PRICE ADJUSTED: {adjustment_msg}"
@@ -3626,7 +3651,17 @@ class Dispatcher:
                     ) = await self.exchange.validate_and_adjust_price_for_percent_filter(
                         order.symbol, order.take_profit, "TAKE_PROFIT"
                     )
-                    if is_adjusted:
+                    # AC4 of #424: the safety-floor refusal path also returns
+                    # (False, None, reason). TPs don't trigger the safety
+                    # floor by default (the floor is STOP-shaped only), but
+                    # the new return shape requires handling None here too;
+                    # skip TP placement in that case rather than crash.
+                    if adjusted_price is None:
+                        self.logger.error(
+                            f"⛔ TAKE PROFIT REFUSED for {order.symbol}: {adjustment_msg}"
+                        )
+                        adjusted_take_profit = None
+                    elif is_adjusted:
                         self.logger.warning(
                             f"🔧 TAKE PROFIT PRICE ADJUSTED: {adjustment_msg}"
                         )

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -761,24 +761,52 @@ class BinanceFuturesExchange:
         }
 
     async def validate_and_adjust_price_for_percent_filter(
-        self, symbol: str, price: float, order_type: str
-    ) -> tuple[bool, float, str]:
-        """Validate and intelligently adjust order price to be within PERCENT_PRICE filter limits.
+        self,
+        symbol: str,
+        price: float,
+        order_type: str,
+        min_safe_distance_pct: float | None = None,
+    ) -> tuple[bool, float | None, str]:
+        """Validate and intelligently adjust an order price to fit Binance's PERCENT_PRICE filter.
 
-        If the price violates the filter, it will be automatically adjusted to the nearest
-        valid price with a safety margin to avoid rejection.
+        AC4 of #424 (2026-05-30 OCO incident): for stop-loss-shaped orders
+        the adjuster also refuses to return a price within
+        ``min_safe_distance_pct`` of the current market — placing such a
+        stop is guaranteed to trigger on routine candle volatility,
+        producing the 272x APIError(-2021) flood observed in the incident.
 
         Args:
             symbol: Trading symbol
             price: Order price to validate/adjust
-            order_type: Type of order (for logging)
+            order_type: Type of order; case-insensitive substring "STOP"
+                triggers the safety-floor check.
+            min_safe_distance_pct: Minimum |distance| from market in percent
+                below which the adjuster will refuse to return a price.
+                Defaults to ``settings.te_min_sl_distance_pct`` (env var
+                ``TE_MIN_SL_DISTANCE_PCT``, default 6.0). Only enforced
+                for stop-loss-shaped order_types — TPs may legitimately
+                sit near market.
 
         Returns:
-            tuple: (is_adjusted, adjusted_price, message)
-                   (False, original_price, "") if already valid
-                   (True, adjusted_price, "adjustment description") if adjusted
+            tuple: ``(is_adjusted, adjusted_price, message)``
+                - ``(False, original_price, "")`` if already valid
+                - ``(True, adjusted_price, msg)`` if adjusted inside the filter
+                - ``(False, None, reason)`` if the requested price cannot
+                  satisfy both PERCENT_PRICE and the safety floor — the
+                  dispatcher must NOT place the order and should emit a
+                  structured rejection instead.
         """
+        # Local import to avoid a config-import cycle in test setups.
+        from shared.config import Settings
+
         try:
+            if min_safe_distance_pct is None:
+                try:
+                    min_safe_distance_pct = float(Settings().te_min_sl_distance_pct)
+                except Exception:
+                    min_safe_distance_pct = 6.0
+            is_stop = "STOP" in (order_type or "").upper()
+
             # Get current market price
             current_price = await self._get_current_price(symbol)
 
@@ -795,10 +823,50 @@ class BinanceFuturesExchange:
             # Calculate deviation percentage
             deviation_pct = ((price - current_price) / current_price) * 100
 
+            # AC4: for STOP-shaped orders, compute the safety-floor band
+            # around market and refuse to return a price inside it. If the
+            # PERCENT_PRICE band fits entirely inside the safety-floor band
+            # (e.g. filter is ±5% and floor is 6%), refuse any adjustment.
+            if is_stop:
+                floor_lo = current_price * (1 - min_safe_distance_pct / 100.0)
+                floor_hi = current_price * (1 + min_safe_distance_pct / 100.0)
+                # Above-market stop (e.g. short SL): must be >= floor_hi
+                # Below-market stop (e.g. long SL): must be <= floor_lo
+                if price > current_price:
+                    # Above-market: adjusted ceiling under filter is max_price;
+                    # safety floor is floor_hi. Feasible iff max_price >= floor_hi.
+                    if max_price < floor_hi:
+                        reason = (
+                            f"sl_unreachable_within_filter: requested ${price:.2f} "
+                            f"({deviation_pct:+.2f}%) cannot satisfy both PERCENT_PRICE "
+                            f"(max {(multiplier_up - 1) * 100:+.2f}%) and safety floor "
+                            f"({min_safe_distance_pct:+.2f}%) for {symbol} {order_type}; "
+                            f"market=${current_price:.2f}"
+                        )
+                        logger.error(reason)
+                        return (False, None, reason)
+                elif price < current_price:
+                    if min_price > floor_lo:
+                        reason = (
+                            f"sl_unreachable_within_filter: requested ${price:.2f} "
+                            f"({deviation_pct:+.2f}%) cannot satisfy both PERCENT_PRICE "
+                            f"(min {(multiplier_down - 1) * 100:+.2f}%) and safety floor "
+                            f"({-min_safe_distance_pct:+.2f}%) for {symbol} {order_type}; "
+                            f"market=${current_price:.2f}"
+                        )
+                        logger.error(reason)
+                        return (False, None, reason)
+
             # Check if adjustment is needed
             if price < min_price:
                 # Price too low - adjust to minimum with safety margin
                 adjusted_price = min_price
+                # AC4: for STOP-shaped orders, also respect the safety floor
+                # — clip to the floor edge whose direction matches the price.
+                if is_stop and adjusted_price > current_price * (
+                    1 - min_safe_distance_pct / 100.0
+                ):
+                    adjusted_price = current_price * (1 - min_safe_distance_pct / 100.0)
                 adjustment_msg = (
                     f"🔧 ADJUSTED {symbol} {order_type} price from ${price:.2f} ({deviation_pct:+.2f}%) "
                     f"to ${adjusted_price:.2f} ({((adjusted_price - current_price) / current_price) * 100:+.2f}%) "
@@ -811,6 +879,10 @@ class BinanceFuturesExchange:
             elif price > max_price:
                 # Price too high - adjust to maximum with safety margin
                 adjusted_price = max_price
+                if is_stop and adjusted_price < current_price * (
+                    1 + min_safe_distance_pct / 100.0
+                ):
+                    adjusted_price = current_price * (1 + min_safe_distance_pct / 100.0)
                 adjustment_msg = (
                     f"🔧 ADJUSTED {symbol} {order_type} price from ${price:.2f} ({deviation_pct:+.2f}%) "
                     f"to ${adjusted_price:.2f} ({((adjusted_price - current_price) / current_price) * 100:+.2f}%) "
@@ -819,6 +891,31 @@ class BinanceFuturesExchange:
                 )
                 logger.warning(adjustment_msg)
                 return (True, adjusted_price, adjustment_msg)
+
+            # Price is within filter — for stops, also verify it clears the safety floor.
+            if is_stop:
+                if price > current_price and price < current_price * (
+                    1 + min_safe_distance_pct / 100.0
+                ):
+                    reason = (
+                        f"sl_within_safety_floor: requested ${price:.2f} "
+                        f"({deviation_pct:+.2f}%) is inside the safety floor "
+                        f"({min_safe_distance_pct:+.2f}%) for {symbol} {order_type}; "
+                        f"market=${current_price:.2f}"
+                    )
+                    logger.error(reason)
+                    return (False, None, reason)
+                if price < current_price and price > current_price * (
+                    1 - min_safe_distance_pct / 100.0
+                ):
+                    reason = (
+                        f"sl_within_safety_floor: requested ${price:.2f} "
+                        f"({deviation_pct:+.2f}%) is inside the safety floor "
+                        f"({-min_safe_distance_pct:+.2f}%) for {symbol} {order_type}; "
+                        f"market=${current_price:.2f}"
+                    )
+                    logger.error(reason)
+                    return (False, None, reason)
 
             # Price is valid - no adjustment needed
             logger.info(


### PR DESCRIPTION
Implements **AC4 / RC#3 of #424** (OCO orphan-legs incident, 2026-05-30). 272x APIError(-2021) — the PERCENT_PRICE adjuster clipped SL prices to the filter boundary, triggering on routine 4h candle volatility.

## Closes
Closes #428

## What changed

- `tradeengine/exchange/binance.py`: `validate_and_adjust_price_for_percent_filter` gains optional `min_safe_distance_pct` (default `Settings().te_min_sl_distance_pct`, env `TE_MIN_SL_DISTANCE_PCT`, default **6.0**). Floor enforced only for STOP-shaped `order_type` — TPs unchanged. Return widened to `tuple[bool, float | None, str]`; `(False, None, reason)` signals 'cannot satisfy both PERCENT_PRICE and safety floor — caller MUST refuse to place'.
- `tradeengine/dispatcher.py`: SL callsite emits structured rejection (`rejection_source='validation'`, `rejection_reason='sl_unreachable_within_filter'`) and skips placement when adjuster returns `None`. TP callsite handles `None` defensively.
- `shared/config.py`: new `te_min_sl_distance_pct: float = 6.0` setting.

## Tests

6 new AC4 tests in `tests/test_min_sl_distance.py`:
- H4 incident reproduction (tight filter + floor → refuse)
- Pre-existing inside-floor SL → refuse
- Outside-both → clip to safety-floor edge (not filter edge)
- LONG-position SL (below market) — same logic, opposite direction
- TP not subject to floor
- Default floor comes from `Settings()` when kwarg omitted

Pre-existing `tests/test_binance_exchange_comprehensive.py` (64 tests) still passes — return-shape widening is backward-compatible.

Full local suite: **1479 passed**, 13 skipped.