### PR TITLE
docs+ops: unhedged-positions runbook + close_unhedged_positions.py (#430)

### DIFF
--- a/docs/runbooks/unhedged-positions.md
+++ b/docs/runbooks/unhedged-positions.md
@@ -1,0 +1,144 @@
+# Runbook: Unhedged Position Detected
+
+**Alert:** `UnhedgedPositionDetected` (Grafana Cloud)
+**Metric:** `tradeengine_position_reconciliation_divergences_total{category="unhedged"} > 0`
+**Severity:** `critical`
+**Origin:** AC5 / RC#5 of [#424](https://github.com/PetroSa2/petrosa-tradeengine/issues/424) (2026-05-30 OCO orphan-legs incident)
+
+---
+
+## What this alert means
+
+A live, non-zero position exists on Binance Futures for which TradeEngine cannot find both:
+
+- a reduceOnly **STOP**-shaped order (stop loss), AND
+- a reduceOnly **TAKE_PROFIT**-shaped order (take profit)
+
+on the matching `(symbol, positionSide)`. The position is running **unprotected** — a routine adverse move will hit the entry-side margin without firing any pre-placed exit.
+
+On 2026-05-30 this exact state covered **11 of 12** open positions for **2+ hours** with no alert firing. The reconciler now flags it within 60 s.
+
+---
+
+## Why it triggers
+
+- **OCO placement failed during entry**, and the atomic-rollback path (AC2 / [#426](https://github.com/PetroSa2/petrosa-tradeengine/pull/434)) didn't close the position — historically blocked when `order.position_id` was absent or `filled_qty<=0`.
+- **stops-health stored a price string in `sl_order_id` / `tp_order_id`** (AC3 / [#427](https://github.com/PetroSa2/petrosa-tradeengine/pull/435)) — the position looked healthy locally while Binance held nothing.
+- **TP/SL `cancel` succeeded but their replacement wasn't placed** — e.g. operator UI action, mass cancel, or a deploy/restart between cancel and place.
+- **Algo-order limit** hit on the symbol (10 open algos max per Binance Futures) — new SL/TP could not be placed and the existing pair was cancelled.
+
+---
+
+## Triage steps
+
+### 1 — Confirm the alert + identify affected symbols
+
+```bash
+# Grafana / Prometheus
+sum(tradeengine_position_reconciliation_divergences_total{category="unhedged"}) by (symbol)
+
+# Reconciler log lines
+kubectl --kubeconfig=petrosa_k8s/k8s/kubeconfig.yaml --insecure-skip-tls-verify=true \
+  logs -n petrosa-apps deploy/petrosa-tradeengine --since=10m \
+  | grep -E "unhedged|PositionReconciler"
+```
+
+The log line carries `symbol`, `side`, `sl_present`, `tp_present`.
+
+### 2 — Cross-check against Binance directly
+
+```bash
+# Open positions
+curl -s http://localhost:8000/positions | jq '.[] | select(.amount != 0)'
+
+# Open algo orders (Binance ground truth)
+curl -s http://localhost:8000/orders/algo | jq '.[] | {symbol, type, positionSide, reduceOnly, closePosition}'
+
+# Or via the data-manager dashboard endpoint
+curl -s http://localhost:8001/api/dashboard/positions | jq .
+```
+
+You should be able to point to each unhedged `(symbol, side)` and confirm:
+
+- there IS a non-zero `positionAmt` on Binance, AND
+- there is NOT both a reduceOnly STOP order AND a reduceOnly TAKE_PROFIT order on the same `positionSide` (or `BOTH` for one-way mode).
+
+### 3 — Decide: place stops, or close the position
+
+If the position is small / recent / strategy still has conviction → **place protective stops manually** (via the Binance UI or `POST /orders/oco`).
+
+If the position has drifted far from entry, the strategy has closed elsewhere, or you cannot reconstruct intended stops → **close the position via the remediation script** (below).
+
+---
+
+## Remediation — one-shot script
+
+`scripts/close_unhedged_positions.py` lists unhedged positions (dry-run) and, with `--commit`, issues `MARKET reduceOnly` close orders against them.
+
+### Dry-run (default — always safe)
+
+```bash
+cd petrosa-tradeengine
+.venv/bin/python scripts/close_unhedged_positions.py
+```
+
+Prints a JSON line per unhedged position:
+
+```json
+{"symbol":"BCHUSDT","positionSide":"LONG","positionAmt":0.5,"sl_present":false,"tp_present":false,"would_close":true}
+```
+
+Exit code 0 if any are listed, 1 otherwise — safe to pipe into operator tooling.
+
+### Commit (live close)
+
+```bash
+.venv/bin/python scripts/close_unhedged_positions.py --commit
+```
+
+Requires `BINANCE_API_KEY` + `BINANCE_API_SECRET` in env. Issues `MARKET reduceOnly` orders for each unhedged `(symbol, positionSide)`; prints the order ID returned by Binance.
+
+Skips any position that already has both reduceOnly SL+TP — the dry-run output reflects the moment the script ran, not the operator's view; re-run with `--commit` if state changed in between.
+
+### Limiting scope
+
+```bash
+# Only close ETHUSDT
+.venv/bin/python scripts/close_unhedged_positions.py --commit --symbol ETHUSDT
+
+# Only close positions older than 1 hour
+.venv/bin/python scripts/close_unhedged_positions.py --commit --min-age-seconds 3600
+```
+
+---
+
+## Post-fix verification
+
+After AC1-AC5 land, re-run the incident reproduction tests:
+
+```bash
+cd petrosa_k8s
+.venv/bin/python -m pytest _bmad-output/incidents/2026-05-30/reproduction_test.py -v
+```
+
+All four (`test_h1` through `test_h4`) MUST pass. If any still fail, file a fresh leaf — do not modify the reproduction file.
+
+---
+
+## Why this happened — engineering background
+
+| Root cause | AC | Ticket | Status |
+|---|---|---|---|
+| RC#1 — partial OCO left surviving leg uncancelled | AC1 | [#425](https://github.com/PetroSa2/petrosa-tradeengine/pull/433) | ✅ shipped |
+| RC#2 — atomic-rollback early-returned without closing | AC2 | [#426](https://github.com/PetroSa2/petrosa-tradeengine/pull/434) | shipped in PR |
+| RC#3 — adjuster clipped SL to filter boundary (-2021) | AC4 | [#428](https://github.com/PetroSa2/petrosa-tradeengine/pull/436) | shipped in PR |
+| RC#4 — stops-health stored price strings as IDs | AC3 | [#427](https://github.com/PetroSa2/petrosa-tradeengine/pull/435) | shipped in PR |
+| RC#5 — reconciler didn't check position↔SL+TP parity | AC5 | [#429](https://github.com/PetroSa2/petrosa-tradeengine/pull/437) | shipped in PR |
+| RC#6 — no runbook for the unhedged state | AC6 | [#430](https://github.com/PetroSa2/petrosa-tradeengine/issues/430) | this document |
+
+---
+
+## Owners
+
+- **Tradeengine subsystem:** @yurisa2
+- **Observability rule:** `petrosa_k8s/observability/alert-rules/tradeengine-business-alerts.yaml` (uid `tradeengine-unhedged-position-detected`)

--- a/scripts/close_unhedged_positions.py
+++ b/scripts/close_unhedged_positions.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""One-shot operator tool: close Binance positions that lack reduceOnly SL+TP.
+
+AC6 of #424 (OCO orphan-legs incident, 2026-05-30). Reads the live Binance
+positionRisk + open-algo-order state, surfaces any position that lacks BOTH
+a reduceOnly STOP-shaped order AND a reduceOnly TAKE_PROFIT-shaped order on
+the matching positionSide, and (with ``--commit``) issues MARKET reduceOnly
+orders to close them.
+
+Dry-run is the default — the script is safe to run repeatedly to inspect
+state. ``--commit`` is what makes it actually close anything.
+
+Authentication: reads ``BINANCE_API_KEY`` and ``BINANCE_API_SECRET`` from
+the environment. Add ``BINANCE_TESTNET=1`` to point at testnet.
+
+Output: one JSON line per unhedged position to stdout. Exit code 0 if any
+were listed/closed, 1 if none — safe to chain into operator tooling.
+
+Usage:
+    # Dry-run (default — always safe)
+    python scripts/close_unhedged_positions.py
+
+    # Live close all unhedged
+    python scripts/close_unhedged_positions.py --commit
+
+    # Only ETHUSDT
+    python scripts/close_unhedged_positions.py --commit --symbol ETHUSDT
+
+    # Only positions older than 1 hour
+    python scripts/close_unhedged_positions.py --commit --min-age-seconds 3600
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from typing import Any
+
+# Logging goes to stderr so stdout is reserved for the JSON-line operator output.
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    stream=sys.stderr,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("close_unhedged_positions")
+
+
+def _is_reduce_only(order: dict[str, Any]) -> bool:
+    return bool(order.get("reduceOnly")) or bool(order.get("closePosition"))
+
+
+def _normalise_side(pos: dict[str, Any]) -> str:
+    side = str(pos.get("positionSide", "BOTH")).upper()
+    if side in ("LONG", "SHORT"):
+        return side
+    return "LONG" if float(pos.get("positionAmt", 0)) >= 0 else "SHORT"
+
+
+def _position_is_unhedged(
+    pos: dict[str, Any], symbol_orders: list[dict[str, Any]]
+) -> tuple[bool, bool, bool]:
+    """Return (unhedged, sl_present, tp_present) for one positionRisk row."""
+    side = _normalise_side(pos)
+    sl_present = False
+    tp_present = False
+    for o in symbol_orders:
+        o_side = str(o.get("positionSide", "BOTH")).upper()
+        if o_side not in ("BOTH", side):
+            continue
+        if not _is_reduce_only(o):
+            continue
+        o_type = str(o.get("type") or o.get("origType") or "").upper()
+        if "STOP" in o_type:
+            sl_present = True
+        elif "TAKE_PROFIT" in o_type:
+            tp_present = True
+    unhedged = not (sl_present and tp_present)
+    return unhedged, sl_present, tp_present
+
+
+async def _fetch_state(
+    client: Any,
+) -> tuple[list[dict[str, Any]], dict[str, list[dict[str, Any]]]]:
+    """Return (positions, open_algo_orders_by_symbol)."""
+    positions_raw = await client.get_position_info()
+    nonzero = [p for p in positions_raw if abs(float(p.get("positionAmt", 0))) > 1e-9]
+
+    orders_by_symbol: dict[str, list[dict[str, Any]]] = {}
+    for symbol in {p["symbol"] for p in nonzero}:
+        try:
+            orders = await client.get_open_algo_orders(symbol=symbol)
+        except Exception:
+            logger.exception(
+                "get_open_algo_orders(%s) failed — treating as no-orders (conservative)",
+                symbol,
+            )
+            orders = []
+        orders_by_symbol[symbol] = orders or []
+
+    return nonzero, orders_by_symbol
+
+
+async def _close_one(client: Any, pos: dict[str, Any]) -> dict[str, Any]:
+    """Issue a MARKET reduceOnly close for one position. Returns the
+    Binance API result (or a synthetic error dict if it raised)."""
+    symbol = pos["symbol"]
+    side = _normalise_side(pos)
+    qty = abs(float(pos["positionAmt"]))
+    # Closing direction is opposite of position side.
+    order_side = "SELL" if side == "LONG" else "BUY"
+    params = {
+        "symbol": symbol,
+        "side": order_side,
+        "type": "MARKET",
+        "quantity": qty,
+        "reduceOnly": True,
+        # If hedge mode, supply positionSide; one-way mode (BOTH) ignores it.
+        "positionSide": pos.get("positionSide", "BOTH"),
+    }
+    try:
+        result = await client.create_order(**params)
+    except Exception as exc:
+        logger.exception("close failed for %s %s qty=%s", symbol, side, qty)
+        return {"error": str(exc), "params": params}
+    return result
+
+
+def _filter_age(
+    positions: list[dict[str, Any]], min_age_seconds: int
+) -> list[dict[str, Any]]:
+    """Drop positions younger than min_age_seconds. ``updateTime`` is in
+    milliseconds; rows missing it are kept (better to consider them
+    eligible than skip silently)."""
+    if min_age_seconds <= 0:
+        return positions
+    cutoff_ms = (time.time() - min_age_seconds) * 1000.0
+    keep = []
+    for p in positions:
+        ts = p.get("updateTime")
+        if ts is None:
+            keep.append(p)
+        elif float(ts) <= cutoff_ms:
+            keep.append(p)
+    return keep
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    # Local import keeps the script runnable without spinning up the full
+    # tradeengine wiring (e.g. NATS, MongoDB) — only the exchange wrapper
+    # is needed here.
+    from tradeengine.exchange.binance import BinanceFuturesExchange
+
+    client = BinanceFuturesExchange()
+    await client.initialize()
+
+    positions, orders_by_symbol = await _fetch_state(client)
+
+    if args.symbol:
+        positions = [p for p in positions if p["symbol"] == args.symbol]
+
+    positions = _filter_age(positions, args.min_age_seconds)
+
+    closed_or_listed = 0
+    for pos in positions:
+        symbol = pos["symbol"]
+        unhedged, sl_present, tp_present = _position_is_unhedged(
+            pos, orders_by_symbol.get(symbol, [])
+        )
+        if not unhedged:
+            continue
+
+        record: dict[str, Any] = {
+            "symbol": symbol,
+            "positionSide": _normalise_side(pos),
+            "positionAmt": float(pos["positionAmt"]),
+            "sl_present": sl_present,
+            "tp_present": tp_present,
+            "would_close": True,
+        }
+
+        if args.commit:
+            result = await _close_one(client, pos)
+            record["close_result"] = result
+            record["would_close"] = False
+            record["closed"] = "error" not in result
+        else:
+            record["dry_run"] = True
+
+        print(json.dumps(record), flush=True)
+        closed_or_listed += 1
+
+    return 0 if closed_or_listed > 0 else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "List or close unhedged Binance Futures positions (positions with "
+            "no matching reduceOnly SL+TP). AC6 of #424."
+        )
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help=(
+            "Issue MARKET reduceOnly close orders for each unhedged position. "
+            "Default is dry-run."
+        ),
+    )
+    parser.add_argument(
+        "--symbol",
+        default=None,
+        help="Limit to a single symbol (e.g. ETHUSDT).",
+    )
+    parser.add_argument(
+        "--min-age-seconds",
+        type=int,
+        default=0,
+        help=(
+            "Only consider positions whose updateTime is older than this many "
+            "seconds. 0 (default) means consider all."
+        ),
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    if args.commit and not (
+        os.environ.get("BINANCE_API_KEY") and os.environ.get("BINANCE_API_SECRET")
+    ):
+        print(
+            "BINANCE_API_KEY/BINANCE_API_SECRET must be set when --commit is passed",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        return asyncio.run(main_async(args))
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_close_unhedged_positions_script.py
+++ b/tests/test_close_unhedged_positions_script.py
@@ -1,0 +1,195 @@
+"""Unit tests for the AC6 remediation script's pure helpers.
+
+The script (``scripts/close_unhedged_positions.py``) drives live Binance
+API calls under ``--commit`` — so this file exercises only the pure
+helpers that decide WHICH positions get touched, not the live API
+boundary.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import time
+from typing import Any
+
+import pytest
+
+
+def _load_script_module():
+    script_path = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "close_unhedged_positions.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "close_unhedged_positions", script_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["close_unhedged_positions"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SCRIPT = _load_script_module()
+
+
+# ---------------------------------------------------------------------------
+# _normalise_side
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_side_hedge_long():
+    assert (
+        SCRIPT._normalise_side({"positionSide": "LONG", "positionAmt": "1.0"}) == "LONG"
+    )
+
+
+def test_normalise_side_one_way_positive():
+    assert (
+        SCRIPT._normalise_side({"positionSide": "BOTH", "positionAmt": "0.5"}) == "LONG"
+    )
+
+
+def test_normalise_side_one_way_negative():
+    assert (
+        SCRIPT._normalise_side({"positionSide": "BOTH", "positionAmt": "-0.5"})
+        == "SHORT"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _position_is_unhedged
+# ---------------------------------------------------------------------------
+
+
+def _pos(symbol="BTCUSDT", side="LONG", amt=1.0) -> dict[str, Any]:
+    return {"symbol": symbol, "positionSide": side, "positionAmt": str(amt)}
+
+
+def test_position_is_hedged_when_both_sl_and_tp_present():
+    pos = _pos()
+    orders = [
+        {"positionSide": "LONG", "type": "STOP_MARKET", "reduceOnly": True},
+        {"positionSide": "LONG", "type": "TAKE_PROFIT_MARKET", "reduceOnly": True},
+    ]
+    unhedged, sl, tp = SCRIPT._position_is_unhedged(pos, orders)
+    assert unhedged is False
+    assert sl is True
+    assert tp is True
+
+
+def test_position_is_unhedged_when_no_orders():
+    pos = _pos()
+    unhedged, sl, tp = SCRIPT._position_is_unhedged(pos, [])
+    assert unhedged is True
+    assert sl is False
+    assert tp is False
+
+
+def test_position_is_unhedged_when_only_sl_present():
+    pos = _pos()
+    orders = [{"positionSide": "LONG", "type": "STOP_MARKET", "reduceOnly": True}]
+    unhedged, sl, tp = SCRIPT._position_is_unhedged(pos, orders)
+    assert unhedged is True
+    assert sl is True
+    assert tp is False
+
+
+def test_position_is_unhedged_when_orders_on_wrong_side():
+    pos = _pos(side="LONG")
+    orders = [
+        {"positionSide": "SHORT", "type": "STOP_MARKET", "reduceOnly": True},
+        {"positionSide": "SHORT", "type": "TAKE_PROFIT_MARKET", "reduceOnly": True},
+    ]
+    unhedged, sl, tp = SCRIPT._position_is_unhedged(pos, orders)
+    assert unhedged is True
+    assert sl is False
+    assert tp is False
+
+
+def test_position_is_hedged_with_both_positionside_in_one_way_mode():
+    pos = _pos()
+    orders = [
+        {"positionSide": "BOTH", "type": "STOP_MARKET", "reduceOnly": True},
+        {"positionSide": "BOTH", "type": "TAKE_PROFIT_MARKET", "reduceOnly": True},
+    ]
+    unhedged, sl, tp = SCRIPT._position_is_unhedged(pos, orders)
+    assert unhedged is False
+
+
+def test_position_ignores_non_reduce_only_orders():
+    pos = _pos()
+    orders = [
+        {"positionSide": "LONG", "type": "STOP_MARKET", "reduceOnly": False},
+        {"positionSide": "LONG", "type": "TAKE_PROFIT_MARKET", "reduceOnly": False},
+    ]
+    unhedged, sl, tp = SCRIPT._position_is_unhedged(pos, orders)
+    assert unhedged is True
+
+
+def test_position_accepts_closeposition_as_reduce_only():
+    pos = _pos()
+    orders = [
+        {"positionSide": "LONG", "type": "STOP_MARKET", "closePosition": True},
+        {"positionSide": "LONG", "type": "TAKE_PROFIT_MARKET", "closePosition": True},
+    ]
+    unhedged, sl, tp = SCRIPT._position_is_unhedged(pos, orders)
+    assert unhedged is False
+
+
+# ---------------------------------------------------------------------------
+# _filter_age
+# ---------------------------------------------------------------------------
+
+
+def test_filter_age_zero_keeps_all():
+    positions = [_pos(), _pos(symbol="ETHUSDT")]
+    assert SCRIPT._filter_age(positions, min_age_seconds=0) == positions
+
+
+def test_filter_age_keeps_only_old_positions():
+    now_ms = time.time() * 1000.0
+    old_pos = {**_pos(symbol="OLD"), "updateTime": now_ms - 3700 * 1000}
+    young_pos = {**_pos(symbol="YOUNG"), "updateTime": now_ms - 60 * 1000}
+    out = SCRIPT._filter_age([old_pos, young_pos], min_age_seconds=3600)
+    assert [p["symbol"] for p in out] == ["OLD"]
+
+
+def test_filter_age_keeps_positions_without_updatetime():
+    # Conservative: rows missing updateTime are kept so we don't silently
+    # skip suspicious data — operator can re-filter externally if needed.
+    pos = _pos()
+    out = SCRIPT._filter_age([pos], min_age_seconds=3600)
+    assert out == [pos]
+
+
+# ---------------------------------------------------------------------------
+# CLI argparse
+# ---------------------------------------------------------------------------
+
+
+def test_build_parser_dry_run_default():
+    args = SCRIPT._build_parser().parse_args([])
+    assert args.commit is False
+    assert args.min_age_seconds == 0
+    assert args.symbol is None
+
+
+def test_build_parser_accepts_filters():
+    args = SCRIPT._build_parser().parse_args(
+        ["--commit", "--symbol", "ETHUSDT", "--min-age-seconds", "3600"]
+    )
+    assert args.commit is True
+    assert args.symbol == "ETHUSDT"
+    assert args.min_age_seconds == 3600
+
+
+def test_main_requires_credentials_for_commit(monkeypatch):
+    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    monkeypatch.setattr(sys, "argv", ["close_unhedged_positions.py", "--commit"])
+    rc = SCRIPT.main()
+    assert rc == 2  # exits with 2 when credentials missing


### PR DESCRIPTION
Implements **AC6 / RC#6 of #424** (OCO orphan-legs incident, 2026-05-30). Operator-facing runbook + one-shot remediation script for the unhedged-position state that the AC5 `UnhedgedPositionDetected` alert flags.

## Closes
Closes #430

## What ships

### `docs/runbooks/unhedged-positions.md`
- What the alert means
- Triage recipes (Grafana / kubectl / Binance state cross-check)
- Decision tree: place manual stops vs run the close script
- Script usage (dry-run, `--commit`, `--symbol`, `--min-age-seconds`)
- Root-cause map across AC1..AC6 with PR links

### `scripts/close_unhedged_positions.py`
- Dry-run by default — one JSON record per unhedged position
- `--commit` issues MARKET reduceOnly close orders via `BinanceFuturesExchange`
- Refuses `--commit` without `BINANCE_API_KEY` + `BINANCE_API_SECRET` (`rc=2`)
- Logs to stderr, JSON to stdout — pipeable

## Tests

16 unit tests covering pure helpers (`_normalise_side`, `_position_is_unhedged` across all hedged/unhedged variants, `_filter_age`), CLI argparse contract, credentials guard.

Full local suite: **1489 passed**, 13 skipped.