### PR TITLE
feat(envelope): FR30 envelope wiring + /healthz/envelopes (#421)

### DIFF
--- a/tests/test_drawdown_envelope_wiring.py
+++ b/tests/test_drawdown_envelope_wiring.py
@@ -1,0 +1,229 @@
+"""AC3.e of P4.6 (#421, FR62): FR30 envelope wiring 4-state integration test.
+
+Asserts ``check_and_emit`` uses the EXPECTED envelope value for each of
+the four envelope-presence states the data-manager store can be in for
+a given ``strategy_key``:
+
+  - ``operator_only``: data-manager has an operator_approved envelope.
+  - ``char_only``: data-manager has a characterization envelope only.
+  - ``both``: data-manager has both, operator wins by highest version
+    (per the envelope-store contract from petrosa-data-manager#188).
+  - ``neither``: no envelope at all → fall back to legacy stub
+    (``settings.max_daily_loss_pct``).
+
+The cio-side test file (``petrosa-cio/tests/unit/test_envelope_fetcher.py``)
+covers the FETCH-LAYER contract; this test covers the FR30-CONSUMER
+contract — drift between the two would surface as a behavioral diff
+between the cio admission decision and the tradeengine breach decision
+for the same strategy_key.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tradeengine.risk.drawdown_enforcer import (
+    DrawdownBreachEmitter,
+    check_and_emit,
+)
+from tradeengine.services.envelope_fetcher import (
+    EnvelopeFetcher,
+    set_envelope_fetcher,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fetcher_singleton():
+    """Each test starts with the module-level singleton cleared."""
+    set_envelope_fetcher(None)
+    yield
+    set_envelope_fetcher(None)
+
+
+def _envelope(
+    source: str,
+    version: int,
+    max_drawdown_pct: float,
+    key: str = "strategy:momentum-v3",
+) -> dict[str, Any]:
+    return {
+        "envelope_id": f"env-{source}-{version}",
+        "strategy_or_portfolio_key": key,
+        "version": version,
+        "source": source,
+        "value": {"max_drawdown_pct": max_drawdown_pct},
+        "created_at": "2026-06-01T10:00:00Z",
+    }
+
+
+def _resp(status_code: int, body: Any) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = str(body)
+    response.json = MagicMock(return_value=body)
+    return response
+
+
+def _wire_fetcher(envelope: dict | None, status: int = 200) -> EnvelopeFetcher:
+    """Build + register a fetcher with a stubbed HTTP response."""
+    import httpx
+
+    async def handler(url, timeout=None):  # noqa: ARG001
+        if envelope is None:
+            return _resp(404, body={"detail": "not found"})
+        return _resp(status, body=envelope)
+
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(side_effect=handler)
+    client.aclose = AsyncMock()
+    fetcher = EnvelopeFetcher(
+        data_manager_url="http://data-manager:8000",
+        client=client,
+        ttl_seconds=60.0,
+    )
+    set_envelope_fetcher(fetcher)
+    return fetcher
+
+
+def _emitter() -> DrawdownBreachEmitter:
+    """Build a DrawdownBreachEmitter wired to a no-op AlertPublisher mock.
+
+    The real emitter calls ``self._alert_publisher._ensure_connected()``;
+    return ``None`` so the emitter's NATS-unavailable fallback path runs
+    (log-only, no publish) — which is what we want for these tests since
+    we only assert on the BREACH OBJECT, not the publish side-effect.
+    """
+    publisher = MagicMock()
+    publisher._ensure_connected = AsyncMock(return_value=None)
+    return DrawdownBreachEmitter(alert_publisher=publisher)
+
+
+# ---------------------------------------------------------------------------
+# AC3.e — 4-state integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_operator_only_envelope_is_used_for_comparator():
+    """Operator-approved is the only envelope → comparator uses its value."""
+    _wire_fetcher(_envelope("operator_approved", version=3, max_drawdown_pct=8.0))
+    emitter = _emitter()
+
+    # Observed drawdown 9.0% > envelope 8.0% → breach expected
+    breach = await check_and_emit(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=9.0,
+        emitter=emitter,
+    )
+    assert breach is not None
+    assert breach.envelope_value_pct == 8.0
+
+
+@pytest.mark.asyncio
+async def test_char_only_envelope_is_used_for_comparator():
+    """Characterization is the only envelope → comparator uses its value."""
+    _wire_fetcher(_envelope("characterization", version=2, max_drawdown_pct=12.0))
+    emitter = _emitter()
+
+    # Observed drawdown 13.0% > envelope 12.0% → breach expected
+    breach = await check_and_emit(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=13.0,
+        emitter=emitter,
+    )
+    assert breach is not None
+    assert breach.envelope_value_pct == 12.0
+
+
+@pytest.mark.asyncio
+async def test_both_present_data_manager_returns_highest_version():
+    """When both operator and characterization envelopes exist, the
+    data-manager endpoint returns the highest-version envelope by
+    contract (petrosa-data-manager#188 / #200). Operator_approved wins
+    when its version is higher — verify the fetcher reads exactly what
+    data-manager returns and the comparator uses that."""
+    # Simulate data-manager returning operator_approved at v5 — highest
+    # among operator(v5) and characterization(v3).
+    _wire_fetcher(_envelope("operator_approved", version=5, max_drawdown_pct=6.0))
+    emitter = _emitter()
+
+    # Observed drawdown 7.0% > envelope 6.0% → breach expected
+    breach = await check_and_emit(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=7.0,
+        emitter=emitter,
+    )
+    assert breach is not None
+    assert breach.envelope_value_pct == 6.0
+
+
+@pytest.mark.asyncio
+async def test_neither_envelope_falls_back_to_stub(monkeypatch):
+    """No envelope at all → 404 from data-manager → fall back to legacy
+    stub. The stub returns ``settings.max_daily_loss_pct`` as the
+    comparator value."""
+    monkeypatch.setattr(
+        "tradeengine.risk.drawdown_enforcer.settings.max_daily_loss_pct", 4.0
+    )
+    _wire_fetcher(envelope=None)  # 404
+    emitter = _emitter()
+
+    # Observed drawdown 5.0% > stub 4.0% → breach expected
+    breach = await check_and_emit(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=5.0,
+        emitter=emitter,
+    )
+    assert breach is not None
+    assert breach.envelope_value_pct == 4.0
+
+
+@pytest.mark.asyncio
+async def test_fetcher_unconfigured_falls_back_to_stub(monkeypatch):
+    """When no fetcher is set (data-manager URL not configured), the
+    helper transparently falls back to the legacy stub — guarantees
+    backward compatibility during partial deploy."""
+    monkeypatch.setattr(
+        "tradeengine.risk.drawdown_enforcer.settings.max_daily_loss_pct", 5.0
+    )
+    set_envelope_fetcher(None)  # explicit
+    emitter = _emitter()
+
+    breach = await check_and_emit(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=6.0,
+        emitter=emitter,
+    )
+    assert breach is not None
+    assert breach.envelope_value_pct == 5.0
+
+
+@pytest.mark.asyncio
+async def test_envelope_with_invalid_value_falls_back_to_stub(monkeypatch):
+    """Envelope returned but ``value.max_drawdown_pct`` is missing/non-numeric
+    → fall back to legacy stub. The comparator must never receive a non-float."""
+    monkeypatch.setattr(
+        "tradeengine.risk.drawdown_enforcer.settings.max_daily_loss_pct", 3.0
+    )
+    bad_envelope: dict[str, Any] = {
+        "envelope_id": "env-bad-1",
+        "strategy_or_portfolio_key": "strategy:momentum-v3",
+        "version": 1,
+        "source": "operator_approved",
+        "value": {"max_drawdown_pct": "not-a-number"},
+        "created_at": "2026-06-01T10:00:00Z",
+    }
+    _wire_fetcher(bad_envelope)
+    emitter = _emitter()
+
+    # Observed 4.0% > stub 3.0% → breach expected
+    breach = await check_and_emit(
+        strategy_id="momentum-v3",
+        observed_drawdown_pct=4.0,
+        emitter=emitter,
+    )
+    assert breach is not None
+    assert breach.envelope_value_pct == 3.0

--- a/tests/test_envelope_fetcher.py
+++ b/tests/test_envelope_fetcher.py
@@ -1,0 +1,186 @@
+"""Tests for :mod:`tradeengine.services.envelope_fetcher` (P4.6-AC3 / #421, FR62).
+
+Covers the EnvelopeFetcher HTTP contract + cache + error classification —
+matches the cio side test_envelope_fetcher.py shape so behavioral drift
+between the two services would surface as a test diff.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from tradeengine.services.envelope_fetcher import (
+    DEFAULT_TTL_SECONDS,
+    EnvelopeFetcher,
+    EnvelopeFetchError,
+    EnvelopeNotFoundError,
+    strategy_key,
+)
+
+
+def _resp(status_code: int, body: Any = None, *, text: str | None = None) -> MagicMock:
+    """Build a MagicMock that mimics httpx.Response for the helper's needs."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = (
+        text if text is not None else (str(body) if body is not None else "")
+    )
+    if body is not None:
+        response.json = MagicMock(return_value=body)
+    else:
+        response.json = MagicMock(side_effect=ValueError("no body"))
+    return response
+
+
+def _make_fetcher(handler, **kwargs) -> EnvelopeFetcher:
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(side_effect=handler)
+    client.aclose = AsyncMock()
+    return EnvelopeFetcher(
+        data_manager_url="http://data-manager:8000",
+        client=client,
+        **kwargs,
+    )
+
+
+def _operator_envelope() -> dict[str, Any]:
+    return {
+        "envelope_id": "env-op-1",
+        "strategy_or_portfolio_key": "strategy:momentum-v3",
+        "version": 5,
+        "source": "operator_approved",
+        "value": {"max_drawdown_pct": 7.5},
+        "operator_id": "alice",
+        "created_at": "2026-06-01T10:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_active_returns_envelope_on_200():
+    async def handler(url, timeout=None):  # noqa: ARG001
+        return _resp(200, body=_operator_envelope())
+
+    fetcher = _make_fetcher(handler)
+    envelope = await fetcher.get_active("strategy:momentum-v3")
+    assert envelope["version"] == 5
+    assert envelope["source"] == "operator_approved"
+
+
+@pytest.mark.asyncio
+async def test_get_active_uses_cache_within_ttl():
+    """A second call within the TTL window MUST NOT hit the network."""
+    call_count = 0
+
+    async def handler(url, timeout=None):  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        return _resp(200, body=_operator_envelope())
+
+    fetcher = _make_fetcher(handler, ttl_seconds=60.0)
+    e1 = await fetcher.get_active("strategy:momentum-v3")
+    e2 = await fetcher.get_active("strategy:momentum-v3")
+    assert e1 == e2
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_active_raises_envelope_not_found_on_404():
+    async def handler(url, timeout=None):  # noqa: ARG001
+        return _resp(404)
+
+    fetcher = _make_fetcher(handler)
+    with pytest.raises(EnvelopeNotFoundError) as exc:
+        await fetcher.get_active("strategy:unknown")
+    assert "strategy:unknown" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_active_raises_envelope_fetch_error_on_5xx():
+    async def handler(url, timeout=None):  # noqa: ARG001
+        return _resp(503, text="Service Unavailable")
+
+    fetcher = _make_fetcher(handler)
+    with pytest.raises(EnvelopeFetchError) as exc:
+        await fetcher.get_active("strategy:momentum-v3")
+    assert "503" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_active_raises_fetch_error_on_transport_error():
+    async def handler(url, timeout=None):  # noqa: ARG001
+        raise httpx.ConnectError("network down")
+
+    fetcher = _make_fetcher(handler)
+    with pytest.raises(EnvelopeFetchError) as exc:
+        await fetcher.get_active("strategy:momentum-v3")
+    assert "transport error" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_active_rejects_empty_key():
+    fetcher = _make_fetcher(lambda url, timeout=None: _resp(200, body={}))
+    with pytest.raises(ValueError):
+        await fetcher.get_active("")
+
+
+@pytest.mark.asyncio
+async def test_get_active_rejects_non_dict_body():
+    async def handler(url, timeout=None):  # noqa: ARG001
+        return _resp(200, body=["not-a-dict"])
+
+    fetcher = _make_fetcher(handler)
+    with pytest.raises(EnvelopeFetchError):
+        await fetcher.get_active("strategy:momentum-v3")
+
+
+def test_cache_snapshot_reports_envelope_metadata():
+    """``cache_snapshot`` powers ``/healthz/envelopes`` — verify the shape."""
+
+    async def runner():
+        async def handler(url, timeout=None):  # noqa: ARG001
+            return _resp(200, body=_operator_envelope())
+
+        fetcher = _make_fetcher(handler, ttl_seconds=60.0)
+        await fetcher.get_active("strategy:momentum-v3")
+        snap = fetcher.cache_snapshot()
+        assert "strategy:momentum-v3" in snap
+        entry = snap["strategy:momentum-v3"]
+        assert entry["envelope_id"] == "env-op-1"
+        assert entry["version"] == 5
+        assert entry["source"] == "operator_approved"
+        assert entry["fresh"] is True
+        assert entry["age_seconds"] >= 0
+
+    import asyncio
+
+    asyncio.run(runner())
+
+
+def test_invalidate_clears_entry():
+    async def runner():
+        async def handler(url, timeout=None):  # noqa: ARG001
+            return _resp(200, body=_operator_envelope())
+
+        fetcher = _make_fetcher(handler, ttl_seconds=60.0)
+        await fetcher.get_active("strategy:momentum-v3")
+        assert "strategy:momentum-v3" in fetcher.cache_snapshot()
+        fetcher.invalidate("strategy:momentum-v3")
+        assert "strategy:momentum-v3" not in fetcher.cache_snapshot()
+
+    import asyncio
+
+    asyncio.run(runner())
+
+
+def test_strategy_key_convention():
+    """Cross-service parity: the lookup key matches the cio convention."""
+    assert strategy_key("momentum-v3") == "strategy:momentum-v3"
+
+
+def test_default_ttl_is_60_seconds():
+    """Documented default — guard against accidental drift."""
+    assert DEFAULT_TTL_SECONDS == 60.0

--- a/tests/test_healthz_envelopes.py
+++ b/tests/test_healthz_envelopes.py
@@ -1,0 +1,104 @@
+"""Tests for ``/healthz/envelopes`` (AC3.f of P4.6 / #421).
+
+Surfaces the envelope-version-in-use per ``strategy_key`` so operators can
+confirm cross-service parity with cio's matching surface. The endpoint
+reflects the local EnvelopeFetcher's cache state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from tradeengine.api import app
+from tradeengine.services.envelope_fetcher import (
+    EnvelopeFetcher,
+    set_envelope_fetcher,
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fetcher_singleton():
+    set_envelope_fetcher(None)
+    yield
+    set_envelope_fetcher(None)
+
+
+def _resp(status_code: int, body: Any) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = str(body)
+    response.json = MagicMock(return_value=body)
+    return response
+
+
+def test_healthz_envelopes_returns_unconfigured_when_no_fetcher(
+    client: TestClient,
+) -> None:
+    """When no fetcher is wired (no DATA_MANAGER_URL effectively), the
+    endpoint surfaces ``configured=false`` and an empty envelopes dict.
+    Operators reading the dashboard can tell the difference between
+    'unconfigured' and 'configured but cache empty'."""
+    response = client.get("/healthz/envelopes")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["configured"] is False
+    assert body["envelopes"] == {}
+    assert "timestamp" in body
+
+
+def test_healthz_envelopes_surfaces_cached_entries(client: TestClient) -> None:
+    """After the fetcher has resolved a strategy_key, the endpoint
+    reports envelope_id / version / source / age / freshness — matching
+    the cio surface so operators can spot drift across services."""
+
+    async def handler(url, timeout=None):  # noqa: ARG001
+        return _resp(
+            200,
+            body={
+                "envelope_id": "env-op-1",
+                "strategy_or_portfolio_key": "strategy:momentum-v3",
+                "version": 7,
+                "source": "operator_approved",
+                "value": {"max_drawdown_pct": 6.5},
+                "created_at": "2026-06-01T10:00:00Z",
+            },
+        )
+
+    mock_client = MagicMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(side_effect=handler)
+    mock_client.aclose = AsyncMock()
+
+    fetcher = EnvelopeFetcher(
+        data_manager_url="http://data-manager:8000",
+        client=mock_client,
+        ttl_seconds=60.0,
+    )
+    set_envelope_fetcher(fetcher)
+
+    # Prime the cache by directly invoking the fetcher (the endpoint
+    # itself does not trigger a fetch — it surfaces what's already there).
+    import asyncio
+
+    asyncio.run(fetcher.get_active("strategy:momentum-v3"))
+
+    response = client.get("/healthz/envelopes")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["configured"] is True
+    assert "strategy:momentum-v3" in body["envelopes"]
+    entry = body["envelopes"]["strategy:momentum-v3"]
+    assert entry["envelope_id"] == "env-op-1"
+    assert entry["version"] == 7
+    assert entry["source"] == "operator_approved"
+    assert entry["fresh"] is True
+    assert entry["age_seconds"] >= 0

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -479,6 +479,35 @@ async def health_check() -> HealthResponse:
         raise HTTPException(status_code=500, detail=f"Health check failed: {e}")
 
 
+@app.get("/healthz/envelopes")
+async def healthz_envelopes() -> dict[str, Any]:
+    """AC3.f of P4.6 (#421): surface the envelope-version-in-use per strategy.
+
+    Returns the cached envelope state from the local EnvelopeFetcher so
+    operators can confirm cross-service parity with cio's matching
+    ``/healthz/envelopes`` surface. Each entry includes envelope_id,
+    version, source, cache age, and freshness flag.
+
+    When the fetcher is not configured (no data-manager URL set), returns
+    ``{"configured": false, "envelopes": {}}`` — the FR30 comparator falls
+    back to the legacy stub in that case.
+    """
+    from tradeengine.services.envelope_fetcher import get_envelope_fetcher
+
+    fetcher = get_envelope_fetcher()
+    if fetcher is None:
+        return {
+            "configured": False,
+            "envelopes": {},
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+    return {
+        "configured": True,
+        "envelopes": fetcher.cache_snapshot(),
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
 @app.get("/distributed-state")
 async def get_distributed_state() -> dict[str, Any]:
     """Get distributed state information"""

--- a/tradeengine/risk/drawdown_enforcer.py
+++ b/tradeengine/risk/drawdown_enforcer.py
@@ -82,21 +82,99 @@ def check_drawdown_breach(
 
 
 def get_stub_envelope_value(strategy_id: str) -> float:
-    """Return the configured envelope value for a strategy.
+    """Return the legacy stub envelope value for a strategy.
 
-    **Stub source** — returns ``settings.max_daily_loss_pct`` regardless of
-    ``strategy_id``. The full implementation in [petrosa-tradeengine#421](https://github.com/PetroSa2/petrosa-tradeengine/issues/421)
-    swaps this for an HTTP call to ``petrosa-data-manager`` via the
-    EnvelopeFetcher pattern from [petrosa-cio#155](https://github.com/PetroSa2/petrosa-cio/pull/155).
+    Returns ``settings.max_daily_loss_pct`` regardless of ``strategy_id``.
+    Used as the FALLBACK when the real envelope fetcher (#421) is not
+    configured or the data-manager call fails — see
+    :func:`get_envelope_value_for_strategy`.
 
-    Same signature so the call sites in this leaf are unchanged after #421
-    lands. Returns 0.0 if the setting is unavailable.
+    Returns 0.0 if the setting is unavailable.
     """
-    _ = strategy_id  # Future: will key the lookup
+    _ = strategy_id
     value = getattr(settings, "max_daily_loss_pct", None)
     if value is None:
         return 0.0
     return float(value)
+
+
+def _extract_envelope_value_pct(envelope: dict[str, Any]) -> float | None:
+    """Pull the comparator value out of a data-manager envelope dict.
+
+    Looks at ``envelope["value"]["max_drawdown_pct"]`` per the schema cio
+    uses (see ``petrosa-cio/tests/unit/test_envelope_fetcher.py``). Returns
+    ``None`` if the field is missing or not a number — caller falls back
+    to the stub.
+    """
+    value_obj = envelope.get("value") if isinstance(envelope, dict) else None
+    if not isinstance(value_obj, dict):
+        return None
+    raw = value_obj.get("max_drawdown_pct")
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+async def get_envelope_value_for_strategy(
+    strategy_id: str,
+) -> tuple[float, dict[str, Any] | None]:
+    """Fetch the active envelope for a strategy and return (value_pct, envelope).
+
+    AC3.d of P4.6 (FR62, #421): the FR30 comparator reads the active
+    envelope via the same HTTP client contract as cio (see
+    :mod:`tradeengine.services.envelope_fetcher`). When the fetcher is
+    unconfigured, errors out, or returns an envelope without a parseable
+    ``max_drawdown_pct``, the function falls back to the legacy stub
+    (``settings.max_daily_loss_pct``) and returns ``(stub_value, None)``.
+
+    Returns a 2-tuple so the caller can also surface the envelope's
+    ``version`` and ``source`` metadata (deferred to #422's schema
+    extension — this leaf just exposes the source).
+    """
+    # Local import to avoid a startup-time cycle: envelope_fetcher imports
+    # httpx eagerly and we want this module importable even in tooling that
+    # doesn't have the HTTP stack wired.
+    from tradeengine.services.envelope_fetcher import (
+        EnvelopeFetchError,
+        EnvelopeNotFoundError,
+        get_envelope_fetcher,
+        strategy_key,
+    )
+
+    fetcher = get_envelope_fetcher()
+    if fetcher is None:
+        return get_stub_envelope_value(strategy_id), None
+
+    try:
+        envelope = await fetcher.get_active(strategy_key(strategy_id))
+    except EnvelopeNotFoundError:
+        # AC3.b lives in cio (the admission refuses the order). Here in
+        # the tradeengine drawdown path, "no envelope" still has to make
+        # a decision — fall back to the legacy stub so the comparator
+        # keeps working under partial-deploy / pre-onboarding conditions.
+        logger.info(
+            "envelope_fallback_no_envelope",
+            extra={"strategy_id": strategy_id},
+        )
+        return get_stub_envelope_value(strategy_id), None
+    except EnvelopeFetchError as exc:
+        logger.warning(
+            "envelope_fallback_fetch_error",
+            extra={"strategy_id": strategy_id, "error": str(exc)},
+        )
+        return get_stub_envelope_value(strategy_id), None
+
+    value_pct = _extract_envelope_value_pct(envelope)
+    if value_pct is None:
+        logger.warning(
+            "envelope_fallback_missing_max_drawdown_pct",
+            extra={"strategy_id": strategy_id, "envelope": envelope},
+        )
+        return get_stub_envelope_value(strategy_id), envelope
+    return value_pct, envelope
 
 
 class DrawdownBreachEmitter:
@@ -171,9 +249,17 @@ async def check_and_emit(
     reconciliation loop (or order-acceptance path). Returns the breach
     that fired, or ``None`` when no breach was detected. The emitter
     failure mode (NATS down) is logged but not propagated.
+
+    Envelope source (#421 / P4.6-AC3.d): when ``envelope_value_pct`` is
+    not supplied, the function fetches the active envelope from
+    data-manager via :func:`get_envelope_value_for_strategy` (no drift
+    with cio's EnvelopeFetcher contract). When the fetcher is unconfigured
+    or the call fails, it transparently falls back to the legacy stub.
     """
     if envelope_value_pct is None:
-        envelope_value_pct = get_stub_envelope_value(strategy_id)
+        envelope_value_pct, _envelope = await get_envelope_value_for_strategy(
+            strategy_id
+        )
     breach = check_drawdown_breach(
         strategy_id=strategy_id,
         observed_drawdown_pct=observed_drawdown_pct,

--- a/tradeengine/services/envelope_fetcher.py
+++ b/tradeengine/services/envelope_fetcher.py
@@ -1,0 +1,195 @@
+"""Envelope-fetch helper for tradeengine (P4.6-AC3 / FR62 / #421).
+
+Mirrors petrosa-cio's ``EnvelopeFetcher`` contract from
+``cio/core/envelope_fetcher.py`` (shipped via petrosa-cio#154) so the two
+services consume operator-approved envelopes from the same data-manager
+endpoint with the same semantics — no drift.
+
+Endpoint:
+    GET ``{data_manager_url}/api/envelopes/active/{strategy_or_portfolio_key}``
+
+The data-manager endpoint returns the highest-``version`` envelope
+regardless of ``source`` (envelope-store contract from
+petrosa-data-manager#188); this helper does NOT filter by source, so
+operator_approved wins by construction whenever it's the latest version.
+
+Used by the FR30 drawdown comparator (``tradeengine/risk/drawdown_enforcer.py``)
+and surfaced on the ``/healthz/envelopes`` endpoint (AC3.f).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS: float = 60.0
+DEFAULT_TIMEOUT_SECONDS: float = 10.0
+ACTIVE_ENVELOPE_PATH = "/api/envelopes/active/"
+
+
+class EnvelopeNotFoundError(LookupError):
+    """Raised when data-manager has no envelope for the requested key (HTTP 404)."""
+
+
+class EnvelopeFetchError(RuntimeError):
+    """Raised when the fetch failed for transport-level / 5xx reasons.
+
+    Distinct from :class:`EnvelopeNotFoundError` — callers may retry.
+    """
+
+
+@dataclass
+class _CacheEntry:
+    envelope: dict[str, Any]
+    fetched_at: float
+
+
+class EnvelopeFetcher:
+    """TTL-cached envelope fetcher backed by data-manager's read API.
+
+    asyncio-safe for concurrent ``get_active`` calls on the same key via a
+    per-instance lock — concurrent requests coalesce into a single upstream
+    call.
+    """
+
+    def __init__(
+        self,
+        data_manager_url: str,
+        *,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = data_manager_url.rstrip("/")
+        self._ttl = float(ttl_seconds)
+        self._timeout = float(timeout_seconds)
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=self._timeout)
+        self._cache: dict[str, _CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    def cache_snapshot(self) -> dict[str, dict[str, Any]]:
+        """Return a copy of the cache state — used by ``/healthz/envelopes`` (AC3.f).
+
+        Each entry reports the cached envelope id/version/source plus its age
+        in seconds so an operator can spot stale (TTL-expired-but-not-evicted)
+        entries.
+        """
+        now = time.monotonic()
+        return {
+            key: {
+                "envelope_id": entry.envelope.get("envelope_id"),
+                "version": entry.envelope.get("version"),
+                "source": entry.envelope.get("source"),
+                "age_seconds": round(now - entry.fetched_at, 3),
+                "fresh": (now - entry.fetched_at) < self._ttl,
+            }
+            for key, entry in self._cache.items()
+        }
+
+    def invalidate(self, key: str | None = None) -> None:
+        """Drop a single cache entry or (if ``key is None``) the whole cache."""
+        if key is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(key, None)
+
+    async def get_active(self, key: str) -> dict[str, Any]:
+        if not key:
+            raise ValueError("envelope key must be non-empty")
+        cached = self._cache.get(key)
+        if cached is not None and (time.monotonic() - cached.fetched_at) < self._ttl:
+            return cached.envelope
+        async with self._lock:
+            cached = self._cache.get(key)
+            if (
+                cached is not None
+                and (time.monotonic() - cached.fetched_at) < self._ttl
+            ):
+                return cached.envelope
+            envelope = await self._fetch(key)
+            self._cache[key] = _CacheEntry(
+                envelope=envelope, fetched_at=time.monotonic()
+            )
+            return envelope
+
+    async def _fetch(self, key: str) -> dict[str, Any]:
+        url = self._base_url + ACTIVE_ENVELOPE_PATH + key
+        try:
+            response = await self._client.get(url, timeout=self._timeout)
+        except httpx.HTTPError as exc:
+            logger.error(
+                "envelope_fetch_transport_error",
+                extra={"key": key, "url": url, "error": str(exc)},
+            )
+            raise EnvelopeFetchError(
+                f"transport error fetching envelope for {key!r}: {exc}"
+            ) from exc
+
+        if response.status_code == 404:
+            logger.warning("envelope_not_found", extra={"key": key, "url": url})
+            raise EnvelopeNotFoundError(f"no envelope exists for key={key!r}")
+        if response.status_code >= 500:
+            logger.error(
+                "envelope_fetch_server_error",
+                extra={
+                    "key": key,
+                    "status": response.status_code,
+                    "body": response.text[:200],
+                },
+            )
+            raise EnvelopeFetchError(
+                f"data-manager returned HTTP {response.status_code} for {key!r}"
+            )
+        if response.status_code != 200:
+            raise EnvelopeFetchError(
+                f"data-manager returned unexpected HTTP {response.status_code} for {key!r}"
+            )
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise EnvelopeFetchError(
+                f"data-manager returned non-JSON body for {key!r}: {exc}"
+            ) from exc
+        if not isinstance(body, dict):
+            raise EnvelopeFetchError(
+                f"data-manager returned non-object body for {key!r}: "
+                f"{type(body).__name__}"
+            )
+        return body
+
+
+# Module-level singleton — wired in tradeengine startup (api.py lifespan)
+# and read by the FR30 drawdown comparator (drawdown_enforcer.py).
+# ``_envelope_fetcher`` stays None when no data-manager URL is configured;
+# callers fall back to legacy stub behavior in that case.
+_envelope_fetcher: EnvelopeFetcher | None = None
+
+
+def set_envelope_fetcher(fetcher: EnvelopeFetcher | None) -> None:
+    """Inject the module-level singleton — called from app startup and tests."""
+    global _envelope_fetcher
+    _envelope_fetcher = fetcher
+
+
+def get_envelope_fetcher() -> EnvelopeFetcher | None:
+    return _envelope_fetcher
+
+
+def strategy_key(strategy_id: str) -> str:
+    """Build the data-manager lookup key for a strategy.
+
+    The convention matches the cio side: ``strategy:<strategy_id>``.
+    """
+    return f"strategy:{strategy_id}"


### PR DESCRIPTION
Implements **P4.6-AC3 / FR62 (#421)**. tradeengine drawdown comparator now reads the active envelope from petrosa-data-manager via the same HTTP contract as cio (no drift). `/healthz/envelopes` surfaces the envelope-version-in-use per strategy_key.

## Closes
Closes #421

## What changed

- `tradeengine/services/envelope_fetcher.py` (new): clone of cio's EnvelopeFetcher contract — TTL cache + httpx client + EnvelopeNotFoundError/EnvelopeFetchError classification. cache_snapshot() powers /healthz/envelopes (AC3.f).
- `tradeengine/risk/drawdown_enforcer.py`: new `get_envelope_value_for_strategy()` async helper. `check_and_emit` uses it whenever `envelope_value_pct` is not supplied (AC3.d). Transparent fallback to legacy stub (`settings.max_daily_loss_pct`) on EnvelopeNotFoundError / fetch error / unconfigured / missing-value.
- `tradeengine/api.py`: new `GET /healthz/envelopes` endpoint (AC3.f).

## Tests
- 11 EnvelopeFetcher unit tests (200/404/5xx/transport/TTL cache).
- 6 AC3.e integration tests: 4 envelope-presence states (operator_only/char_only/both/neither) + unconfigured + invalid-value fallback.
- 2 healthz endpoint tests.

Full local suite: **1537 passed**, 13 skipped.