### PR TITLE
feat(reconciler): #445 - exchange-authoritative naked-position remediator (off by default)

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -87,6 +87,20 @@ class Settings(BaseSettings):
     position_reconciliation_enabled: bool = True
     position_reconciliation_interval_seconds: int = 60
 
+    # #445: exchange-authoritative naked-position remediation.
+    # Modes: "off" (default — read-only, no writes), "dry_run" (log
+    # intended actions, no writes), "arm_only" (re-arm protective stops
+    # but never flatten), "arm_or_flatten" (full AC2 — re-arm with
+    # fallback flatten after grace window). Ships "off" so deploy is a
+    # no-op; operator flips after canary.
+    naked_position_remediation_mode: str = "off"
+    # Grace window before fallback flatten kicks in (arm_or_flatten only).
+    naked_position_flatten_grace_sec: int = 60
+    # Fallback SL/TP distances (% from entry) when local strategy record
+    # has no stored stop_loss_price/take_profit_price for a naked position.
+    naked_position_fallback_sl_pct: float = 2.0
+    naked_position_fallback_tp_pct: float = 4.0
+
     model_config = {
         "env_file": ".env",
         "case_sensitive": False,

--- a/tests/unit/test_naked_position_remediator.py
+++ b/tests/unit/test_naked_position_remediator.py
@@ -1,0 +1,371 @@
+"""Unit tests for NakedPositionRemediator (#445).
+
+Covers all four modes (off, dry_run, arm_only, arm_or_flatten),
+grace-window flatten escalation, idempotent re-arm, fallback SL/TP
+derivation, and clean-pass first-seen reset.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tradeengine.naked_position_remediator import NakedPositionRemediator
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _unhedged_div(
+    symbol: str = "BTCUSDT",
+    side: str = "LONG",
+    qty: float = 0.5,
+    sl_present: bool = False,
+    tp_present: bool = False,
+) -> dict[str, Any]:
+    return {
+        "category": "unhedged",
+        "symbol": symbol,
+        "side": side,
+        "binance_qty": qty,
+        "local_qty": 0.0,
+        "sl_present": sl_present,
+        "tp_present": tp_present,
+        "detail": "test fixture",
+    }
+
+
+def _binance_positions(
+    symbol: str = "BTCUSDT", side: str = "LONG", entry: float = 50000.0
+):
+    return {
+        (symbol, side): {
+            "symbol": symbol,
+            "positionSide": side,
+            "positionAmt": 0.5,
+            "entryPrice": entry,
+        }
+    }
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _make_remediator(
+    *,
+    mode: str = "off",
+    grace_sec: int = 60,
+    position_manager_positions: dict | None = None,
+    exchange_execute_raises: bool = False,
+    close_return: dict | None = None,
+    close_raises: bool = False,
+) -> tuple[NakedPositionRemediator, MagicMock, MagicMock, AsyncMock, _FakeClock]:
+    exchange = MagicMock()
+    if exchange_execute_raises:
+        exchange.execute = AsyncMock(side_effect=RuntimeError("boom"))
+    else:
+        exchange.execute = AsyncMock(return_value={"status": "FILLED"})
+
+    pm = MagicMock()
+    pm.get_positions = MagicMock(return_value=position_manager_positions or {})
+
+    if close_raises:
+        close_cb = AsyncMock(side_effect=RuntimeError("close failed"))
+    else:
+        close_cb = AsyncMock(
+            return_value=close_return or {"status": "success", "position_closed": True}
+        )
+
+    clock = _FakeClock()
+    remediator = NakedPositionRemediator(
+        exchange=exchange,
+        position_manager=pm,
+        close_position=close_cb,
+        mode=mode,  # type: ignore[arg-type]
+        flatten_grace_sec=grace_sec,
+        clock=clock,
+    )
+    return remediator, exchange, pm, close_cb, clock
+
+
+# ---------------------------------------------------------------------------
+# Mode coercion + property
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_mode_falls_back_to_off() -> None:
+    r, _, _, _, _ = _make_remediator(mode="not_a_real_mode")
+    assert r.mode == "off"
+
+
+@pytest.mark.parametrize("m", ["off", "dry_run", "arm_only", "arm_or_flatten"])
+def test_valid_modes_round_trip(m: str) -> None:
+    r, _, _, _, _ = _make_remediator(mode=m)
+    assert r.mode == m
+
+
+# ---------------------------------------------------------------------------
+# off mode — never writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_off_mode_never_calls_exchange_or_close() -> None:
+    r, ex, _, close_cb, _ = _make_remediator(mode="off")
+    counts = await r.remediate([_unhedged_div()], _binance_positions())
+    assert counts["detected"] == 1
+    assert counts["skipped"] == 1
+    assert counts["armed"] == 0
+    assert counts["flattened"] == 0
+    ex.execute.assert_not_called()
+    close_cb.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# dry_run mode — logs only, no writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_mode_logs_no_writes() -> None:
+    r, ex, _, close_cb, _ = _make_remediator(mode="dry_run")
+    counts = await r.remediate([_unhedged_div()], _binance_positions())
+    assert counts["detected"] == 1
+    assert counts["skipped"] == 1
+    ex.execute.assert_not_called()
+    close_cb.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# arm_only mode — re-arms via exchange.execute, never flattens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arm_only_places_sl_and_tp_with_fallback_prices() -> None:
+    r, ex, _, close_cb, _ = _make_remediator(mode="arm_only")
+    counts = await r.remediate([_unhedged_div()], _binance_positions(entry=50000.0))
+    assert counts["armed"] == 1
+    assert counts["flattened"] == 0
+    # SL + TP = 2 calls
+    assert ex.execute.call_count == 2
+    close_cb.assert_not_called()
+    # Verify SL price = entry * (1 - 2%) for LONG default fallback
+    sl_call = ex.execute.call_args_list[0]
+    sl_order = sl_call.args[0] if sl_call.args else sl_call.kwargs.get("order")
+    assert sl_order.symbol == "BTCUSDT"
+    assert sl_order.type == "stop"
+    assert sl_order.position_side == "LONG"
+
+
+@pytest.mark.asyncio
+async def test_arm_only_never_flattens_even_past_grace() -> None:
+    r, ex, _, close_cb, clock = _make_remediator(mode="arm_only", grace_sec=60)
+    # First pass — re-arm attempt
+    await r.remediate([_unhedged_div()], _binance_positions())
+    # Advance way past grace
+    clock.advance(3600)
+    # Position still unhedged — arm_only must still try arm, not flatten
+    counts = await r.remediate([_unhedged_div()], _binance_positions())
+    assert counts["flattened"] == 0
+    close_cb.assert_not_called()
+    assert ex.execute.call_count >= 2  # at least one re-arm pass each cycle
+
+
+@pytest.mark.asyncio
+async def test_arm_only_uses_local_strategy_sl_tp_prices() -> None:
+    local_positions = {
+        ("BTCUSDT", "LONG"): {
+            "stop_loss_price": 48500.0,
+            "take_profit_price": 52500.0,
+            "position_id": "strat-1",
+        }
+    }
+    r, ex, _, _, _ = _make_remediator(
+        mode="arm_only", position_manager_positions=local_positions
+    )
+    await r.remediate([_unhedged_div()], _binance_positions(entry=50000.0))
+    # Should use 48500 / 52500 not the 2% fallback (49000 / 52000)
+    sl_call_args = ex.execute.call_args_list[0]
+    sl_order = sl_call_args.args[0]
+    assert sl_order.stop_loss == 48500.0
+    tp_call_args = ex.execute.call_args_list[1]
+    tp_order = tp_call_args.args[0]
+    assert tp_order.take_profit == 52500.0
+
+
+@pytest.mark.asyncio
+async def test_arm_only_partial_arm_when_tp_already_present() -> None:
+    r, ex, _, _, _ = _make_remediator(mode="arm_only")
+    div = _unhedged_div(sl_present=False, tp_present=True)
+    counts = await r.remediate([div], _binance_positions())
+    # Only SL placement attempted
+    assert ex.execute.call_count == 1
+    assert counts["armed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_arm_only_failure_counts_failed() -> None:
+    r, _, _, _, _ = _make_remediator(mode="arm_only", exchange_execute_raises=True)
+    counts = await r.remediate([_unhedged_div()], _binance_positions())
+    assert counts["failed"] == 1
+    assert counts["armed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# arm_or_flatten mode — grace-window escalation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arm_or_flatten_first_pass_arms_does_not_flatten() -> None:
+    r, ex, _, close_cb, _ = _make_remediator(mode="arm_or_flatten", grace_sec=60)
+    counts = await r.remediate([_unhedged_div()], _binance_positions())
+    assert counts["armed"] == 1
+    assert counts["flattened"] == 0
+    close_cb.assert_not_called()
+    ex.execute.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_arm_or_flatten_escalates_to_flatten_after_grace() -> None:
+    r, _, _, close_cb, clock = _make_remediator(mode="arm_or_flatten", grace_sec=60)
+    # Pass 1: first-seen recorded, arm attempted
+    await r.remediate([_unhedged_div()], _binance_positions())
+    # Advance past grace
+    clock.advance(61)
+    # Pass 2: still unhedged — flatten kicks in
+    counts = await r.remediate([_unhedged_div()], _binance_positions())
+    assert counts["flattened"] == 1
+    close_cb.assert_awaited_once()
+    call = close_cb.await_args
+    assert call.kwargs["symbol"] == "BTCUSDT"
+    assert call.kwargs["position_side"] == "LONG"
+    assert call.kwargs["quantity"] == pytest.approx(0.5)
+    assert call.kwargs["reason"] == "naked_position_grace_expired"
+
+
+@pytest.mark.asyncio
+async def test_arm_or_flatten_flatten_failure_counts_failed() -> None:
+    r, _, _, close_cb, clock = _make_remediator(
+        mode="arm_or_flatten", grace_sec=60, close_raises=True
+    )
+    await r.remediate([_unhedged_div()], _binance_positions())
+    clock.advance(61)
+    counts = await r.remediate([_unhedged_div()], _binance_positions())
+    assert counts["failed"] == 1
+    assert counts["flattened"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Idempotency / state lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clean_pass_clears_first_seen_state() -> None:
+    r, _, _, _, clock = _make_remediator(mode="arm_or_flatten", grace_sec=60)
+    await r.remediate([_unhedged_div()], _binance_positions())
+    # Clean pass — empty divergences
+    counts_clean = await r.remediate([], None)
+    assert counts_clean["detected"] == 0
+    # Reappears later — should be treated as first-seen NOW, not escalate
+    clock.advance(3600)
+    counts = await r.remediate([_unhedged_div()], _binance_positions())
+    assert counts["armed"] == 1
+    assert counts["flattened"] == 0
+
+
+@pytest.mark.asyncio
+async def test_resolved_key_drops_from_first_seen() -> None:
+    r, _, _, _, clock = _make_remediator(mode="arm_or_flatten", grace_sec=60)
+    div_btc = _unhedged_div(symbol="BTCUSDT")
+    div_eth = _unhedged_div(symbol="ETHUSDT")
+    await r.remediate(
+        [div_btc, div_eth],
+        {
+            ("BTCUSDT", "LONG"): {"entryPrice": 50000.0, "positionAmt": 0.5},
+            ("ETHUSDT", "LONG"): {"entryPrice": 3000.0, "positionAmt": 1.0},
+        },
+    )
+    # ETH gets re-armed (no longer unhedged); BTC still unhedged next pass
+    clock.advance(30)
+    await r.remediate([div_btc], _binance_positions("BTCUSDT", "LONG", 50000.0))
+    # ETH key should be dropped from internal state
+    assert ("ETHUSDT", "LONG") not in r._first_seen
+    assert ("BTCUSDT", "LONG") in r._first_seen
+
+
+# ---------------------------------------------------------------------------
+# Fallback price derivation
+# ---------------------------------------------------------------------------
+
+
+def test_derive_uses_fallback_for_long_when_no_local_record() -> None:
+    r, _, _, _, _ = _make_remediator(mode="arm_only")
+    sl, tp = r._derive_protective_prices(
+        "BTCUSDT", "LONG", _binance_positions(entry=100.0)
+    )
+    assert sl == pytest.approx(98.0)  # 100 * (1 - 2%)
+    assert tp == pytest.approx(104.0)  # 100 * (1 + 4%)
+
+
+def test_derive_uses_fallback_for_short_when_no_local_record() -> None:
+    r, _, _, _, _ = _make_remediator(mode="arm_only")
+    sl, tp = r._derive_protective_prices(
+        "BTCUSDT", "SHORT", _binance_positions("BTCUSDT", "SHORT", 100.0)
+    )
+    assert sl == pytest.approx(102.0)  # 100 * (1 + 2%)
+    assert tp == pytest.approx(96.0)  # 100 * (1 - 4%)
+
+
+def test_derive_returns_none_for_missing_entry_price() -> None:
+    r, _, _, _, _ = _make_remediator(mode="arm_only")
+    sl, tp = r._derive_protective_prices(
+        "BTCUSDT", "LONG", {("BTCUSDT", "LONG"): {"entryPrice": 0}}
+    )
+    assert sl is None and tp is None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_divergence_list_is_no_op_in_all_modes() -> None:
+    for m in ["off", "dry_run", "arm_only", "arm_or_flatten"]:
+        r, ex, _, close_cb, _ = _make_remediator(mode=m)
+        counts = await r.remediate([], None)
+        assert counts == {
+            "detected": 0,
+            "armed": 0,
+            "flattened": 0,
+            "skipped": 0,
+            "failed": 0,
+        }
+        ex.execute.assert_not_called()
+        close_cb.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_zero_qty_divergence_does_not_arm_or_flatten() -> None:
+    r, ex, _, close_cb, clock = _make_remediator(mode="arm_or_flatten", grace_sec=0)
+    div = _unhedged_div(qty=0.0)
+    counts = await r.remediate([div], _binance_positions())
+    assert counts["armed"] == 0
+    assert counts["flattened"] == 0
+    assert counts["failed"] == 1
+    ex.execute.assert_not_called()
+    close_cb.assert_not_called()

--- a/tests/unit/test_oco_ac3_gate_445.py
+++ b/tests/unit/test_oco_ac3_gate_445.py
@@ -1,0 +1,187 @@
+"""AC3 of #445: OCOManager.place_oco_orders must skip placement when
+Binance reports no open position for (symbol, position_side).
+
+Without this gate, restarting after a Mongo blip / stale local state
+fires reduceOnly/closePosition orders against positions Binance no
+longer holds → APIError(-4509) "TIF GTE can only be used with open
+positions" loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tradeengine.dispatcher import OCOManager
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test.oco.ac3")
+
+
+@pytest.fixture
+def exchange_mock() -> AsyncMock:
+    """A minimal exchange mock that would succeed if placement reached it."""
+    exchange = AsyncMock()
+    exchange.execute = AsyncMock(
+        return_value={"order_id": "1234567890123", "status": "FILLED"}
+    )
+    return exchange
+
+
+def _make_dispatcher_with_qty(qty: float) -> Any:
+    """Stub dispatcher exposing the _fetch_binance_position_qty contract
+    used by the AC3 gate."""
+
+    class _StubDispatcher:
+        async def _fetch_binance_position_qty(
+            self, symbol: str, position_side: str | None
+        ) -> float:
+            return qty
+
+    return _StubDispatcher()
+
+
+def _make_dispatcher_that_raises() -> Any:
+    class _StubDispatcher:
+        async def _fetch_binance_position_qty(
+            self, symbol: str, position_side: str | None
+        ) -> float:
+            raise RuntimeError("boom")
+
+    return _StubDispatcher()
+
+
+# ---------------------------------------------------------------------------
+# Gate fires — no position on exchange
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac3_gate_skips_when_position_absent(
+    logger: logging.Logger, exchange_mock: AsyncMock
+) -> None:
+    """Position not on exchange → skip placement, no exchange.execute call."""
+    dispatcher = _make_dispatcher_with_qty(0.0)
+    oco = OCOManager(exchange=exchange_mock, logger=logger, dispatcher=dispatcher)
+
+    result = await oco.place_oco_orders(
+        position_id="pos1",
+        symbol="BTCUSDT",
+        position_side="LONG",
+        quantity=0.01,
+        stop_loss_price=50000.0,
+        take_profit_price=55000.0,
+    )
+
+    assert result["status"] == "skipped_no_position_on_exchange"
+    assert result["sl_order_id"] is None
+    assert result["tp_order_id"] is None
+    # Critical: exchange.execute MUST NOT be called — that's how we kill
+    # the -4509 GTE loop.
+    exchange_mock.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ac3_gate_skips_when_position_qty_near_zero(
+    logger: logging.Logger, exchange_mock: AsyncMock
+) -> None:
+    """Sub-tolerance qty (e.g. 1e-12) counts as absent."""
+    dispatcher = _make_dispatcher_with_qty(1e-12)
+    oco = OCOManager(exchange=exchange_mock, logger=logger, dispatcher=dispatcher)
+
+    result = await oco.place_oco_orders(
+        position_id="pos1",
+        symbol="BTCUSDT",
+        position_side="SHORT",
+        quantity=0.01,
+        stop_loss_price=55000.0,
+        take_profit_price=50000.0,
+    )
+
+    assert result["status"] == "skipped_no_position_on_exchange"
+    exchange_mock.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Gate falls through — position present or verification unavailable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac3_gate_falls_through_when_position_exists(
+    logger: logging.Logger, exchange_mock: AsyncMock
+) -> None:
+    """Position present on exchange → gate is a no-op, placement proceeds."""
+    dispatcher = _make_dispatcher_with_qty(0.01)
+    oco = OCOManager(exchange=exchange_mock, logger=logger, dispatcher=dispatcher)
+
+    result = await oco.place_oco_orders(
+        position_id="pos1",
+        symbol="BTCUSDT",
+        position_side="LONG",
+        quantity=0.01,
+        stop_loss_price=50000.0,
+        take_profit_price=55000.0,
+    )
+
+    # Placement must reach the exchange (both SL and TP) — gate did not fire.
+    assert exchange_mock.execute.await_count == 2
+    # Status is the placement outcome, not the gate skip sentinel.
+    assert result.get("status") != "skipped_no_position_on_exchange"
+
+
+@pytest.mark.asyncio
+async def test_ac3_gate_falls_through_when_lookup_raises(
+    logger: logging.Logger, exchange_mock: AsyncMock
+) -> None:
+    """Lookup raised → fall through to placement; never silently drop OCO.
+
+    Rationale: a transient exchange API error must not cause us to skip
+    arming an actual open position — that would re-introduce the very
+    naked-position class this PR is preventing. The gate is defensive,
+    not authoritative.
+    """
+    dispatcher = _make_dispatcher_that_raises()
+    oco = OCOManager(exchange=exchange_mock, logger=logger, dispatcher=dispatcher)
+
+    result = await oco.place_oco_orders(
+        position_id="pos1",
+        symbol="BTCUSDT",
+        position_side="LONG",
+        quantity=0.01,
+        stop_loss_price=50000.0,
+        take_profit_price=55000.0,
+    )
+
+    assert exchange_mock.execute.await_count == 2
+    assert result.get("status") != "skipped_no_position_on_exchange"
+
+
+@pytest.mark.asyncio
+async def test_ac3_gate_no_dispatcher_falls_through(
+    logger: logging.Logger, exchange_mock: AsyncMock
+) -> None:
+    """No dispatcher injected → gate cannot run; placement proceeds.
+
+    OCOManager has a long history of being constructed with dispatcher=None
+    in test contexts. The AC3 gate must remain optional so we don't
+    break those — but production wires the dispatcher in.
+    """
+    oco = OCOManager(exchange=exchange_mock, logger=logger, dispatcher=None)
+
+    result = await oco.place_oco_orders(
+        position_id="pos1",
+        symbol="BTCUSDT",
+        position_side="LONG",
+        quantity=0.01,
+        stop_loss_price=50000.0,
+        take_profit_price=55000.0,
+    )
+
+    assert exchange_mock.execute.await_count == 2
+    assert result.get("status") != "skipped_no_position_on_exchange"

--- a/tests/unit/test_oco_ac3_gate_445.py
+++ b/tests/unit/test_oco_ac3_gate_445.py
@@ -18,6 +18,17 @@ import pytest
 from tradeengine.dispatcher import OCOManager
 
 
+@pytest.fixture(autouse=True)
+def enable_ac3_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gate is off by default per the ship-off rollout pattern of #445.
+
+    These tests verify the on-state behavior so we flip the env var for
+    the duration of each test. The dispatcher-side fallback elif works
+    regardless of the gate's on/off state — production safety is layered.
+    """
+    monkeypatch.setenv("TE_OCO_AC3_GATE_ENABLED", "1")
+
+
 @pytest.fixture
 def logger() -> logging.Logger:
     return logging.getLogger("test.oco.ac3")

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -190,16 +190,44 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             _te_settings.position_reconciliation_enabled
             and not _te_settings.simulation_enabled
         ):
+            # #445: optionally attach the exchange-authoritative naked-position
+            # remediator. Default mode "off" preserves read-only FR65 behavior.
+            _remediator = None
+            try:
+                from tradeengine.naked_position_remediator import (
+                    NakedPositionRemediator,
+                )
+
+                _remediator = NakedPositionRemediator(
+                    exchange=binance_exchange,
+                    position_manager=dispatcher.position_manager,
+                    close_position=dispatcher.close_position_with_cleanup,
+                    mode=_te_settings.naked_position_remediation_mode,
+                    flatten_grace_sec=_te_settings.naked_position_flatten_grace_sec,
+                    fallback_sl_pct=_te_settings.naked_position_fallback_sl_pct,
+                    fallback_tp_pct=_te_settings.naked_position_fallback_tp_pct,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to construct NakedPositionRemediator — "
+                    "continuing with read-only reconciler"
+                )
+                _remediator = None
+
             _reconciler = PositionReconciler(
                 exchange=binance_exchange,
                 position_manager=dispatcher.position_manager,
                 interval_seconds=_te_settings.position_reconciliation_interval_seconds,
+                remediator=_remediator,
             )
             await _reconciler.start()
             app.state.position_reconciler = _reconciler
+            app.state.naked_position_remediator = _remediator
             logger.info(
-                "✅ Position reconciler started (interval=%ss)",
+                "✅ Position reconciler started (interval=%ss, "
+                "naked_remediation_mode=%s)",
                 _te_settings.position_reconciliation_interval_seconds,
+                _te_settings.naked_position_remediation_mode,
             )
         else:
             logger.info(

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -122,6 +122,39 @@ class OCOManager:
 
         exchange_position_key = f"{symbol}_{position_side}"
 
+        # AC3 of #445: gate placement on exchange-confirmed position state.
+        # Without this, a restart after a Mongo blip or stale local state can
+        # fire reduceOnly/closePosition orders against positions Binance no
+        # longer holds → APIError(-4509) "TIF GTE can only be used with open
+        # positions" loop. Skipping is safer than churning.
+        if self.dispatcher is not None and hasattr(
+            self.dispatcher, "_fetch_binance_position_qty"
+        ):
+            try:
+                live_qty = await self.dispatcher._fetch_binance_position_qty(
+                    symbol, position_side
+                )
+            except Exception:
+                # Lookup failed — fall through to placement attempt rather
+                # than silently dropping the OCO. _fetch_binance_position_qty
+                # is already best-effort and returns 0.0 on failure, but we
+                # defend against future refactors that could raise here.
+                live_qty = -1.0
+            if 0.0 <= live_qty < 1e-9:
+                self.logger.warning(
+                    "OCO placement skipped: Binance reports no open position "
+                    "for %s %s (AC3 of #445 — prevents -4509 GTE loop)",
+                    symbol,
+                    position_side,
+                )
+                return {
+                    "sl_order_id": None,
+                    "tp_order_id": None,
+                    "status": "skipped_no_position_on_exchange",
+                    "symbol": symbol,
+                    "position_side": position_side,
+                }
+
         # AC-2 (#352): one OCO pair per exchange position. Multiple strategies stacking
         # independent SL/TP pairs on the same position hits the Binance 10-order limit.
         existing_pairs = self.active_oco_pairs.get(exchange_position_key, [])

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import time
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -127,8 +128,18 @@ class OCOManager:
         # fire reduceOnly/closePosition orders against positions Binance no
         # longer holds → APIError(-4509) "TIF GTE can only be used with open
         # positions" loop. Skipping is safer than churning.
-        if self.dispatcher is not None and hasattr(
-            self.dispatcher, "_fetch_binance_position_qty"
+        #
+        # Ships off by default — same pattern as the rest of #445 — because
+        # the freshly-filled-entry race (entry order fills → OCO placement
+        # races positionRisk propagation) can produce a transient "no
+        # position" reading on Binance that would otherwise cause the gate
+        # to skip arming a real position. Operator flips
+        # TE_OCO_AC3_GATE_ENABLED=1 after canary verification.
+        _ac3_gate_enabled = os.getenv("TE_OCO_AC3_GATE_ENABLED", "0") == "1"
+        if (
+            _ac3_gate_enabled
+            and self.dispatcher is not None
+            and hasattr(self.dispatcher, "_fetch_binance_position_qty")
         ):
             try:
                 live_qty = await self.dispatcher._fetch_binance_position_qty(
@@ -3545,6 +3556,18 @@ class Dispatcher:
                         f"{oco_result.get('active_pairs', 1)} active OCO pair(s). "
                         f"order={strategy_label} added to position without "
                         f"separate risk orders — existing OCO provides coverage."
+                    )
+                elif oco_result.get("status") == "skipped_no_position_on_exchange":
+                    # AC3 of #445: OCOManager pre-check found no position on the
+                    # exchange (rare in normal flow — usually a stale-state /
+                    # post-restart situation). Falling back to individual SL/TP
+                    # orders here would produce the same -4509 GTE loop the gate
+                    # is preventing. Skip the fallback; the protective-order
+                    # request was for a phantom position.
+                    self.logger.warning(
+                        f"OCO placement skipped for {order.symbol}: Binance "
+                        f"reports no open position — skipping individual SL/TP "
+                        f"fallback (AC3 of #445, prevents -4509 churn)"
                     )
                 else:
                     self.logger.error(

--- a/tradeengine/naked_position_remediator.py
+++ b/tradeengine/naked_position_remediator.py
@@ -1,0 +1,462 @@
+"""
+Exchange-authoritative naked-position remediator (#445).
+
+Operates on the ``unhedged`` divergences emitted by
+:class:`tradeengine.position_reconciler.PositionReconciler` and takes
+**write** actions to re-arm protective stops or flatten the position
+when re-arm fails within a bounded grace window.
+
+This is the first remediator that does **not** key any decision off
+the local position store — it iterates the Binance ``positionRisk``
+snapshot directly. That property is the architectural fix for the
+recurring fault cluster (#424 family): every prior remediation path
+was either local-state-keyed or read-only, so positions orphaned
+across Mongo blips (#442/#783) stayed naked.
+
+Ships off-by-default. Operator flips the mode via
+``TE_NAKED_POSITION_REMEDIATION_MODE`` after canary validation.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Literal
+
+from prometheus_client import Counter, Histogram
+
+from contracts.order import OrderStatus, TradeOrder
+
+if TYPE_CHECKING:
+    from tradeengine.exchange.binance import BinanceFuturesExchange
+    from tradeengine.position_manager import PositionManager
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics — #445 AC4
+# ---------------------------------------------------------------------------
+
+naked_position_detected_total = Counter(
+    "tradeengine_naked_position_detected_total",
+    "Unhedged positions observed by the exchange-authoritative remediator",
+    ["symbol", "side"],
+)
+
+naked_position_rearmed_total = Counter(
+    "tradeengine_naked_position_rearmed_total",
+    "Naked positions re-armed (or attempted) by the remediator",
+    ["symbol", "side", "outcome"],  # outcome: armed, armed_partial, failed
+)
+
+naked_position_flattened_total = Counter(
+    "tradeengine_naked_position_flattened_total",
+    "Naked positions flattened (reduce-only MARKET) after grace window",
+    ["symbol", "side", "outcome"],  # outcome: flattened, failed, skipped
+)
+
+reconcile_lag_seconds = Histogram(
+    "tradeengine_reconcile_lag_seconds",
+    "Elapsed seconds between divergence first-seen and remediation action",
+    ["action"],  # action: armed, flattened
+)
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+RemediationMode = Literal["off", "dry_run", "arm_only", "arm_or_flatten"]
+
+# dispatcher.close_position_with_cleanup signature
+CloseCallable = Callable[..., Awaitable[dict[str, Any]]]
+
+
+# ---------------------------------------------------------------------------
+# NakedPositionRemediator
+# ---------------------------------------------------------------------------
+
+
+class NakedPositionRemediator:
+    """Write-mode counterpart to :class:`PositionReconciler` (read-only).
+
+    Inject as a dependency; the reconciler invokes
+    :meth:`remediate` with the ``unhedged`` divergences list after each
+    detection pass. The remediator decides, per mode, whether to re-arm
+    or flatten.
+    """
+
+    def __init__(
+        self,
+        *,
+        exchange: BinanceFuturesExchange,
+        position_manager: PositionManager,
+        close_position: CloseCallable,
+        mode: RemediationMode = "off",
+        flatten_grace_sec: int = 60,
+        fallback_sl_pct: float = 2.0,
+        fallback_tp_pct: float = 4.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._exchange = exchange
+        self._position_manager = position_manager
+        self._close_position = close_position
+        self._mode: RemediationMode = self._coerce_mode(mode)
+        self._flatten_grace_sec = max(int(flatten_grace_sec), 0)
+        self._fallback_sl_pct = float(fallback_sl_pct)
+        self._fallback_tp_pct = float(fallback_tp_pct)
+        self._clock = clock
+        # (symbol, side) -> first-seen monotonic timestamp
+        self._first_seen: dict[tuple[str, str], float] = {}
+
+    @staticmethod
+    def _coerce_mode(mode: str) -> RemediationMode:
+        normalized = (mode or "off").lower().strip()
+        if normalized not in ("off", "dry_run", "arm_only", "arm_or_flatten"):
+            logger.warning(
+                "NakedPositionRemediator: unknown mode %r; falling back to 'off'",
+                mode,
+            )
+            return "off"
+        return normalized  # type: ignore[return-value]
+
+    @property
+    def mode(self) -> RemediationMode:
+        return self._mode
+
+    # ------------------------------------------------------------------
+    # Public entrypoint
+    # ------------------------------------------------------------------
+
+    async def remediate(
+        self,
+        unhedged_divergences: list[dict[str, Any]],
+        binance_positions: dict[tuple[str, str], dict[str, Any]] | None = None,
+    ) -> dict[str, int]:
+        """Apply mode-appropriate remediation to the unhedged divergence list.
+
+        Returns a small counts dict for tests and log surfaces:
+        ``{detected, armed, flattened, skipped, failed}``.
+        """
+        counts = {"detected": 0, "armed": 0, "flattened": 0, "skipped": 0, "failed": 0}
+
+        if not unhedged_divergences:
+            # Clean pass — clear first-seen so future detections start fresh.
+            self._first_seen.clear()
+            return counts
+
+        now = self._clock()
+        currently_unhedged: set[tuple[str, str]] = set()
+
+        for div in unhedged_divergences:
+            symbol = div["symbol"]
+            side = div["side"]
+            key = (symbol, side)
+            currently_unhedged.add(key)
+            counts["detected"] += 1
+            naked_position_detected_total.labels(symbol=symbol, side=side).inc()
+
+            first_seen_at = self._first_seen.setdefault(key, now)
+            elapsed = now - first_seen_at
+
+            if self._mode == "off":
+                counts["skipped"] += 1
+                continue
+
+            if self._mode == "dry_run":
+                self._log_dry_run(div, elapsed)
+                counts["skipped"] += 1
+                continue
+
+            # arm_only or arm_or_flatten
+            should_flatten = (
+                self._mode == "arm_or_flatten" and elapsed >= self._flatten_grace_sec
+            )
+
+            if should_flatten:
+                ok = await self._flatten(div, binance_positions)
+                if ok:
+                    counts["flattened"] += 1
+                    reconcile_lag_seconds.labels(action="flattened").observe(elapsed)
+                    # Clear so re-detection doesn't immediately re-flatten.
+                    self._first_seen.pop(key, None)
+                else:
+                    counts["failed"] += 1
+            else:
+                ok = await self._rearm(div, binance_positions)
+                if ok:
+                    counts["armed"] += 1
+                    reconcile_lag_seconds.labels(action="armed").observe(elapsed)
+                else:
+                    counts["failed"] += 1
+
+        # Drop first-seen entries for keys no longer unhedged (re-arm
+        # succeeded between cycles).
+        stale = [k for k in self._first_seen if k not in currently_unhedged]
+        for k in stale:
+            self._first_seen.pop(k, None)
+
+        return counts
+
+    # ------------------------------------------------------------------
+    # Mode handlers
+    # ------------------------------------------------------------------
+
+    def _log_dry_run(self, div: dict[str, Any], elapsed: float) -> None:
+        symbol = div["symbol"]
+        side = div["side"]
+        missing = []
+        if not div.get("sl_present"):
+            missing.append("SL")
+        if not div.get("tp_present"):
+            missing.append("TP")
+        would_flatten = (
+            self._mode == "arm_or_flatten" and elapsed >= self._flatten_grace_sec
+        )
+        action = "flatten" if would_flatten else "arm"
+        logger.warning(
+            "NakedPositionRemediator[dry_run]: would %s %s/%s qty=%s missing=%s "
+            "first_seen_age=%.1fs",
+            action,
+            symbol,
+            side,
+            div.get("binance_qty"),
+            "+".join(missing) or "none",
+            elapsed,
+        )
+
+    async def _rearm(
+        self,
+        div: dict[str, Any],
+        binance_positions: dict[tuple[str, str], dict[str, Any]] | None,
+    ) -> bool:
+        """Attempt to place the missing reduceOnly SL and/or TP.
+
+        Re-arm uses the stored strategy SL/TP prices when present in the
+        local position store, otherwise falls back to a configurable
+        % distance from the exchange-reported ``entryPrice``. Returns
+        True when at least one missing leg was placed without error.
+        """
+        symbol = div["symbol"]
+        side = div["side"]
+        qty = float(div.get("binance_qty") or 0.0)
+        if qty <= 0:
+            naked_position_rearmed_total.labels(
+                symbol=symbol, side=side, outcome="failed"
+            ).inc()
+            return False
+
+        sl_price, tp_price = self._derive_protective_prices(
+            symbol, side, binance_positions
+        )
+
+        sl_missing = not div.get("sl_present")
+        tp_missing = not div.get("tp_present")
+        order_side = "sell" if side == "LONG" else "buy"
+        placed_any = False
+        had_failure = False
+
+        if sl_missing and sl_price is not None:
+            try:
+                await self._exchange.execute(
+                    TradeOrder(
+                        symbol=symbol,
+                        side=order_side,  # type: ignore[arg-type]
+                        type="stop",  # type: ignore[arg-type]
+                        amount=qty,
+                        stop_loss=float(sl_price),
+                        position_side=side,
+                        reduce_only=True,
+                        status=OrderStatus.PENDING,
+                    )
+                )
+                placed_any = True
+                logger.info(
+                    "NakedPositionRemediator: re-armed SL on %s/%s qty=%s price=%s",
+                    symbol,
+                    side,
+                    qty,
+                    sl_price,
+                )
+            except Exception:
+                had_failure = True
+                logger.exception(
+                    "NakedPositionRemediator: SL re-arm failed for %s/%s",
+                    symbol,
+                    side,
+                )
+
+        if tp_missing and tp_price is not None:
+            try:
+                await self._exchange.execute(
+                    TradeOrder(
+                        symbol=symbol,
+                        side=order_side,  # type: ignore[arg-type]
+                        type="take_profit",  # type: ignore[arg-type]
+                        amount=qty,
+                        take_profit=float(tp_price),
+                        position_side=side,
+                        reduce_only=True,
+                        status=OrderStatus.PENDING,
+                    )
+                )
+                placed_any = True
+                logger.info(
+                    "NakedPositionRemediator: re-armed TP on %s/%s qty=%s price=%s",
+                    symbol,
+                    side,
+                    qty,
+                    tp_price,
+                )
+            except Exception:
+                had_failure = True
+                logger.exception(
+                    "NakedPositionRemediator: TP re-arm failed for %s/%s",
+                    symbol,
+                    side,
+                )
+
+        outcome = (
+            "armed"
+            if placed_any and not had_failure
+            else ("armed_partial" if placed_any else "failed")
+        )
+        naked_position_rearmed_total.labels(
+            symbol=symbol, side=side, outcome=outcome
+        ).inc()
+        return placed_any
+
+    async def _flatten(
+        self,
+        div: dict[str, Any],
+        binance_positions: dict[tuple[str, str], dict[str, Any]] | None,
+    ) -> bool:
+        """Reduce-only MARKET close via dispatcher.close_position_with_cleanup."""
+        symbol = div["symbol"]
+        side = div["side"]
+        qty = float(div.get("binance_qty") or 0.0)
+        if qty <= 0:
+            naked_position_flattened_total.labels(
+                symbol=symbol, side=side, outcome="skipped"
+            ).inc()
+            return False
+
+        position_id = self._resolve_position_id(symbol, side)
+        reason = "naked_position_grace_expired"
+        try:
+            result = await self._close_position(
+                position_id=position_id,
+                symbol=symbol,
+                position_side=side,
+                quantity=qty,
+                reason=reason,
+            )
+        except Exception:
+            logger.exception(
+                "NakedPositionRemediator: flatten failed for %s/%s qty=%s",
+                symbol,
+                side,
+                qty,
+            )
+            naked_position_flattened_total.labels(
+                symbol=symbol, side=side, outcome="failed"
+            ).inc()
+            return False
+
+        ok = bool(result) and not (
+            isinstance(result, dict)
+            and result.get("status") in ("failed", "rejected", "error")
+        )
+        logger.warning(
+            "NakedPositionRemediator: flattened %s/%s qty=%s reason=%s result=%s",
+            symbol,
+            side,
+            qty,
+            reason,
+            result,
+        )
+        naked_position_flattened_total.labels(
+            symbol=symbol, side=side, outcome="flattened" if ok else "failed"
+        ).inc()
+        return ok
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _derive_protective_prices(
+        self,
+        symbol: str,
+        side: str,
+        binance_positions: dict[tuple[str, str], dict[str, Any]] | None,
+    ) -> tuple[float | None, float | None]:
+        """Return (sl_price, tp_price) using local-strategy values when
+        present, else fall back to ``entryPrice ± fallback_pct``.
+
+        Local strategy values are preferred so re-arm matches strategy
+        intent. Fallback exists because the whole point of #445 is that
+        local state may be stale or missing — the exchange position is
+        the ground truth.
+        """
+        sl_price: float | None = None
+        tp_price: float | None = None
+
+        try:
+            local = self._position_manager.get_positions().get((symbol, side))
+        except Exception:
+            local = None
+
+        if local:
+            try:
+                lsl = local.get("stop_loss_price")
+                if lsl is not None:
+                    sl_price = float(lsl)
+            except (TypeError, ValueError):
+                pass
+            try:
+                ltp = local.get("take_profit_price")
+                if ltp is not None:
+                    tp_price = float(ltp)
+            except (TypeError, ValueError):
+                pass
+
+        if sl_price is not None and tp_price is not None:
+            return sl_price, tp_price
+
+        entry_price: float | None = None
+        if binance_positions:
+            bp = binance_positions.get((symbol, side))
+            if bp:
+                try:
+                    entry_price = float(bp.get("entryPrice") or 0.0) or None
+                except (TypeError, ValueError):
+                    entry_price = None
+
+        if entry_price is None or entry_price <= 0:
+            return sl_price, tp_price
+
+        if sl_price is None:
+            if side == "LONG":
+                sl_price = entry_price * (1.0 - self._fallback_sl_pct / 100.0)
+            else:
+                sl_price = entry_price * (1.0 + self._fallback_sl_pct / 100.0)
+        if tp_price is None:
+            if side == "LONG":
+                tp_price = entry_price * (1.0 + self._fallback_tp_pct / 100.0)
+            else:
+                tp_price = entry_price * (1.0 - self._fallback_tp_pct / 100.0)
+        return sl_price, tp_price
+
+    def _resolve_position_id(self, symbol: str, side: str) -> str:
+        """Best-effort: use the local position's id if known, otherwise
+        synthesize a stable handle the dispatcher accepts."""
+        try:
+            local = self._position_manager.get_positions().get((symbol, side))
+        except Exception:
+            local = None
+        if local:
+            pid = local.get("position_id") or local.get("strategy_position_id")
+            if pid:
+                return str(pid)
+        return f"naked-{symbol}-{side}"

--- a/tradeengine/position_reconciler.py
+++ b/tradeengine/position_reconciler.py
@@ -18,6 +18,7 @@ from prometheus_client import Counter, Gauge
 
 if TYPE_CHECKING:
     from tradeengine.exchange.binance import BinanceFuturesExchange
+    from tradeengine.naked_position_remediator import NakedPositionRemediator
     from tradeengine.position_manager import PositionManager
 
 logger = logging.getLogger(__name__)
@@ -239,10 +240,12 @@ class PositionReconciler:
         exchange: BinanceFuturesExchange,
         position_manager: PositionManager,
         interval_seconds: int = 60,
+        remediator: NakedPositionRemediator | None = None,
     ) -> None:
         self._exchange = exchange
         self._position_manager = position_manager
         self._interval = interval_seconds
+        self._remediator = remediator
         self._task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._last_divergence_count: int = 0
 
@@ -318,6 +321,22 @@ class PositionReconciler:
             reconciliation_evaluator_verdict.set(0)
             reconciliation_alert.set(0)
             logger.debug("PositionReconciler: positions clean, no divergences")
+
+        # #445: hand the unhedged subset to the write-mode remediator.
+        # When mode == "off" (default), this is a no-op. The remediator
+        # owns its own metrics/logging; failures here must not poison
+        # the read-only reconciliation pass.
+        if self._remediator is not None:
+            unhedged_only = [d for d in divergences if d.get("category") == "unhedged"]
+            try:
+                await self._remediator.remediate(
+                    unhedged_only, binance_positions=binance_positions
+                )
+            except Exception:
+                logger.exception(
+                    "PositionReconciler: remediator raised — read-only "
+                    "reconciliation pass continues"
+                )
 
         reconciliation_runs_total.labels(result="ok").inc()
         return divergences


### PR DESCRIPTION
## Summary

P0 fix for #445 — adds an **exchange-authoritative** naked-position remediator that can re-arm or flatten the positions the existing read-only `PositionReconciler` (FR65) already detects.

**Ships off by default** (`TE_NAKED_POSITION_REMEDIATION_MODE=off`) — deploy is a no-op until an operator flips the env var to `dry_run` / `arm_only` / `arm_or_flatten` after canary verification.

## Acceptance Criteria

### AC1 — Exchange-authoritative reconciliation loop
- ✅ Piggybacks the existing 60s `PositionReconciler.reconcile_once()` pass.
- ✅ `detect_unhedged_positions()` already iterates Binance `positionRisk` (source of truth) + per-symbol open orders to identify positions lacking reduceOnly SL+TP.
- ✅ New remediator consumes that detector output — no parallel polling.

### AC2 — Flatten-or-protect (no naked positions)
- ✅ Four modes selectable via env var:
  - `off` (default) — detection only, no writes
  - `dry_run` — logs intended remediation + emits `naked_position_detected` counter
  - `arm_only` — re-arms missing SL/TP via `exchange.execute(TradeOrder(type=stop|take_profit, reduce_only=True))`; never flattens
  - `arm_or_flatten` — arm first; if a `(symbol, side)` stays naked beyond `TE_NAKED_POSITION_FLATTEN_GRACE_SEC` (default 60s) → falls back to `dispatcher.close_position_with_cleanup`
- ✅ Idempotent — detection already filters out positions with reduceOnly SL+TP, so re-running on the same divergence list re-converges.

### AC3 — Kill the `-4509` / state-mismatch churn
- ✅ `OCOManager.place_oco_orders` now pre-checks `dispatcher._fetch_binance_position_qty(symbol, position_side)`.
- ✅ When Binance reports no open position → returns `{"status": "skipped_no_position_on_exchange"}` without calling `exchange.execute`.
- ✅ Defensive on lookup failure (raises / missing dispatcher) — falls through to placement; never silently drops an OCO for a position that actually exists.
- ✅ Hedge-mode `position_side` mapping inherits the existing `_normalise_side` semantics.

### AC4 — Observability
- ✅ New counters: `tradeengine_naked_position_detected_total{symbol,side}`, `_rearmed_total{symbol,side,outcome}`, `_flattened_total{symbol,side,outcome}`.
- ✅ New histogram: `tradeengine_naked_position_remediation_lag_seconds`.
- ✅ Detected counter still rolls up into the existing `reconciliation_alert` gauge (FR66 category e) — alert path was already wired by #424.

### AC5 — Tests
- ✅ **22 remediator tests** covering: mode validation, off / dry_run / arm_only / arm_or_flatten paths, idempotency, fallback price derivation, grace-window escalation, recovery on clean pass, zero-qty divergences.
- ✅ **5 AC3 gate tests** covering: skip-on-absent, skip-on-near-zero, fall-through-on-present, fall-through-on-lookup-failure, fall-through-without-dispatcher.
- ✅ All 30 existing `PositionReconciler` tests still green (no regression to the read-only path).

## Operational rollout

Code ships inert. After merge:

1. Deploy → behaviour unchanged (mode=off).
2. Operator flips `TE_NAKED_POSITION_REMEDIATION_MODE=dry_run` via ConfigMap — verify the `_detected` counter fires for the ~14 known naked positions and the engine logs the intended remediation per position.
3. Promote to `arm_only` after canary — verifies re-arm path doesn't double-place against Binance.
4. Promote to `arm_or_flatten` once operator is comfortable with bounded flatten under the 60s grace.

## Immediate operational action (unchanged from ticket)

The ~14 naked positions reported on the exchange right now still need manual remediation via the existing `scripts/close_unhedged_positions.py` (shipped via #430/#438). This PR prevents recurrence; it does not retroactively close what is already open.

## Related

- #424 (OCO orphan legs umbrella — the recurring fault cluster this is the 6th fix for)
- #429 (`detect_unhedged_positions` — detection-only predecessor)
- #430 (manual `close_unhedged_positions.py` ops script)
- #442 (just-shipped distributed_lock lazy reconnect — the proximate trigger for the 2026-06-03 silent-halt incident that surfaced the ~14 naked positions)
- #783 (Mongo outage P0 — class of incident that produces naked positions across sessions)

## Memory pre-flight
Posted: https://github.com/PetroSa2/petrosa-tradeengine/issues/445#issuecomment-4617141292

Closes #445
