### PR TITLE
feat(data-manager-client): #447 Phase 0 — replace stub with real async httpx client

### DIFF
--- a/tests/unit/test_data_manager_client_real.py
+++ b/tests/unit/test_data_manager_client_real.py
@@ -1,0 +1,309 @@
+"""
+Real HTTP behavior tests for BaseDataManagerClient (#447 Phase 0).
+
+These tests prove:
+- AC0.2: insert_one actually issues a POST to /api/v1/data/insert and
+         returns an inserted_id derived from the data-manager response,
+         never the literal "placeholder".
+- AC0.3: on repeated 5xx, the client retries with backoff and finally
+         raises a typed APIError — it does not silently succeed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from tradeengine.services.data_manager_client import (
+    APIError,
+    BaseDataManagerClient,
+    ConnectionError as DMConnectionError,
+)
+
+
+def _install_transport(client: BaseDataManagerClient, handler) -> None:
+    """Pre-populate the client's internal httpx.AsyncClient with a mock transport."""
+    client._client = httpx.AsyncClient(
+        base_url=client.base_url,
+        transport=httpx.MockTransport(handler),
+        timeout=httpx.Timeout(client.timeout),
+    )
+
+
+@pytest.mark.asyncio
+async def test_insert_one_real_http_returns_non_placeholder_id() -> None:
+    """AC0.2: insert_one issues a real POST and returns a non-placeholder id."""
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["body"] = request.read().decode()
+        return httpx.Response(
+            200,
+            json={
+                "message": "Successfully inserted 1 records",
+                "inserted_count": 1,
+                "metadata": {
+                    "database": "mongodb",
+                    "collection": "trading_configs_audit",
+                },
+            },
+        )
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=2)
+    _install_transport(client, handler)
+
+    record = {"_id": "abc-123", "kind": "test"}
+    result = await client.insert_one("mongodb", "trading_configs_audit", record)
+    await client.close()
+
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/api/v1/data/insert")
+    assert "abc-123" in captured["body"], "record payload must be transmitted verbatim"
+    assert result["inserted_count"] == 1
+    assert result["inserted_id"] != "placeholder", (
+        "AC0.2: literal 'placeholder' is forbidden"
+    )
+    assert result["inserted_id"] == "abc-123", "synthetic id derives from record._id"
+
+
+@pytest.mark.asyncio
+async def test_insert_one_synthesises_id_when_record_has_no_identity() -> None:
+    """Even with no _id/id/uuid in the record, the returned id must not be 'placeholder'."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"inserted_count": 1})
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=1)
+    _install_transport(client, handler)
+
+    result = await client.insert_one("mongodb", "audit", {"only": "payload"})
+    await client.close()
+
+    assert result["inserted_count"] == 1
+    assert result["inserted_id"], "must surface a non-empty id when count > 0"
+    assert result["inserted_id"] != "placeholder"
+
+
+@pytest.mark.asyncio
+async def test_insert_one_zero_count_does_not_fake_success() -> None:
+    """If data-manager reports inserted_count=0, the client must not invent an id."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"inserted_count": 0})
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=1)
+    _install_transport(client, handler)
+
+    result = await client.insert_one("mongodb", "audit", {"x": 1})
+    await client.close()
+
+    assert result["inserted_count"] == 0
+    assert result["inserted_id"] == "", "no count → empty id, never 'placeholder'"
+
+
+@pytest.mark.asyncio
+async def test_insert_one_retries_5xx_then_succeeds() -> None:
+    """AC0.3 partial: bounded retry on 5xx; success on the third attempt."""
+
+    attempts = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            return httpx.Response(503, json={"detail": "temporarily unavailable"})
+        return httpx.Response(200, json={"inserted_count": 1})
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=3)
+    _install_transport(client, handler)
+
+    # Patch sleep to keep the test fast
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_seconds: float) -> None:
+        await real_sleep(0)
+
+    asyncio_module = asyncio  # local alias to satisfy type-checkers
+    asyncio_module.sleep = fast_sleep  # type: ignore[assignment]
+    try:
+        result = await client.insert_one("mongodb", "audit", {"_id": "r1"})
+    finally:
+        asyncio_module.sleep = real_sleep  # type: ignore[assignment]
+        await client.close()
+
+    assert attempts["n"] == 3
+    assert result["inserted_count"] == 1
+    assert result["inserted_id"] != "placeholder"
+
+
+@pytest.mark.asyncio
+async def test_insert_one_5xx_exhaustion_raises_api_error() -> None:
+    """AC0.3: persistent 5xx must raise APIError after max_retries — never placeholder success."""
+
+    attempts = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["n"] += 1
+        return httpx.Response(502, json={"detail": "bad gateway"})
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=3)
+    _install_transport(client, handler)
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_seconds: float) -> None:
+        await real_sleep(0)
+
+    asyncio.sleep = fast_sleep  # type: ignore[assignment]
+    try:
+        with pytest.raises(APIError) as excinfo:
+            await client.insert_one("mongodb", "audit", {"_id": "r1"})
+    finally:
+        asyncio.sleep = real_sleep  # type: ignore[assignment]
+        await client.close()
+
+    assert attempts["n"] == 3, "must retry exactly max_retries times"
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_4xx_is_not_retried_and_raises_immediately() -> None:
+    """Non-retryable client errors (4xx) must fail fast — no silent placeholder."""
+
+    attempts = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["n"] += 1
+        return httpx.Response(400, json={"detail": "bad request"})
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=3)
+    _install_transport(client, handler)
+
+    with pytest.raises(APIError) as excinfo:
+        await client.insert_one("mongodb", "audit", {"_id": "r1"})
+    await client.close()
+
+    assert attempts["n"] == 1, "4xx must not be retried"
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_insert_passes_records_list_and_returns_count() -> None:
+    """The `insert` path used by audit logs hits the same endpoint with records[]."""
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.read().decode()
+        return httpx.Response(200, json={"inserted_count": 1})
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=1)
+    _install_transport(client, handler)
+
+    result = await client.insert("mongodb", "audit", {"k": "v"})
+    await client.close()
+
+    assert '"records":' in captured["body"]
+    assert '"k": "v"' in captured["body"] or '"k":"v"' in captured["body"]
+    assert result == {"inserted_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_query_returns_data_list() -> None:
+    """query() unwraps the data-manager `data` array for callers."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"_id": "1", "x": 1}, {"_id": "2", "x": 2}],
+                "pagination": {"total": 2},
+                "metadata": {},
+            },
+        )
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=1)
+    _install_transport(client, handler)
+
+    result = await client.query("mongodb", "audit", filter={"x": 1}, limit=10)
+    await client.close()
+
+    assert len(result["data"]) == 2
+    assert result["pagination"] == {"total": 2}
+
+
+@pytest.mark.asyncio
+async def test_upsert_one_returns_real_counts_never_placeholder() -> None:
+    """upsert_one must surface real counts; upserted_id may be synthesized but never 'placeholder'."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"modified_count": 0, "upserted_count": 1},
+        )
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=1)
+    _install_transport(client, handler)
+
+    result = await client.upsert_one("mongodb", "trading_configs_global", {}, {"x": 1})
+    await client.close()
+
+    assert result["upserted_count"] == 1
+    assert result["modified_count"] == 0
+    assert result["upserted_id"] != "placeholder"
+    assert result["upserted_id"], "must surface a non-empty id when upsert occurred"
+
+
+@pytest.mark.asyncio
+async def test_delete_one_returns_real_count() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        return httpx.Response(200, json={"deleted_count": 1})
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=1)
+    _install_transport(client, handler)
+
+    result = await client.delete_one("mongodb", "audit", {"x": 1})
+    await client.close()
+
+    assert result == {"deleted_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_health_unhealthy_when_data_manager_unreachable() -> None:
+    """health() must NOT raise; it must return {'status': 'unhealthy'} after retries."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "down"})
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=2)
+    _install_transport(client, handler)
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_seconds: float) -> None:
+        await real_sleep(0)
+
+    asyncio.sleep = fast_sleep  # type: ignore[assignment]
+    try:
+        health = await client.health()
+    finally:
+        asyncio.sleep = real_sleep  # type: ignore[assignment]
+        await client.close()
+
+    assert health["status"] == "unhealthy"
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent() -> None:
+    """close() may be called multiple times safely (mongodb_client.py disconnect path)."""
+
+    client = BaseDataManagerClient(base_url="http://dm.test", timeout=5, max_retries=1)
+    _install_transport(client, lambda req: httpx.Response(200, json={}))
+    await client.close()
+    await client.close()  # second call must not raise

--- a/tradeengine/services/data_manager_client.py
+++ b/tradeengine/services/data_manager_client.py
@@ -3,53 +3,246 @@ Data Manager client for petrosa-tradeengine.
 
 This module provides a client for interacting with the petrosa-data-manager API
 for audit logging and configuration management.
+
+Closes #447 (P0): replaces the prior `BaseDataManagerClient` stub — which
+silently returned placeholder dicts and never issued any HTTP — with a real
+async httpx implementation that talks to data-manager's legacy and generic
+endpoints with bounded retry-with-backoff.
 """
 
+import asyncio
+import logging
 import os
+import random
 from datetime import datetime
 from typing import Any, Optional
+
+import httpx
 
 from contracts.trading_config import LeverageStatus, TradingConfig, TradingConfigAudit
 from shared.constants import UTC
 
-# Local Data Manager Client implementation
-# from data_manager_client import DataManagerClient as BaseDataManagerClient
-# from data_manager_client.exceptions import ConnectionError
+logger = logging.getLogger(__name__)
 
 
-# Temporary local implementation
+class APIError(Exception):
+    """Raised when the data-manager API call fails after exhausting retries."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        body: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+
+
+class ConnectionError(APIError):
+    """Raised when connecting to data-manager fails after retries."""
+
+    pass
+
+
+_RETRYABLE_STATUS_CODES = frozenset({500, 502, 503, 504})
+_RETRY_BACKOFF_BASE = 0.5
+_RETRY_BACKOFF_CAP = 8.0
+
+
 class BaseDataManagerClient:
-    """Temporary local implementation of Data Manager Client."""
+    """
+    Async HTTP client for petrosa-data-manager.
+
+    Talks to data-manager's legacy `/api/v1/data/{insert,query}` routes
+    (per #447 F6 operator decision — matches extractor pattern) and the
+    generic `/api/v1/{db}/{coll}` routes for update/upsert/delete. Bounded
+    retry-with-jittered-backoff on 5xx and connection errors; raises
+    :class:`APIError` (or :class:`ConnectionError`) on retry exhaustion.
+
+    Response-key contract preserved for callers in
+    `tradeengine/db/mongodb_client.py` and `shared/mysql_client.py`:
+
+    - ``query``       → ``{"data": list}``
+    - ``insert_one``  → ``{"inserted_id": str, "inserted_count": int}``
+    - ``insert``      → ``{"inserted_count": int}``
+    - ``update_one``  → ``{"modified_count": int}``
+    - ``upsert_one``  → ``{"modified_count", "upserted_count", "upserted_id"}``
+    - ``delete_one``  → ``{"deleted_count": int}``
+    - ``delete``      → ``{"deleted_count": int}``
+    - ``health``      → ``{"status": "healthy" | "unhealthy", ...}``
+    """
 
     def __init__(self, base_url: str, timeout: int = 30, max_retries: int = 3):
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/")
         self.timeout = timeout
-        self.max_retries = max_retries
+        self.max_retries = max(1, int(max_retries))
+        self._client: httpx.AsyncClient | None = None
+        self._client_lock: asyncio.Lock | None = None
 
-    async def health(self) -> dict[str, Any]:
-        """Health check."""
-        return {"status": "healthy"}
+    def _ensure_lock(self) -> asyncio.Lock:
+        if self._client_lock is None:
+            self._client_lock = asyncio.Lock()
+        return self._client_lock
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            async with self._ensure_lock():
+                if self._client is None:
+                    self._client = httpx.AsyncClient(
+                        base_url=self.base_url,
+                        timeout=httpx.Timeout(self.timeout),
+                    )
+        return self._client
 
     async def close(self) -> None:
-        """Close connection."""
-        pass
+        """Close the underlying httpx client (idempotent)."""
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            finally:
+                self._client = None
 
-    # NEW METHODS - Implement missing Data Manager methods
+    async def _retry_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue an HTTP request with bounded retry-with-backoff."""
+        client = await self._get_client()
+        last_exc: Exception | None = None
+        for attempt in range(self.max_retries):
+            try:
+                resp = await client.request(method, path, json=json_body, params=params)
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                last_exc = ConnectionError(f"connection to data-manager failed: {exc}")
+            except httpx.HTTPError as exc:
+                last_exc = APIError(f"transport error: {exc}")
+            else:
+                if resp.status_code in _RETRYABLE_STATUS_CODES:
+                    last_exc = APIError(
+                        f"data-manager {method} {path} returned {resp.status_code}",
+                        status_code=resp.status_code,
+                        body=resp.text[:1000],
+                    )
+                elif 200 <= resp.status_code < 300:
+                    try:
+                        payload = resp.json()
+                    except ValueError:
+                        payload = {}
+                    return payload if isinstance(payload, dict) else {"data": payload}
+                else:
+                    # Non-retryable 4xx (or other) — fail fast
+                    raise APIError(
+                        f"data-manager {method} {path} returned {resp.status_code}",
+                        status_code=resp.status_code,
+                        body=resp.text[:1000],
+                    )
+
+            if attempt < self.max_retries - 1:
+                backoff = min(
+                    _RETRY_BACKOFF_BASE * (2**attempt) + random.uniform(0, 0.25),
+                    _RETRY_BACKOFF_CAP,
+                )
+                logger.warning(
+                    "data-manager %s %s attempt %d/%d failed (%s); retrying in %.2fs",
+                    method,
+                    path,
+                    attempt + 1,
+                    self.max_retries,
+                    last_exc,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+        assert last_exc is not None
+        raise last_exc
+
+    async def health(self) -> dict[str, Any]:
+        """Probe data-manager's readiness endpoint.
+
+        Returns the canonical ``{"status": "healthy"}`` payload on a 2xx with
+        a recognized status field; ``{"status": "unhealthy", "error": ...}``
+        on retry exhaustion (does NOT raise — callers gate on the status).
+        """
+        try:
+            body = await self._retry_request("GET", "/health/readiness")
+        except APIError as exc:
+            return {"status": "unhealthy", "error": str(exc)}
+        status_field = body.get("status") or body.get("readiness")
+        if isinstance(status_field, str) and status_field.lower() in {
+            "ok",
+            "ready",
+            "healthy",
+            "up",
+            "available",
+        }:
+            return {"status": "healthy", "raw": body}
+        # Some readiness endpoints answer 200 with no `status` field;
+        # treat a 2xx response as healthy so the outer DataManagerClient
+        # can still proceed when the API surface evolves.
+        return {"status": "healthy" if body else "unhealthy", "raw": body}
+
     async def query(
         self, database: str, collection: str, **kwargs: Any
     ) -> dict[str, Any]:
-        """Query records."""
-        # TODO: Implement actual HTTP call to Data Manager API
-        # For now, return empty to avoid errors
-        return {"data": []}
+        """Query records via `POST /api/v1/data/query`."""
+        body: dict[str, Any] = {"database": database, "collection": collection}
+        for key in ("filter", "sort", "limit", "offset", "fields"):
+            value = kwargs.get(key)
+            if value is not None:
+                body[key] = value
+        resp = await self._retry_request("POST", "/api/v1/data/query", json_body=body)
+        return {"data": resp.get("data", []), "pagination": resp.get("pagination")}
 
     async def insert_one(
         self, database: str, collection: str, record: dict[str, Any]
     ) -> dict[str, Any]:
-        """Insert one record."""
-        # TODO: Implement actual HTTP call to Data Manager API
-        # For now, return success to avoid errors
-        return {"inserted_id": "placeholder"}
+        """Insert a single record via `POST /api/v1/data/insert`.
+
+        data-manager's legacy insert endpoint returns ``inserted_count``
+        but NOT ``inserted_id``. Per AC0.2 the response must reflect the
+        real call — never the literal ``"placeholder"``. We synthesize a
+        deterministic non-placeholder id from the record's own identity
+        when present, otherwise from collection + count.
+        """
+        body = {
+            "database": database,
+            "collection": collection,
+            "records": [record],
+        }
+        resp = await self._retry_request("POST", "/api/v1/data/insert", json_body=body)
+        inserted_count = int(resp.get("inserted_count", 0) or 0)
+        synthetic_id = ""
+        if inserted_count > 0:
+            for candidate_key in ("_id", "id", "uuid"):
+                value = record.get(candidate_key)
+                if value:
+                    synthetic_id = str(value)
+                    break
+            if not synthetic_id:
+                synthetic_id = f"{collection}-{inserted_count}"
+        return {"inserted_id": synthetic_id, "inserted_count": inserted_count}
+
+    async def insert(
+        self,
+        database: str,
+        collection: str,
+        data: dict[str, Any] | list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Insert one or many records via `POST /api/v1/data/insert`.
+
+        Mirrors the audit-trail / batch-insert path in the outer
+        :class:`DataManagerClient`. Existing call sites pass a single
+        dict (`add_audit_record`); we accept lists too for forward
+        compatibility.
+        """
+        records = data if isinstance(data, list) else [data]
+        body = {"database": database, "collection": collection, "records": records}
+        resp = await self._retry_request("POST", "/api/v1/data/insert", json_body=body)
+        return {"inserted_count": int(resp.get("inserted_count", 0) or 0)}
 
     async def update_one(
         self,
@@ -58,9 +251,12 @@ class BaseDataManagerClient:
         filter: dict[str, Any],
         update: dict[str, Any],
     ) -> dict[str, Any]:
-        """Update one record."""
-        # TODO: Implement actual HTTP call to Data Manager API
-        return {"modified_count": 1}
+        """Update via `PUT /api/v1/{database}/{collection}` (upsert=False)."""
+        body = {"filter": filter, "data": update, "upsert": False}
+        resp = await self._retry_request(
+            "PUT", f"/api/v1/{database}/{collection}", json_body=body
+        )
+        return {"modified_count": int(resp.get("modified_count", 0) or 0)}
 
     async def upsert_one(
         self,
@@ -69,52 +265,54 @@ class BaseDataManagerClient:
         filter: dict[str, Any],
         record: dict[str, Any],
     ) -> dict[str, Any]:
-        """Upsert one record."""
-        # TODO: Implement actual HTTP call to Data Manager API
-        return {"upserted_id": "placeholder", "modified_count": 1}
+        """Upsert via `PUT /api/v1/{database}/{collection}` (upsert=True)."""
+        body = {"filter": filter, "data": record, "upsert": True}
+        resp = await self._retry_request(
+            "PUT", f"/api/v1/{database}/{collection}", json_body=body
+        )
+        modified_count = int(resp.get("modified_count", 0) or 0)
+        upserted_count = int(resp.get("upserted_count", 0) or 0)
+        upserted_id = resp.get("upserted_id")
+        if upserted_id is None and upserted_count > 0:
+            upserted_id = f"{collection}-upsert-{upserted_count}"
+        return {
+            "modified_count": modified_count,
+            "upserted_count": upserted_count,
+            "upserted_id": upserted_id,
+        }
 
     async def delete_one(
         self, database: str, collection: str, filter: dict[str, Any]
     ) -> dict[str, Any]:
-        """Delete one record."""
-        # TODO: Implement actual HTTP call to Data Manager API
-        return {"deleted_count": 1}
+        """Delete via `DELETE /api/v1/{database}/{collection}`."""
+        body = {"filter": filter}
+        resp = await self._retry_request(
+            "DELETE", f"/api/v1/{database}/{collection}", json_body=body
+        )
+        return {"deleted_count": int(resp.get("deleted_count", 0) or 0)}
 
     async def delete(
         self, database: str, collection: str, filter: dict[str, Any]
     ) -> dict[str, Any]:
-        """Delete records."""
-        return {"deleted_count": 1}
-
-    async def insert(
-        self, database: str, collection: str, data: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Insert records."""
-        return {"inserted_count": 1}
+        """Delete (multi). Same DELETE route as `delete_one`."""
+        return await self.delete_one(database, collection, filter)
 
     async def request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
-        """Make HTTP request."""
-        # TODO: Implement actual HTTP call to Data Manager API
-        # For now, return success to avoid errors
-        return {"status": "success"}
-
-
-class ConnectionError(Exception):
-    """Connection error."""
-
-    pass
-
-
-logger = None
+        """Generic HTTP passthrough used by `mongodb_client.py`."""
+        path = url if url.startswith("/") else f"/{url}"
+        json_body = kwargs.get("json")
+        if json_body is None:
+            json_body = kwargs.get("json_body")
+        return await self._retry_request(
+            method.upper(),
+            path,
+            json_body=json_body,
+            params=kwargs.get("params"),
+        )
 
 
 def get_logger() -> Any:
-    """Get logger instance."""
-    global logger
-    if logger is None:
-        import logging
-
-        logger = logging.getLogger(__name__)
+    """Backwards-compatible accessor for the module logger."""
     return logger
 
 
@@ -153,7 +351,7 @@ class DataManagerClient:
             max_retries=self.max_retries,
         )
 
-        self._logger = get_logger()
+        self._logger = logger
         self._logger.info(f"Initialized Data Manager client: {self.base_url}")
 
     async def connect(self) -> None:


### PR DESCRIPTION
Closes PetroSa2/petrosa-tradeengine#447

## Why

Live-pod write-then-read probe (recorded in [issue comment](https://github.com/PetroSa2/petrosa-tradeengine/issues/447#issuecomment-4623087476)) **confirmed the P0 in production**:

- Wrote `{"probe_tag": "ac01-probe-b0023d195f32"}` through the deployed `DataManagerClient` → returned `{"inserted_id": "placeholder"}`.
- Direct query to data-manager `/api/v1/mongodb/trading_configs_audit` → `{"total": 0}`. The record never landed.

Every audit/config/leverage write through `tradeengine.services.data_manager_client.BaseDataManagerClient` was a silent no-op. `get_open_positions()` always returned `[]` so position recovery on startup was broken.

## What changed

Replaced the stub `BaseDataManagerClient` with a real `httpx.AsyncClient`-backed implementation. Outer `DataManagerClient` and all call sites in `tradeengine/db/mongodb_client.py` / `shared/mysql_client.py` are untouched — the response-key contract is preserved.

Per operator decisions (#447 F4/F5/F6):

| Decision | Choice | Where |
|---|---|---|
| F5 transport | `httpx` async client | `BaseDataManagerClient._get_client` |
| F6 insert endpoint | `POST /api/v1/data/insert` (extractor pattern) | `insert_one`, `insert` |
| F4 verification | Live-pod write-then-read probe | Issue comment |

Endpoint mapping:

| Method | Route | Notes |
|---|---|---|
| `insert_one` / `insert` | `POST /api/v1/data/insert` | Synthesizes a non-placeholder `inserted_id` from record `_id`/`id`/`uuid` (the legacy route returns `inserted_count` but no id) |
| `query` | `POST /api/v1/data/query` | Returns `{"data": [...], "pagination": ...}` |
| `update_one` | `PUT /api/v1/{db}/{coll}` | `upsert=False` |
| `upsert_one` | `PUT /api/v1/{db}/{coll}` | `upsert=True`; synthesizes `upserted_id` when count > 0 |
| `delete_one` / `delete` | `DELETE /api/v1/{db}/{coll}` | |
| `health` | `GET /health/readiness` | Returns `{"status": "unhealthy"}` on retry exhaustion (does not raise) |

## AC coverage

- **AC0.1** — Stub vs real documented; finding posted to issue. Probe confirms stub ships in prod → this PR is the P0 hotfix.
- **AC0.2** — `insert_one` now issues a real `POST /api/v1/data/insert` and returns a synthesized id (`record["_id"]` / `record["id"]` / `record["uuid"]` / `{collection}-{count}`) — **never** the literal `"placeholder"`. Covered by `test_insert_one_real_http_returns_non_placeholder_id`, `test_insert_one_synthesises_id_when_record_has_no_identity`, `test_insert_one_zero_count_does_not_fake_success`.
- **AC0.3** — Bounded retry (exponential + jittered backoff) on 5xx and connection/timeout errors; 4xx fails fast; retry exhaustion raises typed `APIError` with `status_code` + truncated body. Covered by `test_insert_one_retries_5xx_then_succeeds`, `test_insert_one_5xx_exhaustion_raises_api_error`, `test_4xx_is_not_retried_and_raises_immediately`.

## Tests

```
89 passed  -- existing data_manager_*.py contract tests (unchanged)
12 passed  -- new tests/unit/test_data_manager_client_real.py
1349 passed -- full suite (excluding 11 pre-existing tests/test_api.py-style
              files broken by starlette==0.45 / httpx==0.28 TestClient kwarg
              incompatibility, tracked in MemPalace as
              reference_starlette_045_httpx_028_testclient_incompat)
```

## Risk

Medium. The change is constrained to the persistence client; outer `DataManagerClient` methods and all call-site signatures are byte-identical to before. **Behaviour change**: writes that previously "succeeded" with placeholders will now actually issue HTTP and may surface real failures (e.g. schema validation, connectivity). That is the entire point of the P0 fix.

httpx is already a runtime dep (`httpx==0.28.1`); no new pin.

## Out of scope for Phase 0

- Phase 1 resilience (circuit breakers, backpressure) — separate ticket in #801.
- Migrating any tradeengine call site to use a different endpoint — keeping the surface stable was the contract.
- Backfilling lost writes from the stub era — operator decision required.

## Follow-up considerations

- Should we add a startup self-test that issues a real write to `trading_configs_audit` and reads it back, so future regressions to a stub are detected at boot rather than via prod probe? (Suggested follow-up, not landing here.)
- `health()` now reflects reality. Any deploy-time health gate that relied on the stub's always-`healthy` will now reveal actual data-manager outages.
