### PR TITLE
fix(boot-probe): #465 prevent event-loop starvation from sync REST during startup (AC1+AC2+AC3)

### DIFF
--- a/tests/test_data_manager_boot_probe.py
+++ b/tests/test_data_manager_boot_probe.py
@@ -164,19 +164,29 @@ async def test_readback_exception_failure(probe: DataManagerBootProbe) -> None:
 
 
 # ---------------------------------------------------------------------------
-# AC3: 5-second total timeout
+# #451 AC3 / #465 AC1: hard total timeout still fires when the probe overruns
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_timeout_returns_failure(probe: DataManagerBootProbe) -> None:
-    """Probe must return failure if _run_probe exceeds 5 seconds."""
+    """Probe must return failure if ``_run_probe`` exceeds ``_PROBE_TIMEOUT_SECONDS``.
+
+    The constant is patched to a small value so the test stays fast even
+    after #465 raised the production ceiling to 20 s.
+    """
 
     async def _slow_probe(_probe_id: str) -> BootProbeResult:
-        await asyncio.sleep(10)
+        await asyncio.sleep(1.0)
         return BootProbeResult(success=True)
 
-    with patch.object(probe, "_run_probe", side_effect=_slow_probe):
+    with (
+        patch(
+            "tradeengine.services.data_manager_boot_probe._PROBE_TIMEOUT_SECONDS",
+            0.1,
+        ),
+        patch.object(probe, "_run_probe", side_effect=_slow_probe),
+    ):
         result = await probe.run(pod_name="slow-pod")
 
     assert result.success is False
@@ -233,3 +243,61 @@ async def test_metric_failure_does_not_raise(probe: DataManagerBootProbe) -> Non
     ):
         result = await probe.run(pod_name="metrics-pod")
     assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# #465 AC1+AC3: 20s timeout tolerates event-loop scheduling delay
+# ---------------------------------------------------------------------------
+
+
+def test_probe_timeout_constant_is_twenty_seconds() -> None:
+    """#465 AC1: hard-coded probe timeout is the 20 s ceiling, not the prior 5 s."""
+    from tradeengine.services.data_manager_boot_probe import _PROBE_TIMEOUT_SECONDS
+
+    assert _PROBE_TIMEOUT_SECONDS == 20.0
+
+
+@pytest.mark.asyncio
+async def test_probe_succeeds_under_event_loop_contention(
+    probe: DataManagerBootProbe,
+) -> None:
+    """#465 AC3: a ~6s event-loop scheduling delay no longer trips the timeout.
+
+    Pre-#465 the probe budget was 5 s; any startup-time contention (sync
+    Binance REST calls during leverage setup / OCO reconcile) starved the
+    probe coroutine and produced a spurious ``probe_timeout_after_5.0s``.
+    Post-#465 the budget is 20 s, so a combined ~6 s of asyncio scheduling
+    delay during insert + readback completes well within budget.
+    """
+
+    async def slow_insert(*_args: object, **_kwargs: object) -> dict:
+        await asyncio.sleep(3)
+        return {"inserted_id": "probe-contended", "inserted_count": 1}
+
+    async def slow_query(*_args: object, **_kwargs: object) -> dict:
+        await asyncio.sleep(3)
+        return {
+            "data": [
+                {
+                    "_id": "probe-contended",
+                    "created_at": "2026-06-10T16:00:00Z",
+                }
+            ]
+        }
+
+    client = MagicMock()
+    client.close = AsyncMock(return_value=None)
+    client.insert_one = AsyncMock(side_effect=slow_insert)
+    client.query = AsyncMock(side_effect=slow_query)
+    client.delete = AsyncMock(return_value={"deleted_count": 0})
+
+    with patch(
+        "tradeengine.services.data_manager_boot_probe.BaseDataManagerClient",
+        return_value=client,
+    ):
+        result = await probe.run(pod_name="contended-pod")
+
+    assert result.success is True, (
+        f"expected success under contention, got failure_mode={result.failure_mode}"
+    )
+    assert result.failure_mode is None

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -739,7 +739,11 @@ class OCOManager:
 
         if not open_orders:
             try:
-                std_orders = self.exchange.client.futures_get_open_orders()
+                # #465: offload sync REST to a thread so the event loop stays
+                # responsive for the boot probe scheduled immediately after.
+                std_orders = await asyncio.to_thread(
+                    self.exchange.client.futures_get_open_orders
+                )
                 open_orders = list(std_orders) if std_orders else []
                 self.logger.info(
                     f"[STARTUP] Fallback: fetched {len(open_orders)} standard open orders for OCO reconciliation"
@@ -1455,7 +1459,9 @@ class Dispatcher:
                 "Strategy position manager initialization started in background"
             )
 
-            # PROACTIVE LEVERAGE SETUP
+            # PROACTIVE LEVERAGE SETUP (#465: offload sync REST to a thread so it
+            # yields the event loop between symbols and does not starve the
+            # downstream DataManager boot probe)
             if self.exchange:
                 try:
                     self.logger.info("🔧 SETTING PROACTIVE LEVERAGE (10x)...")
@@ -1463,10 +1469,10 @@ class Dispatcher:
 
                     for symbol in SUPPORTED_SYMBOLS:
                         try:
-                            # Use futures_change_leverage directly from the exchange client
-                            # Adjusting to 10x as a safe default
-                            self.exchange.client.futures_change_leverage(
-                                symbol=symbol, leverage=10
+                            await asyncio.to_thread(
+                                self.exchange.client.futures_change_leverage,
+                                symbol=symbol,
+                                leverage=10,
                             )
                             self.logger.info(f"✅ Leverage set to 10x for {symbol}")
                         except Exception as lev_err:

--- a/tradeengine/services/data_manager_boot_probe.py
+++ b/tradeengine/services/data_manager_boot_probe.py
@@ -18,7 +18,7 @@ from tradeengine.services.data_manager_client import BaseDataManagerClient
 
 logger = logging.getLogger(__name__)
 
-_PROBE_TIMEOUT_SECONDS = 5.0
+_PROBE_TIMEOUT_SECONDS = 20.0
 _PROBE_COLLECTION = "tradeengine_boot_probes"
 _PROBE_DB = "mongodb"
 _TTL_HOURS = 24
@@ -49,7 +49,15 @@ class DataManagerBootProbe:
         self._timeout = timeout
 
     async def run(self, pod_name: str = "unknown") -> BootProbeResult:
-        """Execute the boot probe within a hard 5-second total timeout (AC3)."""
+        """Execute the boot probe within a hard 20-second total timeout (#465 AC1).
+
+        Raised from 5s to 20s because ``dispatcher.initialize()`` can leave the
+        event loop saturated by background tasks (sync Binance REST calls during
+        leverage setup and OCO reconciliation) for several seconds after it
+        returns. Data-manager write+read round-trip is ~300 ms, so 20 s gives
+        ~19.7 s of event-loop slack — enough that any realistic contention
+        clears before the probe coroutine reaches its first ``await``.
+        """
         if not _probe_enabled():
             logger.info("dm_boot_probe.skipped TE_BOOT_PROBE_ENABLED=false")
             return BootProbeResult(success=True)


### PR DESCRIPTION
## Summary

Fixes the boot-probe `TimeoutError` that crash-looped tradeengine pods on 2026-06-10 by addressing both the event-loop starvation root cause **and** the too-tight timeout that surfaced it.

The current production workaround is `TE_BOOT_PROBE_ENABLED=false` (set in `petrosa_k8s` commit `8b644286`). Once this PR is green, a follow-up `petrosa_k8s` PR will flip the flag back on.

## Acceptance Criteria

### AC1 — Bump `_PROBE_TIMEOUT_SECONDS` 5.0 → 20.0
- `tradeengine/services/data_manager_boot_probe.py:21` — constant bumped.
- DM round-trip is ~300 ms, so 20 s gives ~19.7 s of event-loop slack.
- New regression: `test_probe_timeout_constant_is_twenty_seconds`.

### AC2 — Offload blocking Binance REST calls to threads
- `tradeengine/dispatcher.py` line ~1473 — `PROACTIVE LEVERAGE SETUP` loop now uses `await asyncio.to_thread(self.exchange.client.futures_change_leverage, …)` per symbol, so the loop yields between each call instead of monopolising the loop for ~3 s.
- `tradeengine/dispatcher.py` line ~745 — `OCOManager.reconcile_from_exchange` fallback path (`futures_get_open_orders`) likewise wrapped.
- Other `self.exchange.client.futures_*` sites at lines 610 / 1246 are in hot-path OCO/post-fill flows (not in the boot-probe critical path) and are out of scope.

### AC3 — Regression test under event-loop contention
- `test_probe_succeeds_under_event_loop_contention` patches `BaseDataManagerClient` so `insert_one` and `query` each `await asyncio.sleep(3)` — ~6 s of scheduling delay total. Pre-#465 this would have tripped the 5 s timeout; post-#465 the probe completes with `success=True`.

### AC4 — Re-enable `TE_BOOT_PROBE_ENABLED`
- Deferred to a follow-up `petrosa_k8s` PR (cross-repo) once AC1+AC2+AC3 land green here. Will remove the `false` override from `k8s/tradeengine/deployment.yaml`.

## Test results

```
tests/test_data_manager_boot_probe.py  16 passed
tests/test_oco_orders.py              17 passed
tests/test_dispatcher.py              42 passed
Full suite (excl. pre-existing TestClient/starlette
version-mismatch failures unrelated to #465)
                                    1420 passed, 11 skipped
```

`ruff check` clean on all touched files. `pre-commit` hooks all passed on commit.

## References

- Closes #465 (AC1, AC2, AC3)
- Follow-up: AC4 will be filed as a `petrosa_k8s` change once this is merged
- Related: #451 (boot probe feature), #462 (TTL index — closed), workaround commit `8b644286`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
