### PR TITLE
fix(boot-probe): filter read-back by probe_id, not _id (#468)

### DIFF
--- a/tests/test_data_manager_boot_probe.py
+++ b/tests/test_data_manager_boot_probe.py
@@ -301,3 +301,42 @@ async def test_probe_succeeds_under_event_loop_contention(
         f"expected success under contention, got failure_mode={result.failure_mode}"
     )
     assert result.failure_mode is None
+
+
+@pytest.mark.asyncio
+async def test_readback_uses_probe_id_not_id_field(probe: DataManagerBootProbe) -> None:
+    """#468 regression: filter MUST use `probe_id` field (which the data-manager
+    MongoDB adapter preserves), NOT `_id` (which is stripped by
+    mongodb_adapter.query_range before _apply_filter runs).
+
+    Before this fix the probe always reported `readback_empty` in production
+    because every record came back without `_id` and the filter could never
+    match. We assert both halves of the contract here:
+      1. The insert record carries `probe_id` alongside `_id`.
+      2. The query filter keys on `probe_id`, not `_id`.
+    """
+    client = _make_client(
+        insert_one_return={"inserted_id": "probe-468", "inserted_count": 1},
+        query_return={
+            "data": [{"probe_id": "probe-468", "created_at": "2026-06-10T20:00:00Z"}]
+        },
+    )
+
+    result = await probe._probe_with_client(client, "probe-468", "2026-06-10T20:00:00Z")
+
+    assert result.success is True
+
+    insert_kwargs = client.insert_one.call_args
+    inserted_record = (
+        insert_kwargs.args[2]
+        if len(insert_kwargs.args) >= 3
+        else insert_kwargs.kwargs.get("record") or insert_kwargs.args[-1]
+    )
+    assert inserted_record.get("probe_id") == "probe-468", (
+        f"insert record must carry `probe_id`, got {inserted_record!r}"
+    )
+
+    query_kwargs = client.query.call_args.kwargs
+    assert query_kwargs.get("filter") == {"probe_id": "probe-468"}, (
+        f"query filter must key on `probe_id`, got {query_kwargs.get('filter')!r}"
+    )

--- a/tradeengine/services/data_manager_boot_probe.py
+++ b/tradeengine/services/data_manager_boot_probe.py
@@ -98,8 +98,11 @@ class DataManagerBootProbe:
         probe_id: str,
         created_at: str,
     ) -> BootProbeResult:
-        # AC1: Write sentinel record
-        record = {"_id": probe_id, "created_at": created_at}
+        # AC1: Write sentinel record. `probe_id` is duplicated outside `_id` because
+        # data-manager's MongoDB adapter strips `_id` from query_range results
+        # (mongodb_adapter.query_range line ~174), so the read-back filter must
+        # use a field that survives that strip. Fixes petrosa-tradeengine#468.
+        record = {"_id": probe_id, "probe_id": probe_id, "created_at": created_at}
         try:
             write_result = await client.insert_one(_PROBE_DB, _PROBE_COLLECTION, record)
         except Exception as exc:
@@ -132,7 +135,7 @@ class DataManagerBootProbe:
         # AC1: Read back the sentinel record
         try:
             read_result = await client.query(
-                _PROBE_DB, _PROBE_COLLECTION, filter={"_id": probe_id}, limit=1
+                _PROBE_DB, _PROBE_COLLECTION, filter={"probe_id": probe_id}, limit=1
             )
         except Exception as exc:
             failure_mode = f"readback_exception:{type(exc).__name__}"


### PR DESCRIPTION
## Summary

Fixes the `dm_boot_probe.failure readback_empty` regression that caused [petrosa_k8s#825](https://github.com/PetroSa2/petrosa_k8s/issues/825) to be rolled back.

## Root cause

`data-manager`'s MongoDB adapter strips `_id` from every record returned by `query_range`:

```python
# petrosa-data-manager mongodb_adapter.py:174
for doc in documents:
    doc.pop("_id", None)
```

The boot probe wrote sentinel records keyed on `_id` and then filtered the read-back by `_id` — but after the adapter strip, the `_id` field is gone, so `_apply_filter` could never match. Every probe returned `readback_empty` even when the write succeeded.

## Fix

Carry the probe identifier in a separate `probe_id` field on the sentinel record. The MongoDB adapter does not strip this field, so the read-back filter finds the record correctly.

## Test

Added `test_readback_uses_probe_id_not_id_field` which asserts:
1. The insert record carries `probe_id` alongside `_id`.
2. The query filter keys on `probe_id`, not `_id`.

A regression of either half fails the test. **17/17 boot probe tests pass.**

## References

- Closes #468
- Blocks: PetroSa2/petrosa_k8s#825
- Rollback that uncovered this: PetroSa2/petrosa_k8s#828
