### PR TITLE
feat(db): positions composite indexes migration 002 (tradeengine#466)

### DIFF
--- a/scripts/migrations/002_positions_index_optimization.sql
+++ b/scripts/migrations/002_positions_index_optimization.sql
@@ -1,0 +1,12 @@
+-- Migration 002: positions composite indexes for open-positions hot path
+--
+-- Covers get_open_positions(): WHERE status='open' ORDER BY entry_time DESC LIMIT 100
+CREATE INDEX IF NOT EXISTS idx_positions_status_entry_time
+  ON positions (status, entry_time);
+
+-- Covers upsert_position() + close_position(): WHERE symbol=? AND position_side=? AND status=?
+CREATE INDEX IF NOT EXISTS idx_positions_symbol_side_status
+  ON positions (symbol, position_side, status);
+
+-- Refresh stats so optimizer picks the new indexes
+ANALYZE TABLE positions;


### PR DESCRIPTION
## Summary

Adds `scripts/migrations/002_positions_index_optimization.sql` with two composite indexes for the positions table hot paths:

- `idx_positions_status_entry_time (status, entry_time)` — covers `get_open_positions()`: `WHERE status='open' ORDER BY entry_time DESC LIMIT 100`
- `idx_positions_symbol_side_status (symbol, position_side, status)` — covers `upsert_position()` / `close_position()`: `WHERE symbol=? AND position_side=? AND status=?`

Both use `CREATE INDEX IF NOT EXISTS` (idempotent). `ANALYZE TABLE positions` appended to refresh optimizer stats.

## Acceptance Criteria
- AC5: EXPLAIN for get_open_positions returns key=idx_positions_status_entry_time, no Using filesort
- AC6: EXPLAIN for upsert_position lookup returns key=idx_positions_symbol_side_status
- AC10: UPDATE_TIME in INFORMATION_SCHEMA.TABLES for positions ≤1h after verification

K8s migration Job is in petrosa_k8s PR (companion PR).

Closes #466