### PR TITLE
feat: check-before-place idempotency in OrderManager / dispatcher (te#460)

### DIFF
--- a/tests/test_460_check_before_place.py
+++ b/tests/test_460_check_before_place.py
@@ -1,0 +1,145 @@
+"""Tests for tradeengine#460 — check-before-place idempotency in _place_risk_management_orders.
+
+AC1: when ExchangeTruthStore already has a SL for BTCUSDT, placement is skipped + counter increments.
+AC2: position_side stored in OrderSnapshot from WS event (ps field).
+AC3: when exchange has no protective order, placement is NOT skipped.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from contracts.order import OrderStatus, TradeOrder
+from tradeengine.dispatcher import Dispatcher
+from tradeengine.exchange_truth_store import OrderSnapshot
+
+
+def _make_dispatcher_with_store(open_orders: list[OrderSnapshot]) -> Dispatcher:
+    d = Dispatcher()
+    d.exchange = MagicMock()
+    d.exchange.client = MagicMock()
+
+    mock_consumer = MagicMock()
+    mock_store = MagicMock()
+    mock_store.get_open_orders.return_value = open_orders
+    mock_consumer.store = mock_store
+    d.user_data_consumer = mock_consumer
+
+    # Mock OCO manager so it doesn't try to call Binance
+    d.oco_manager = AsyncMock()
+    d.oco_manager.place_oco_orders = AsyncMock(return_value={"status": "OK"})
+    return d
+
+
+def _make_order(**kwargs) -> TradeOrder:
+    defaults = {
+        "symbol": "BTCUSDT",
+        "type": "market",
+        "side": "buy",
+        "amount": 0.1,
+        "order_id": "test-order-001",
+        "status": OrderStatus.PENDING,
+        "time_in_force": "GTC",
+        "position_size_pct": 0.1,
+        "stop_loss": 44000.0,
+        "take_profit": 46000.0,
+    }
+    defaults.update(kwargs)
+    return TradeOrder(**defaults)
+
+
+_FILL_RESULT = {"fill_price": 45000.0, "amount": 0.1, "status": "FILLED"}
+
+
+@pytest.mark.asyncio
+async def test_skip_when_stop_market_already_armed():
+    """AC1: STOP_MARKET on exchange → placement skipped, counter incremented."""
+    armed = OrderSnapshot(
+        symbol="BTCUSDT",
+        order_id="99999",
+        side="SELL",
+        order_type="STOP_MARKET",
+        status="NEW",
+        quantity=0.1,
+        price=44000.0,
+        position_side="LONG",
+    )
+    d = _make_dispatcher_with_store([armed])
+    order = _make_order()
+
+    with patch("tradeengine.dispatcher.order_placement_skipped_total") as mock_ctr:
+        await d._place_risk_management_orders(order, _FILL_RESULT)
+
+    mock_ctr.labels.assert_called_once_with(reason="already_armed")
+    mock_ctr.labels.return_value.inc.assert_called_once()
+    d.oco_manager.place_oco_orders.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skip_when_take_profit_market_already_armed():
+    """AC1: TAKE_PROFIT_MARKET on exchange → placement skipped."""
+    armed = OrderSnapshot(
+        symbol="BTCUSDT",
+        order_id="88888",
+        side="SELL",
+        order_type="TAKE_PROFIT_MARKET",
+        status="NEW",
+        quantity=0.1,
+        price=46000.0,
+        position_side="LONG",
+    )
+    d = _make_dispatcher_with_store([armed])
+    order = _make_order()
+
+    with patch("tradeengine.dispatcher.order_placement_skipped_total") as mock_ctr:
+        await d._place_risk_management_orders(order, _FILL_RESULT)
+
+    mock_ctr.labels.assert_called_once_with(reason="already_armed")
+    mock_ctr.labels.return_value.inc.assert_called_once()
+    d.oco_manager.place_oco_orders.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_placement_proceeds_when_no_protective_order():
+    """AC3: no armed order on exchange → skip guard does not fire."""
+    d = _make_dispatcher_with_store([])  # empty exchange state
+    order = _make_order()
+
+    with (
+        patch("tradeengine.dispatcher.order_placement_skipped_total") as mock_ctr,
+        patch.object(d, "_place_individual_risk_orders", new_callable=AsyncMock),
+    ):
+        await d._place_risk_management_orders(order, _FILL_RESULT)
+
+    mock_ctr.labels.assert_not_called()
+
+
+def test_order_snapshot_stores_position_side_from_ws():
+    """AC2: OrderSnapshot.position_side is populated from WS event ps field."""
+    snap = OrderSnapshot(
+        symbol="BTCUSDT",
+        order_id="12345",
+        side="SELL",
+        order_type="STOP_MARKET",
+        status="NEW",
+        quantity=0.1,
+        price=44000.0,
+        position_side="LONG",
+    )
+    assert snap.position_side == "LONG"
+
+
+def test_order_snapshot_default_position_side_is_both():
+    """AC2: default position_side is BOTH (one-way mode)."""
+    snap = OrderSnapshot(
+        symbol="BTCUSDT",
+        order_id="12345",
+        side="SELL",
+        order_type="STOP_MARKET",
+        status="NEW",
+        quantity=0.1,
+        price=44000.0,
+    )
+    assert snap.position_side == "BOTH"

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -21,6 +21,7 @@ from tradeengine.metrics import (
     atomic_rollback_failed_total,
     order_execution_latency_seconds,
     order_failures_total,
+    order_placement_skipped_total,
     orders_executed_by_type,
     risk_checks_total,
     risk_rejections_total,
@@ -3334,6 +3335,26 @@ class Dispatcher:
                     "Skipping risk management orders for reduce_only order"
                 )
                 return
+
+            # AC1 (#460): check-before-place — skip if exchange already has a protective order
+            if self.user_data_consumer is not None:
+                _PROTECTIVE_TYPES = frozenset(
+                    {"STOP_MARKET", "STOP", "TAKE_PROFIT_MARKET", "TAKE_PROFIT"}
+                )
+                existing_protective = [
+                    o
+                    for o in self.user_data_consumer.store.get_open_orders(order.symbol)
+                    if o.order_type.upper() in _PROTECTIVE_TYPES
+                ]
+                if existing_protective:
+                    order_placement_skipped_total.labels(reason="already_armed").inc()
+                    self.logger.info(
+                        f"⏭️ Skipping protective order placement for {order.symbol}: "
+                        f"exchange already has {len(existing_protective)} armed protective "
+                        f"order(s) ({[o.order_type for o in existing_protective]}). "
+                        "Skipping to prevent duplicates."
+                    )
+                    return
 
             # Ensure entry_price is a float for OCO math and logging
             # Fallback to order.target_price if fill_price is missing or zero

--- a/tradeengine/exchange_truth_store.py
+++ b/tradeengine/exchange_truth_store.py
@@ -73,6 +73,7 @@ class OrderSnapshot:
     status: str
     quantity: float
     price: float
+    position_side: str = "BOTH"
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
@@ -157,6 +158,7 @@ class ExchangeTruthStore:
                     status=status,
                     quantity=float(o.get("q", 0)),
                     price=float(o.get("p", 0)),
+                    position_side=o.get("ps", "BOTH").upper(),
                 )
             self._last_updated = datetime.now(UTC)
             self._is_ready = True

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -245,6 +245,12 @@ order_failures_total = Counter(
     ["symbol", "order_type", "failure_reason", "exchange"],
 )
 
+order_placement_skipped_total = Counter(
+    "tradeengine_order_placement_skipped_total",
+    "Protective order placements skipped because exchange already has an armed order",
+    ["reason"],
+)
+
 # ========================================
 # NATS Heartbeat & Fail-Safe Observability
 # ========================================


### PR DESCRIPTION
## Summary

Closes #460

Implements the check-before-place guard in `_place_risk_management_orders()`: before placing any SL or TP protective order, the dispatcher queries `ExchangeTruthStore.get_open_orders(symbol)` and skips placement if a STOP_MARKET, STOP, TAKE_PROFIT_MARKET, or TAKE_PROFIT order already exists on the exchange.

## Changes

### `tradeengine/metrics.py`
- Added `tradeengine_order_placement_skipped_total{reason}` counter (imported at module level to avoid duplicate Prometheus registration)

### `tradeengine/exchange_truth_store.py`
- Added `position_side: str = "BOTH"` field to `OrderSnapshot`
- Populates `position_side` from `o.get("ps", "BOTH").upper()` in `update_order_from_trade_update()` — enables future hedge-mode per-side filtering

### `tradeengine/dispatcher.py`
- Check-before-place guard in `_place_risk_management_orders()` after the `reduce_only` early-return
- Moved `order_placement_skipped_total` to module-level import block

### `tests/test_460_check_before_place.py` (5 tests)
- `test_skip_when_stop_market_already_armed` — AC1: STOP_MARKET → skip + counter
- `test_skip_when_take_profit_market_already_armed` — AC1: TAKE_PROFIT_MARKET → skip + counter
- `test_placement_proceeds_when_no_protective_order` — AC3: no armed order → guard does not fire
- `test_order_snapshot_stores_position_side_from_ws` — AC2: position_side stored
- `test_order_snapshot_default_position_side_is_both` — AC2: default is BOTH

## Test Results

```
5 passed in 0.84s (new tests)
77 passed, 0 failures (exchange_truth_store + dispatcher suite)
```

## Notes

- Guard fires only when `self.user_data_consumer` is not None (i.e., when the ExchangeTruthStore is running)
- Idempotent — if the stream is not started, the guard is silently skipped (no change in behavior)
- `position_side` on `OrderSnapshot` sets up AC2 hedge-mode correctness (full per-side filtering is a follow-up)