### PR TITLE
fix: use params= for DELETE algoOrder to fix -1102 SL/TP cancel failure (#475)

### DIFF
--- a/tests/test_binance_exchange_comprehensive.py
+++ b/tests/test_binance_exchange_comprehensive.py
@@ -898,14 +898,12 @@ class TestFallbackLogic:
 
         result = await binance_exchange.cancel_order("BTCUSDT", 12345)
         assert result is not None
-        # Should have called _request_futures_api with force_params=True so that
-        # DELETE parameters go in the query string (not the request body)
+        # params= ensures DELETE parameters go in the query string, not the request body
         binance_exchange.client._request_futures_api.assert_called_once_with(
             "delete",
             "algoOrder",
             signed=True,
-            force_params=True,
-            data={"symbol": "BTCUSDT", "algoId": 12345},
+            params={"symbol": "BTCUSDT", "algoId": 12345},
         )
 
     @pytest.mark.asyncio

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -1240,8 +1240,7 @@ class BinanceFuturesExchange:
                         "delete",
                         "algoOrder",
                         signed=True,
-                        force_params=True,
-                        data={"symbol": symbol, "algoId": order_id},
+                        params={"symbol": symbol, "algoId": order_id},
                     )
                     canceled_order_id = result.get("algoId")
                     status = "CANCELED"


### PR DESCRIPTION
## Summary

Fixes `cancel_order` fallback for SL/TP algo orders.

**Root cause:** `_request_futures_api("delete", "algoOrder", ..., force_params=True, data={...})` was sending `symbol`/`algoId` in the HTTP request body. Binance's `DELETE /fapi/v1/algoOrder` requires them in the query string. Result: every SL/TP cancellation attempt raised `APIError(code=-1102)`.

**Fix:** Replace `force_params=True, data={...}` with `params={...}` — the `params=` kwarg maps directly to the query string in the underlying `requests` library.

## Changes

- `tradeengine/exchange/binance.py` — `cancel_order` fallback: `data=` → `params=`, drop `force_params=True`
- `tests/test_binance_exchange_comprehensive.py` — update `test_cancel_order_fallback_logic` assertion to match corrected signature

## Testing

- 68 targeted tests (cancel + exchange comprehensive) pass
- 1076 total non-api tests pass

Closes #475