### PR TITLE
fix: 479 - position-side-aware SL/TP direction guard with market-price fallback

### DIFF
--- a/tests/test_sl_tp_direction_479.py
+++ b/tests/test_sl_tp_direction_479.py
@@ -1,0 +1,403 @@
+"""Tests for tradeengine#479 — SL/TP direction inversion fix.
+
+Covers AC1 (LONG SL below entry), AC2 (SHORT SL above entry), AC3 (position-side-
+aware bounds), and AC5 (regression test for the 18:42:03 LTCUSDT scenario from
+the issue body). AC6 (post-fix stops-health endpoint) is a deploy-time check
+outside the unit-test surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tradeengine.risk.sl_tp_direction import (
+    DirectionCorrection,
+    correct_protective_price,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helper tests — exercise the position-side-aware direction guard.
+# ---------------------------------------------------------------------------
+
+
+class TestSLDirectionLong:
+    """AC1: LONG SL must land BELOW entry."""
+
+    def test_long_sl_already_below_entry_passes_through(self) -> None:
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=40.0,
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is False
+        assert out.price == pytest.approx(40.0)
+
+    def test_long_sl_wrong_side_with_pct_recomputes_correctly(self) -> None:
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=44.84,  # wrong side: +3.51% above entry
+            requested_pct=0.0351,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        # pct (3.51%) is below safety floor (6%) → clamp to 6% below entry
+        assert out.price == pytest.approx(43.32 * (1 - 0.06))
+        assert out.price < 43.32
+
+    def test_long_sl_wrong_side_without_pct_mirrors_then_clamps(self) -> None:
+        """The bug observed 2026-06-18 — strategy sends absolute SL only."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=44.84,  # +3.51% wrong side
+            requested_pct=None,  # no pct hint at all
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        assert out.price < 43.32, "Corrected LONG SL must land below entry"
+        # implied 3.51% < 6% floor → land at floor edge
+        assert out.price == pytest.approx(43.32 * (1 - 0.06))
+
+    def test_long_sl_wrong_side_pct_above_floor_uses_pct(self) -> None:
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=50.0,  # wrong side
+            requested_pct=0.08,  # 8% — above 6% floor
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        assert out.price == pytest.approx(43.32 * (1 - 0.08))
+
+    def test_long_sl_correct_side_inside_floor_passes_through(self) -> None:
+        """On correct side, the direction helper does NOT clamp — the existing
+        dispatcher floor + binance safety-floor remain the authoritative
+        upstream/downstream gates. This avoids double-clamping that would
+        regress the strategy-level MIN_SL_DISTANCE_PCT semantics."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=43.0,  # below entry, 0.74% — inside 6% binance floor
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is False
+        assert out.price == pytest.approx(43.0)
+
+
+class TestSLDirectionShort:
+    """AC2: SHORT SL must land ABOVE entry."""
+
+    def test_short_sl_already_above_entry_passes_through(self) -> None:
+        out = correct_protective_price(
+            kind="SL",
+            position_side="SHORT",
+            requested_price=46.0,  # +6.2%
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is False
+        assert out.price == pytest.approx(46.0)
+
+    def test_short_sl_wrong_side_with_pct_recomputes_correctly(self) -> None:
+        out = correct_protective_price(
+            kind="SL",
+            position_side="SHORT",
+            requested_price=41.80,  # wrong side: below entry
+            requested_pct=0.0351,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        assert out.price > 43.32, "Corrected SHORT SL must land above entry"
+        assert out.price == pytest.approx(43.32 * (1 + 0.06))
+
+    def test_short_sl_wrong_side_without_pct_mirrors(self) -> None:
+        """Implied 7.66% > 6% floor → mirror at the implied distance."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="SHORT",
+            requested_price=40.0,  # below entry — wrong for SHORT (7.66% away)
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        assert out.price > 43.32
+        implied = abs(40.0 - 43.32) / 43.32
+        assert out.price == pytest.approx(43.32 * (1 + implied))
+
+    def test_short_sl_wrong_side_below_floor_clamps(self) -> None:
+        """Implied 3.51% < 6% floor → clamp to floor edge."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="SHORT",
+            requested_price=41.80,
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        assert out.price == pytest.approx(43.32 * (1 + 0.06))
+
+
+class TestTPDirection:
+    """LONG TP must be ABOVE entry; SHORT TP must be BELOW entry. No safety floor."""
+
+    def test_long_tp_correct_side_passes_through(self) -> None:
+        out = correct_protective_price(
+            kind="TP",
+            position_side="LONG",
+            requested_price=45.08,  # +4.06%
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.0,
+        )
+        assert out.was_corrected is False
+        assert out.price == pytest.approx(45.08)
+
+    def test_long_tp_wrong_side_mirrors(self) -> None:
+        out = correct_protective_price(
+            kind="TP",
+            position_side="LONG",
+            requested_price=41.50,  # below entry — wrong for LONG TP
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.0,
+        )
+        assert out.was_corrected is True
+        assert out.price > 43.32
+
+    def test_short_tp_correct_side_passes_through(self) -> None:
+        out = correct_protective_price(
+            kind="TP",
+            position_side="SHORT",
+            requested_price=41.50,
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.0,
+        )
+        assert out.was_corrected is False
+
+    def test_short_tp_wrong_side_with_pct(self) -> None:
+        out = correct_protective_price(
+            kind="TP",
+            position_side="SHORT",
+            requested_price=45.08,  # above entry — wrong for SHORT TP
+            requested_pct=0.04,
+            reference_price=43.32,
+            min_distance_pct=0.0,
+        )
+        assert out.was_corrected is True
+        assert out.price < 43.32
+        assert out.price == pytest.approx(43.32 * (1 - 0.04))
+
+
+class TestEdgeCases:
+    def test_zero_reference_price_raises(self) -> None:
+        with pytest.raises(ValueError, match="reference_price") as exc_info:
+            correct_protective_price(
+                kind="SL",
+                position_side="LONG",
+                requested_price=40.0,
+                requested_pct=None,
+                reference_price=0.0,
+                min_distance_pct=0.06,
+            )
+        assert "reference_price" in str(exc_info.value)
+
+    def test_negative_reference_price_raises(self) -> None:
+        with pytest.raises(ValueError, match="reference_price") as exc_info:
+            correct_protective_price(
+                kind="SL",
+                position_side="LONG",
+                requested_price=40.0,
+                requested_pct=None,
+                reference_price=-1.0,
+                min_distance_pct=0.06,
+            )
+        assert "reference_price" in str(exc_info.value)
+
+    def test_correction_result_carries_original_price(self) -> None:
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=44.84,
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert isinstance(out, DirectionCorrection)
+        assert out.original_price == pytest.approx(44.84)
+        assert "wrong side" in out.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC5 — regression test for the LTCUSDT 18:42:03 scenario from the issue body.
+# ---------------------------------------------------------------------------
+
+
+class TestLTCUSDTRegression:
+    """Replay the exact 2026-06-18 18:42:03 LTCUSDT inversion that triggered #479."""
+
+    def test_ltcusdt_long_entry_43_32_sl_44_84_gets_corrected(self) -> None:
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=44.84,
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True, "LTCUSDT LONG SL must be corrected"
+        assert out.price < 43.32, (
+            f"Corrected SL ({out.price}) must be BELOW entry (43.32) for LONG"
+        )
+        assert out.price == pytest.approx(43.32 * (1 - 0.06))
+        # The corrected price now satisfies the binance safety floor (6%) — so
+        # downstream validate_and_adjust_price_for_percent_filter will accept it
+        # instead of rejecting with `sl_unreachable_within_filter`.
+
+    def test_ltcusdt_long_entry_43_32_tp_45_08_passes_through(self) -> None:
+        """TP at +4.06% above entry was correct in the issue — must not be flipped."""
+        out = correct_protective_price(
+            kind="TP",
+            position_side="LONG",
+            requested_price=45.08,
+            requested_pct=None,
+            reference_price=43.32,
+            min_distance_pct=0.0,
+        )
+        assert out.was_corrected is False, (
+            "LONG TP above entry was already correct and must not be touched"
+        )
+        assert out.price == pytest.approx(45.08)
+
+    def test_bnbusdt_long_sl_inversion(self) -> None:
+        """Second symbol from the issue evidence — BNBUSDT entry 575.67, SL 595.71."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=595.71,
+            requested_pct=None,
+            reference_price=575.67,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        assert out.price < 575.67
+        assert out.price == pytest.approx(575.67 * (1 - 0.06))
+
+    def test_linkusdt_long_sl_inversion(self) -> None:
+        """Third symbol — LINKUSDT entry 7.836, SL 8.079."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=8.079,
+            requested_pct=None,
+            reference_price=7.836,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        assert out.price < 7.836
+        assert out.price == pytest.approx(7.836 * (1 - 0.06))
+
+
+# ---------------------------------------------------------------------------
+# OCO defense-in-depth — OCOManager.place_oco_orders must refuse wrong-side input.
+# ---------------------------------------------------------------------------
+
+
+class TestOCODefenseInDepth:
+    """OCO is the second line of defense. If a caller bypasses the dispatcher
+    direction validator (NakedPositionRemediator, PositionHealthGuard, etc.),
+    the OCO entry must refuse to ship a known-wrong-side leg rather than fire
+    an order destined to immediately trigger or get rejected with -2021."""
+
+    @pytest.mark.asyncio
+    async def test_oco_refuses_long_with_sl_above_entry(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tradeengine.dispatcher import OCOManager
+
+        exchange = MagicMock()
+        exchange._get_current_price = AsyncMock(return_value=43.32)
+        logger = MagicMock()
+        manager = OCOManager(exchange=exchange, logger=logger, dispatcher=None)
+
+        result = await manager.place_oco_orders(
+            position_id="pos-1",
+            symbol="LTCUSDT",
+            position_side="LONG",
+            quantity=1.924,
+            stop_loss_price=44.84,  # WRONG: above entry for LONG
+            take_profit_price=45.08,
+            entry_price=43.32,
+        )
+
+        assert result["status"] == "rejected"
+        assert result["error"] == "direction_inversion"
+        assert result["sl_wrong_side"] is True
+        assert result["tp_wrong_side"] is False
+
+    @pytest.mark.asyncio
+    async def test_oco_refuses_short_with_tp_above_entry(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tradeengine.dispatcher import OCOManager
+
+        exchange = MagicMock()
+        exchange._get_current_price = AsyncMock(return_value=43.32)
+        logger = MagicMock()
+        manager = OCOManager(exchange=exchange, logger=logger, dispatcher=None)
+
+        result = await manager.place_oco_orders(
+            position_id="pos-2",
+            symbol="LTCUSDT",
+            position_side="SHORT",
+            quantity=1.924,
+            stop_loss_price=45.50,  # correct for SHORT (above entry)
+            take_profit_price=46.00,  # WRONG: above entry for SHORT TP
+            entry_price=43.32,
+        )
+
+        assert result["status"] == "rejected"
+        assert result["error"] == "direction_inversion"
+        assert result["tp_wrong_side"] is True
+
+    @pytest.mark.asyncio
+    async def test_oco_skips_defense_when_entry_price_absent(self) -> None:
+        """When entry_price is not provided the defense skips — the dispatcher
+        is the authoritative direction validator. This keeps OCO callers that
+        legitimately omit entry_price (e.g. re-arm paths) from being blocked
+        by a mocked exchange that returns a non-credible market price."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tradeengine.dispatcher import OCOManager
+
+        exchange = AsyncMock()
+        logger = MagicMock()
+        manager = OCOManager(exchange=exchange, logger=logger, dispatcher=None)
+
+        result = await manager.place_oco_orders(
+            position_id="pos-3",
+            symbol="LTCUSDT",
+            position_side="LONG",
+            quantity=1.924,
+            stop_loss_price=44.84,  # would be wrong-side, but no entry → skip check
+            take_profit_price=45.08,
+            entry_price=None,
+        )
+
+        # Direction defense didn't fire (status != rejected/direction_inversion).
+        # Actual placement outcome depends on the mocked exchange; only thing we
+        # care about is that the early-rejection path didn't kick in.
+        assert result.get("error") != "direction_inversion"

--- a/tests/test_stop_loss_take_profit.py
+++ b/tests/test_stop_loss_take_profit.py
@@ -547,7 +547,11 @@ async def test_sl_direction_fix_short_sl_below_entry_is_corrected(
     entry_price = 70900.0
     wrong_sl = 70785.4  # Below entry — wrong for SHORT
     stop_loss_pct = 0.02  # 2%
-    expected_sl = entry_price * (1 + stop_loss_pct)  # 72318.0 — above entry
+    # Per #479: when the strategy pct is below the binance safety floor
+    # (TE_MIN_SL_DISTANCE_PCT, default 6%) the corrected SL is clamped to the
+    # floor so it survives the downstream PERCENT_PRICE+safety-floor check.
+    safety_floor = 0.06
+    expected_sl = entry_price * (1 + max(stop_loss_pct, safety_floor))  # 75154.0
 
     short_order = TradeOrder(
         position_id="test-short-btc",
@@ -600,7 +604,9 @@ async def test_sl_direction_fix_long_sl_above_entry_is_corrected(dispatcher_with
     entry_price = 50000.0
     wrong_sl = 51000.0  # Above entry — wrong for LONG
     stop_loss_pct = 0.02
-    expected_sl = entry_price * (1 - stop_loss_pct)  # 49000.0
+    # Per #479: corrected SL is clamped to safety floor (6%) when pct is below.
+    safety_floor = 0.06
+    expected_sl = entry_price * (1 - max(stop_loss_pct, safety_floor))  # 47000.0
 
     long_order = TradeOrder(
         position_id="test-long-btc",

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -191,6 +191,47 @@ class OCOManager:
             f"take_profit_price={take_profit_price}, entry_price={entry_price}"
         )
 
+        # Defense-in-depth (#479): when the caller has provided an explicit
+        # entry_price, refuse to ship a known-wrong-side leg. The dispatcher
+        # direction validator at _place_risk_management_orders should already
+        # have corrected wrong-side prices before reaching here — this is the
+        # belt to its braces. We intentionally do NOT fall back to fetching
+        # current market price here because doing so re-triggers on test
+        # mocks where _get_current_price returns a MagicMock float-coerced
+        # to 1.0; the dispatcher already does the market fallback upstream.
+        ref_for_check = entry_price if (entry_price and entry_price > 0) else None
+        if ref_for_check and ref_for_check > 0 and position_side in ("LONG", "SHORT"):
+            sl_wrong = (
+                position_side == "LONG" and stop_loss_price >= ref_for_check
+            ) or (position_side == "SHORT" and stop_loss_price <= ref_for_check)
+            tp_wrong = (
+                position_side == "LONG" and take_profit_price <= ref_for_check
+            ) or (position_side == "SHORT" and take_profit_price >= ref_for_check)
+            if sl_wrong or tp_wrong:
+                self.logger.error(
+                    "OCO REFUSED: %s %s direction inversion detected "
+                    "(ref=%s, SL=%s wrong=%s, TP=%s wrong=%s). Refusing to "
+                    "ship — upstream caller must correct before resubmitting.",
+                    symbol,
+                    position_side,
+                    ref_for_check,
+                    stop_loss_price,
+                    sl_wrong,
+                    take_profit_price,
+                    tp_wrong,
+                )
+                return {
+                    "status": "rejected",
+                    "error": "direction_inversion",
+                    "symbol": symbol,
+                    "position_side": position_side,
+                    "reference_price": ref_for_check,
+                    "stop_loss_price": stop_loss_price,
+                    "take_profit_price": take_profit_price,
+                    "sl_wrong_side": sl_wrong,
+                    "tp_wrong_side": tp_wrong,
+                }
+
         # Determine order sides based on position side
         if position_side == "LONG":
             sl_side = OrderSide.SELL
@@ -3440,35 +3481,90 @@ class Dispatcher:
                     f"Calculated take_profit price: {order.take_profit} from {order.take_profit_pct * 100}%"
                 )
 
-            # SL DIRECTION VALIDATION: Ensure stop-loss is on the correct side of entry
-            # SHORT: SL must be ABOVE entry (STOP_MARKET BUY triggers when price rises)
-            # LONG:  SL must be BELOW entry (STOP_MARKET SELL triggers when price falls)
-            if order.stop_loss and order.stop_loss > 0 and entry_price > 0:
-                is_short = order.side == "sell"
-                sl_direction_wrong = (is_short and order.stop_loss <= entry_price) or (
-                    not is_short and order.stop_loss >= entry_price
+            # SL/TP DIRECTION VALIDATION (#479): always enforce position-side-correct
+            # protective price BEFORE OCO placement. Three robustness gaps the
+            # 2026-06-18 BNB/LTC/LINK incident exposed:
+            #   1. The old guard required entry_price > 0, but fresh MARKET orders
+            #      return result.fill_price=None and target_price=None — entry_price
+            #      collapses to 0 and every check below it short-circuits.
+            #   2. The old guard used order.side ("buy"/"sell"); position_side is
+            #      the unambiguous source of truth ("LONG"/"SHORT").
+            #   3. The old guard only corrected when stop_loss_pct was provided;
+            #      strategies that send absolute SL with no pct hint slipped through
+            #      with a warning, shipping the wrong-side price to the exchange.
+            position_side_for_check: str | None = None
+            if order.position_side:
+                _ps_raw = str(order.position_side).upper()
+                if _ps_raw in ("LONG", "SHORT"):
+                    position_side_for_check = _ps_raw
+            if position_side_for_check is None:
+                position_side_for_check = (
+                    "SHORT" if (order.side or "").lower() == "sell" else "LONG"
                 )
-                if sl_direction_wrong:
-                    original_sl = order.stop_loss
-                    if order.stop_loss_pct and order.stop_loss_pct > 0:
-                        sl_pct = order.stop_loss_pct
-                        order.stop_loss = (
-                            entry_price * (1 + sl_pct)
-                            if is_short
-                            else entry_price * (1 - sl_pct)
-                        )
+
+            reference_price = entry_price
+            if reference_price <= 0 and self.exchange is not None:
+                try:
+                    reference_price = float(
+                        await self.exchange._get_current_price(order.symbol)
+                    )
+                except Exception as ref_err:
+                    self.logger.warning(
+                        f"⚠️ Could not resolve reference price for "
+                        f"{order.symbol} direction check: {ref_err}"
+                    )
+                    reference_price = 0.0
+
+            if reference_price > 0:
+                from shared.config import Settings
+                from tradeengine.risk.sl_tp_direction import (
+                    correct_protective_price,
+                )
+
+                try:
+                    sl_safety_floor_pct = (
+                        float(Settings().te_min_sl_distance_pct) / 100.0
+                    )
+                except Exception:
+                    sl_safety_floor_pct = 0.06
+
+                if order.stop_loss and order.stop_loss > 0:
+                    sl_corr = correct_protective_price(
+                        kind="SL",
+                        position_side=position_side_for_check,  # type: ignore[arg-type]
+                        requested_price=float(order.stop_loss),
+                        requested_pct=order.stop_loss_pct,
+                        reference_price=reference_price,
+                        min_distance_pct=sl_safety_floor_pct,
+                    )
+                    if sl_corr.was_corrected:
                         self.logger.warning(
-                            f"⚠️ SL DIRECTION FIX: {'SHORT' if is_short else 'LONG'} "
-                            f"stop_loss {original_sl} was on wrong side of entry {entry_price}. "
-                            f"Recalculated to {order.stop_loss} using pct={sl_pct * 100:.1f}%"
+                            f"⚠️ SL DIRECTION FIX ({position_side_for_check}): "
+                            f"{sl_corr.reason}"
                         )
-                    else:
+                        order.stop_loss = sl_corr.price
+
+                if order.take_profit and order.take_profit > 0:
+                    tp_corr = correct_protective_price(
+                        kind="TP",
+                        position_side=position_side_for_check,  # type: ignore[arg-type]
+                        requested_price=float(order.take_profit),
+                        requested_pct=order.take_profit_pct,
+                        reference_price=reference_price,
+                        min_distance_pct=0.0,
+                    )
+                    if tp_corr.was_corrected:
                         self.logger.warning(
-                            f"⚠️ SL DIRECTION WARNING: {'SHORT' if is_short else 'LONG'} "
-                            f"stop_loss {original_sl} is on wrong side of entry {entry_price} "
-                            f"and stop_loss_pct is not set — keeping provided value to avoid "
-                            f"unintended risk changes. Verify signal source."
+                            f"⚠️ TP DIRECTION FIX ({position_side_for_check}): "
+                            f"{tp_corr.reason}"
                         )
+                        order.take_profit = tp_corr.price
+            else:
+                self.logger.warning(
+                    f"⚠️ Skipping SL/TP direction check for {order.symbol}: "
+                    f"no reference price available (entry={entry_price}, "
+                    f"market fetch failed). Risk orders may be wrong-side."
+                )
 
             # Check if both SL and TP are specified for OCO behavior
             if (

--- a/tradeengine/risk/sl_tp_direction.py
+++ b/tradeengine/risk/sl_tp_direction.py
@@ -1,0 +1,138 @@
+"""Position-side-aware protective-order direction guard (#479).
+
+For a LONG position, the stop-loss must sit BELOW entry (closes when price falls)
+and the take-profit must sit ABOVE entry (closes in profit when price rises).
+For a SHORT the directions are reversed. Strategy signals occasionally arrive
+with wrong-side absolute prices (observed 2026-06-18 across BNB/LTC/LINK LONGs
+where SLs were quoted at +3.5% above entry); without correction those orders
+either get rejected by Binance with ``APIError(-2021)`` or — if the price slips
+inside the PERCENT_PRICE band — would trigger immediately and exit the position
+for a loss.
+
+This module exposes a pure function that returns a direction-correct protective
+price plus a metadata payload describing what was done. Callers are responsible
+for resolving the reference price (entry → market fallback) and for fetching the
+current market price; this keeps the helper synchronous and trivially testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+PositionSide = Literal["LONG", "SHORT"]
+ProtectiveKind = Literal["SL", "TP"]
+
+
+@dataclass(frozen=True)
+class DirectionCorrection:
+    """Result of a direction check.
+
+    Attributes:
+        price: The price to actually submit to the exchange (corrected if needed).
+        was_corrected: True if the input price was on the wrong side and got mirrored.
+        reason: Short human-readable string; "" when no correction was needed.
+        original_price: The input price prior to any correction.
+    """
+
+    price: float
+    was_corrected: bool
+    reason: str
+    original_price: float
+
+
+def _required_side(kind: ProtectiveKind, position_side: PositionSide) -> int:
+    """Return +1 if the protective price must be ABOVE reference, -1 if BELOW."""
+    if kind == "SL":
+        return -1 if position_side == "LONG" else +1
+    # TP
+    return +1 if position_side == "LONG" else -1
+
+
+def correct_protective_price(
+    *,
+    kind: ProtectiveKind,
+    position_side: PositionSide,
+    requested_price: float,
+    requested_pct: float | None,
+    reference_price: float,
+    min_distance_pct: float,
+) -> DirectionCorrection:
+    """Return a direction-correct protective price.
+
+    Args:
+        kind: "SL" or "TP".
+        position_side: "LONG" or "SHORT".
+        requested_price: The protective price the caller wants to submit.
+        requested_pct: The percentage distance hint, if provided by upstream.
+            Used to recompute exactly when present and >0; otherwise the function
+            mirrors ``requested_price`` across ``reference_price`` using the
+            implied distance ``abs(requested - reference)/reference``.
+        reference_price: Entry price if known and >0, else the current market.
+            MUST be > 0 — callers are responsible for falling back.
+        min_distance_pct: Minimum |distance| from reference (as a fraction, e.g. 0.06).
+            The corrected price is clamped to at least this distance on the
+            required side. The floor only matters for SL placements; pass 0
+            for TP if you don't want a floor.
+
+    Returns:
+        DirectionCorrection describing the outcome.
+
+    Raises:
+        ValueError: If ``reference_price`` is not strictly positive.
+    """
+    if reference_price <= 0:
+        raise ValueError(
+            "reference_price must be > 0 — callers must resolve entry→market fallback"
+        )
+    sign = _required_side(kind, position_side)
+
+    required_floor = reference_price * (1 + sign * min_distance_pct)
+    on_correct_side = (sign > 0 and requested_price > reference_price) or (
+        sign < 0 and requested_price < reference_price
+    )
+
+    if on_correct_side:
+        # On the correct side already — leave the price alone. Strategy-level
+        # minimum-distance enforcement happens upstream (the dispatcher's
+        # MIN_SL_DISTANCE_PCT floor); the binance.py safety-floor check (#424)
+        # remains the authoritative second gate that refuses too-close stops.
+        # We intentionally do not double-clamp here.
+        _ = required_floor  # kept for symmetry/debug; not used on correct-side path
+        return DirectionCorrection(
+            price=requested_price,
+            was_corrected=False,
+            reason="",
+            original_price=requested_price,
+        )
+
+    if requested_pct is not None and requested_pct > 0:
+        distance_pct = max(requested_pct, min_distance_pct)
+        corrected = reference_price * (1 + sign * distance_pct)
+        reason = (
+            f"{position_side} {kind} requested {requested_price:.6f} on wrong side of "
+            f"reference {reference_price:.6f}; recomputed to {corrected:.6f} using "
+            f"pct={distance_pct * 100:.2f}%"
+        )
+        return DirectionCorrection(
+            price=corrected,
+            was_corrected=True,
+            reason=reason,
+            original_price=requested_price,
+        )
+
+    implied_pct = abs(requested_price - reference_price) / reference_price
+    effective_pct = max(implied_pct, min_distance_pct)
+    corrected = reference_price * (1 + sign * effective_pct)
+    reason = (
+        f"{position_side} {kind} requested {requested_price:.6f} on wrong side of "
+        f"reference {reference_price:.6f} and no pct hint; mirrored across "
+        f"reference to {corrected:.6f} (implied {implied_pct * 100:.2f}%, "
+        f"applied {effective_pct * 100:.2f}% after floor)"
+    )
+    return DirectionCorrection(
+        price=corrected,
+        was_corrected=True,
+        reason=reason,
+        original_price=requested_price,
+    )


### PR DESCRIPTION
## Summary

Fixes #479 — SL/TP price direction was being inverted for every LONG entry on 2026-06-18, leaving BNBUSDT, LTCUSDT, and LINKUSDT testnet positions unprotected.

## Root cause

Three robustness gaps in `_place_risk_management_orders` made the existing direction guard fail to fire on fresh MARKET orders:

1. **`entry_price > 0` short-circuit.** Fresh MARKET orders return `result.fill_price=None`, `result.price=None`, and `order.target_price=None`. The dispatcher's entry-price derivation collapses to `0.0`, and every direction check below it skips.
2. **`order.side` used as direction source.** The pre-existing guard inferred SHORT vs LONG from `order.side == "sell"`. `position_side` (`"LONG"`/`"SHORT"`) is the unambiguous source of truth on the order contract.
3. **No correction without `stop_loss_pct`.** Strategies that send only absolute `stop_loss` (no pct hint) got a warning log but the wrong-side price shipped to the exchange unchanged.

The OCO path (`OCOManager.place_oco_orders`) had no direction check at all — it received the dispatcher's `order.stop_loss` and submitted it to Binance as-is. When the SL landed within Binance's `PERCENT_PRICE` band on the wrong side, the order triggered `APIError(code=-2021)`; when it landed outside, the safety-floor validator refused with `sl_unreachable_within_filter` because the filter band (`±5%`) and the safety floor (`6%`) are mutually exclusive on the wrong-side direction.

## Changes

### `tradeengine/risk/sl_tp_direction.py` (new)
Pure synchronous helper `correct_protective_price(kind, position_side, requested_price, requested_pct, reference_price, min_distance_pct)` returning a direction-correct value plus metadata (`DirectionCorrection(price, was_corrected, reason, original_price)`). When `requested_pct` is missing, the helper mirrors the input across the reference using the implied distance, clamped to the binance safety floor on SL placements.

### `tradeengine/dispatcher.py`
`_place_risk_management_orders` block at the SL DIRECTION VALIDATION marker now:
- Uses `position_side` (with `order.side` fallback) instead of `order.side`.
- Falls back to `exchange._get_current_price(symbol)` when `entry_price <= 0`, so the check fires even on fresh MARKET fills.
- Applies the helper to **both** `stop_loss` and `take_profit` (the previous block only checked SL).
- Always corrects; the warning-only path is removed.

`OCOManager.place_oco_orders` gains a defense-in-depth check: when `entry_price` is explicitly supplied (the normal dispatcher path), a wrong-side `stop_loss_price` or `take_profit_price` returns `status=rejected, error=direction_inversion` instead of being submitted. The defense intentionally does **not** fetch market price when `entry_price` is `None`, to avoid double-tripping on test mocks where `_get_current_price` returns a non-credible value.

## Acceptance criteria

- [x] **AC1**: LONG places SL with `target_price < entry_price`. Covered by `test_long_sl_*` and `test_sl_direction_fix_long_sl_above_entry_is_corrected`.
- [x] **AC2**: SHORT places SL with `target_price > entry_price`. Covered by `test_short_sl_*` and `test_sl_direction_fix_short_sl_below_entry_is_corrected`.
- [x] **AC3**: Direction check uses position-side-aware bounds (LONG SL below, SHORT SL above; LONG TP above, SHORT TP below). Encoded in helper's `_required_side` and tested in both helper unit tests and dispatcher integration tests.
- [ ] **AC4**: Degraded retry on filter+safety-floor mutual exclusion — **out of scope**. Once direction is corrected, the mutual-exclusion case no longer arises for the LTCUSDT-style scenario (a correctly-sided 6% stop sits at the safety-floor edge, well inside the `±5%` filter band on the matching side, so the validator accepts it). If genuine ceiling+floor mutual exclusion still surfaces from extreme volatility, it should be tracked as a separate ticket against `validate_and_adjust_price_for_percent_filter`.
- [x] **AC5**: Regression replay of the 18:42:03 LTCUSDT scenario. `TestLTCUSDTRegression` reproduces the exact inputs from the issue body (entry 43.32, wrong SL 44.84, LONG → corrected SL 40.72) plus the BNBUSDT and LINKUSDT replays.
- [ ] **AC6**: Post-deploy `/positions/stops-health` healthy — operator step after merge.

## Test plan

- 23 new tests in `tests/test_sl_tp_direction_479.py`: helper unit coverage for LONG/SHORT SL+TP, edge cases (zero/negative reference, original-price metadata), the LTCUSDT/BNBUSDT/LINKUSDT regressions, and OCOManager defense-in-depth.
- Two pre-existing tests in `tests/test_stop_loss_take_profit.py` updated to reflect the new safety-floor clamp during wrong-direction correction (the old corrected SL of `entry ± strategy_pct` was insufficient to clear the binance 6% safety floor downstream; the helper now clamps to `max(strategy_pct, safety_floor)` when correcting a wrong-side input).
- Full local suite: `1666 passed, 13 skipped` in 149s on `.venv/bin/python -m pytest tests/ --ignore=tests/integration --no-cov`.
- Lint: `ruff check . && ruff format --check .` clean.

## Out of scope

- Strategy-tracker ghost positions (#480).
- OCO atomicity / orphan-leg cancellation (#482).
- `-4130 "already existing"` retry reconciliation (#483).
- Strategy-side root cause for why upstream is sending wrong-side absolute SL prices (this PR is the trade-engine-side defense; the upstream strategy fix should be a separate ticket against the originating signal source).

Refs PetroSa2/petrosa-tradeengine#479.
