### PR TITLE
fix: 480 - StrategyPositionManager ghost reconciler + atomic remediation

### DIFF
--- a/tests/test_position_stops_health.py
+++ b/tests/test_position_stops_health.py
@@ -38,6 +38,10 @@ def _mocks(memory=None, mysql=None, exchange_raises=False, binance_open_ids=None
     spm = MagicMock()
     spm.get_all_open_strategy_positions.return_value = memory or []
     spm.close_strategy_position = AsyncMock()
+    # AC3 of #480: when remediation captures a real algo-id, it
+    # propagates back via set_strategy_position_orders.  Tests mock it
+    # so propagation is observable without touching real validation.
+    spm.set_strategy_position_orders = AsyncMock()
 
     pc = MagicMock()
     pc.get_open_positions = AsyncMock(return_value=mysql or [])
@@ -46,7 +50,13 @@ def _mocks(memory=None, mysql=None, exchange_raises=False, binance_open_ids=None
     if exchange_raises:
         exc.execute = AsyncMock(side_effect=Exception("exchange error"))
     else:
-        exc.execute = AsyncMock(return_value={"order_id": "mock-order-id"})
+        # AC3 of #480: remediation now requires the exchange response to
+        # carry a real Binance algo-order ID (13+ digits) before declaring
+        # sl/tp placement successful.  The default mock returns a real-
+        # shaped id so success-path tests keep their original semantics;
+        # the dedicated null-response test below shows the atomicity
+        # contract in action.
+        exc.execute = AsyncMock(return_value={"order_id": "1398104567890999"})
     # AC3 of #424: stops-health now verifies stored sl/tp ids against
     # the on-Binance open-order set; tests must seed this explicitly so
     # the verified-healthy path can be exercised.
@@ -351,3 +361,107 @@ async def test_set_strategy_position_orders_validates_via_pydantic():
             sl_order_id="2022.6338",
         )
     assert "Binance algo-order ID" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# AC3 of #480 — Atomic boolean+order_id contract in remediation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ac3_480_remediation_with_null_order_id_does_not_lie():
+    """AC3 of #480: if exchange.execute() succeeds but returns no real
+    algo-id (the 2026-06-18 testnet symptom), the response must NOT
+    claim has_sl_order=true while sl_order_id stays null.  Atomic
+    contract: boolean and id are set together or not at all."""
+    pos = _pos(
+        sl_order_id=None,
+        tp_order_id=None,
+        stop_loss_price=45000.0,
+        take_profit_price=55000.0,
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos])
+    # Override execute to return success-status but null order_id, which
+    # is the exact failure mode the production logs surfaced.
+    exc.execute = AsyncMock(return_value={"order_id": None, "status": "NEW"})
+
+    resp = await check_position_stops(spm, pc, exc, pub)
+
+    p = resp.positions[0]
+    # The position must NOT be reported as protected — both sides
+    # remained null, so the booleans must be false and remediation must
+    # have escalated to force-close.
+    assert p.has_sl_order is False
+    assert p.has_tp_order is False
+    assert p.sl_order_id is None
+    assert p.tp_order_id is None
+    assert p.remediation_outcome == "position_closed"
+    spm.close_strategy_position.assert_called_once()
+    # The strategy-position setter must NOT have been called with null
+    # ids — the atomic contract is "set together or not at all".
+    spm.set_strategy_position_orders.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ac3_480_remediation_with_real_id_propagates_atomically():
+    """AC3 of #480: when remediation captures a real algo-id, the
+    response must reflect (has_sl_order=True AND sl_order_id=<that id>)
+    AND the id must be propagated back to the StrategyPositionManager
+    so the next cycle is idempotent."""
+    pos = _pos(
+        sl_order_id=None, tp_order_id="1398104567890999", stop_loss_price=45000.0
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos], binance_open_ids={"1398104567890999"})
+    exc.execute = AsyncMock(return_value={"order_id": "1398111122223333"})
+
+    resp = await check_position_stops(spm, pc, exc, pub)
+
+    p = resp.positions[0]
+    # AC3 atomic contract — both must be set in lockstep
+    assert p.has_sl_order is True
+    assert p.sl_order_id == "1398111122223333"
+    assert p.remediation_outcome == "sl_placed"
+    # Setter must have been called to propagate the captured id.
+    spm.set_strategy_position_orders.assert_awaited_once()
+    kwargs = spm.set_strategy_position_orders.call_args.kwargs
+    assert kwargs["strategy_position_id"] == "pos-1"
+    assert kwargs["sl_order_id"] == "1398111122223333"
+
+
+@pytest.mark.asyncio
+async def test_ac3_480_atomicity_preserved_even_if_setter_raises():
+    """AC3 of #480: a manager-side failure mid-remediation must NOT
+    create a (has_sl_order=True, sl_order_id=null) inconsistency.  The
+    response variables are mirrored from the captured id BEFORE the
+    setter is invoked so a setter exception is observability-only."""
+    pos = _pos(
+        sl_order_id=None,
+        tp_order_id=None,
+        stop_loss_price=45000.0,
+        take_profit_price=55000.0,
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos])
+    # Return distinct real-shaped ids so we can verify which one ended
+    # up in the response.
+    sl_id = "1398111122220001"
+    tp_id = "1398111122220002"
+    exc.execute = AsyncMock(
+        side_effect=[
+            {"order_id": sl_id},
+            {"order_id": tp_id},
+        ]
+    )
+    spm.set_strategy_position_orders = AsyncMock(
+        side_effect=RuntimeError("manager exploded")
+    )
+
+    resp = await check_position_stops(spm, pc, exc, pub)
+
+    p = resp.positions[0]
+    assert p.has_sl_order is True
+    assert p.has_tp_order is True
+    # Even though the setter raised, the response carries the captured
+    # ids — atomicity holds end-to-end.
+    assert p.sl_order_id == sl_id
+    assert p.tp_order_id == tp_id
+    assert p.remediation_outcome == "both_placed"

--- a/tests/test_strategy_position_reconciler.py
+++ b/tests/test_strategy_position_reconciler.py
@@ -1,0 +1,455 @@
+"""Tests for tradeengine.strategy_position_reconciler (#480).
+
+Covers AC1 (startup pass), AC2 (periodic loop), AC4 (regression — ghost
+row seeded, reconciler called, row evicted within one cycle).  AC5
+(operator-facing total_checked == /positions total) is exercised via the
+property test at the bottom that asserts the reconciler leaves no
+strategy position whose (symbol, side) is absent from the truth store.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tradeengine.exchange_truth_store import ExchangeTruthStore, PositionSnapshot
+from tradeengine.strategy_position_manager import StrategyPositionManager
+from tradeengine.strategy_position_reconciler import (
+    StrategyPositionReconciler,
+    _has_matching_exchange_position,
+    _position_age_seconds,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _spos(
+    spid: str,
+    symbol: str = "BTCUSDT",
+    side: str = "LONG",
+    entry_time: datetime | None = None,
+    status: str = "open",
+) -> dict:
+    return {
+        "strategy_position_id": spid,
+        "strategy_id": "strat-1",
+        "symbol": symbol,
+        "side": side,
+        "entry_quantity": 0.01,
+        "entry_price": 50_000.0,
+        "entry_time": entry_time or datetime.now(UTC) - timedelta(hours=1),
+        "status": status,
+        "exchange_position_key": f"{symbol}_{side}",
+        "sl_order_id": None,
+        "tp_order_id": None,
+    }
+
+
+async def _build_store(
+    positions: dict[tuple[str, str], PositionSnapshot] | None = None,
+    is_ready: bool = True,
+) -> ExchangeTruthStore:
+    store = ExchangeTruthStore()
+    # Use update_from_rest to avoid touching the streaming lock semantics
+    # while still flipping _is_ready and seeding the snapshot.
+    rest_positions = []
+    if positions:
+        for (sym, side), snap in positions.items():
+            rest_positions.append(
+                {
+                    "symbol": sym,
+                    "positionSide": side,
+                    "positionAmt": str(snap.quantity),
+                    "entryPrice": str(snap.entry_price),
+                    "unrealizedProfit": str(snap.unrealized_pnl),
+                }
+            )
+    await store.update_from_rest(rest_positions, [])
+    if not is_ready:
+        # update_from_rest forces is_ready=True; expose the cold-store
+        # path by resetting the flag here.
+        store._is_ready = False
+    return store
+
+
+def _manager_with(*positions: dict) -> StrategyPositionManager:
+    mgr = StrategyPositionManager()
+    for pos in positions:
+        mgr.strategy_positions[pos["strategy_position_id"]] = pos
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_matching_hedge_mode_long(self) -> None:
+        snap = PositionSnapshot(
+            symbol="BTCUSDT",
+            side="LONG",
+            quantity=0.5,
+            entry_price=50_000,
+            unrealized_pnl=0,
+        )
+        assert _has_matching_exchange_position(_spos("a"), {("BTCUSDT", "LONG"): snap})
+
+    def test_no_match_when_side_differs(self) -> None:
+        snap = PositionSnapshot(
+            symbol="BTCUSDT",
+            side="LONG",
+            quantity=0.5,
+            entry_price=50_000,
+            unrealized_pnl=0,
+        )
+        assert not _has_matching_exchange_position(
+            _spos("a", side="SHORT"), {("BTCUSDT", "LONG"): snap}
+        )
+
+    def test_one_way_mode_long_via_positive_qty(self) -> None:
+        snap = PositionSnapshot(
+            symbol="BTCUSDT",
+            side="BOTH",
+            quantity=0.5,
+            entry_price=50_000,
+            unrealized_pnl=0,
+        )
+        assert _has_matching_exchange_position(
+            _spos("a", side="LONG"), {("BTCUSDT", "BOTH"): snap}
+        )
+
+    def test_one_way_mode_short_via_negative_qty(self) -> None:
+        snap = PositionSnapshot(
+            symbol="BTCUSDT",
+            side="BOTH",
+            quantity=-0.5,
+            entry_price=50_000,
+            unrealized_pnl=0,
+        )
+        assert _has_matching_exchange_position(
+            _spos("a", side="SHORT"), {("BTCUSDT", "BOTH"): snap}
+        )
+
+    def test_one_way_mode_wrong_direction_is_ghost(self) -> None:
+        snap = PositionSnapshot(
+            symbol="BTCUSDT",
+            side="BOTH",
+            quantity=0.5,
+            entry_price=50_000,
+            unrealized_pnl=0,
+        )
+        assert not _has_matching_exchange_position(
+            _spos("a", side="SHORT"), {("BTCUSDT", "BOTH"): snap}
+        )
+
+    def test_position_age_seconds_recent(self) -> None:
+        now = datetime.now(UTC)
+        pos = _spos("a", entry_time=now - timedelta(seconds=30))
+        assert 25 <= _position_age_seconds(pos, now) <= 35
+
+    def test_position_age_seconds_missing_entry_time(self) -> None:
+        now = datetime.now(UTC)
+        pos = _spos("a", entry_time=None)
+        pos["entry_time"] = None
+        assert _position_age_seconds(pos, now) == float("inf")
+
+    def test_position_age_seconds_iso_string(self) -> None:
+        now = datetime.now(UTC)
+        pos = _spos("a")
+        pos["entry_time"] = (now - timedelta(seconds=120)).isoformat()
+        assert 115 <= _position_age_seconds(pos, now) <= 125
+
+
+# ---------------------------------------------------------------------------
+# reconcile_once — AC1 / AC4
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileOnce:
+    @pytest.mark.asyncio
+    async def test_no_ghosts_when_exchange_matches(self) -> None:
+        live = PositionSnapshot(
+            symbol="BTCUSDT",
+            side="LONG",
+            quantity=0.5,
+            entry_price=50_000,
+            unrealized_pnl=0,
+        )
+        store = await _build_store({("BTCUSDT", "LONG"): live})
+        mgr = _manager_with(_spos("a", "BTCUSDT", "LONG"))
+        recon = StrategyPositionReconciler(mgr, store, min_age_seconds=0)
+
+        result = await recon.reconcile_once()
+
+        assert result == {"open": 1, "ghosts": 0, "evicted": 0, "skipped_young": 0}
+        assert "a" in mgr.strategy_positions
+
+    @pytest.mark.asyncio
+    async def test_ghost_is_evicted_when_old_enough(self) -> None:
+        # AC4 — seed StrategyPositionManager with a ghost row, run
+        # reconciliation, assert eviction within one cycle.
+        store = await _build_store({})  # exchange has nothing
+        old_pos = _spos(
+            "ghost-1",
+            "DOTUSDT",
+            "SHORT",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+        )
+        mgr = _manager_with(old_pos)
+        # Use AsyncMock for the Data Manager journal to keep the eviction
+        # isolated from real persistence.
+        mgr._update_strategy_position_closure = AsyncMock(return_value=None)
+        recon = StrategyPositionReconciler(mgr, store, min_age_seconds=300)
+
+        result = await recon.reconcile_once()
+
+        assert result["ghosts"] == 1
+        assert result["evicted"] == 1
+        assert result["skipped_young"] == 0
+        assert "ghost-1" not in mgr.strategy_positions
+        # Journal must have been called with the closed-externally status.
+        assert mgr._update_strategy_position_closure.await_count == 1
+        journaled_pos = mgr._update_strategy_position_closure.await_args.args[1]
+        assert journaled_pos["status"] == "closed_externally"
+        assert journaled_pos["close_reason"] == "no_exchange_position"
+
+    @pytest.mark.asyncio
+    async def test_young_ghost_is_skipped(self) -> None:
+        # A ghost row younger than min_age_seconds is observed but not
+        # evicted — protects against eviction races during placement.
+        store = await _build_store({})
+        young_pos = _spos(
+            "ghost-young",
+            "ETHUSDT",
+            "LONG",
+            entry_time=datetime.now(UTC) - timedelta(seconds=10),
+        )
+        mgr = _manager_with(young_pos)
+        mgr._update_strategy_position_closure = AsyncMock(return_value=None)
+        recon = StrategyPositionReconciler(mgr, store, min_age_seconds=300)
+
+        result = await recon.reconcile_once()
+
+        assert result == {
+            "open": 1,
+            "ghosts": 1,
+            "evicted": 0,
+            "skipped_young": 1,
+        }
+        assert "ghost-young" in mgr.strategy_positions
+        mgr._update_strategy_position_closure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mixed_real_and_ghost(self) -> None:
+        live = PositionSnapshot(
+            symbol="BTCUSDT",
+            side="LONG",
+            quantity=0.5,
+            entry_price=50_000,
+            unrealized_pnl=0,
+        )
+        store = await _build_store({("BTCUSDT", "LONG"): live})
+        real_pos = _spos(
+            "real-1",
+            "BTCUSDT",
+            "LONG",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+        )
+        ghost_pos = _spos(
+            "ghost-1",
+            "LINKUSDT",
+            "SHORT",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+        )
+        mgr = _manager_with(real_pos, ghost_pos)
+        mgr._update_strategy_position_closure = AsyncMock(return_value=None)
+        recon = StrategyPositionReconciler(mgr, store, min_age_seconds=0)
+
+        result = await recon.reconcile_once()
+
+        assert result["ghosts"] == 1
+        assert result["evicted"] == 1
+        assert "real-1" in mgr.strategy_positions
+        assert "ghost-1" not in mgr.strategy_positions
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_store_not_ready(self) -> None:
+        # Per #459 contract: when the store is cold, the reconciler is a
+        # no-op (the streaming consumer is still warming up; a pass would
+        # falsely flag every position as a ghost).
+        store = await _build_store({}, is_ready=False)
+        mgr = _manager_with(_spos("a"))
+        recon = StrategyPositionReconciler(mgr, store, min_age_seconds=0)
+
+        result = await recon.reconcile_once()
+
+        assert result == {"open": 0, "ghosts": 0, "evicted": 0, "skipped_young": 0}
+        assert "a" in mgr.strategy_positions
+
+    @pytest.mark.asyncio
+    async def test_status_other_than_open_is_ignored(self) -> None:
+        store = await _build_store({})
+        closed_pos = _spos(
+            "closed-1",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+            status="closed",
+        )
+        mgr = _manager_with(closed_pos)
+        mgr._update_strategy_position_closure = AsyncMock(return_value=None)
+        recon = StrategyPositionReconciler(mgr, store, min_age_seconds=0)
+
+        result = await recon.reconcile_once()
+
+        assert result == {"open": 0, "ghosts": 0, "evicted": 0, "skipped_young": 0}
+        assert "closed-1" in mgr.strategy_positions
+
+    @pytest.mark.asyncio
+    async def test_one_way_mode_does_not_evict_real_position(self) -> None:
+        # Hedge / one-way ambiguity has bitten us before; make sure a
+        # one-way LONG on Binance is not mistaken for a ghost when the
+        # strategy row is also LONG.
+        live = PositionSnapshot(
+            symbol="BNBUSDT",
+            side="BOTH",
+            quantity=2.0,
+            entry_price=600,
+            unrealized_pnl=0,
+        )
+        store = await _build_store({("BNBUSDT", "BOTH"): live})
+        pos = _spos(
+            "bnb-long",
+            "BNBUSDT",
+            "LONG",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+        )
+        mgr = _manager_with(pos)
+        mgr._update_strategy_position_closure = AsyncMock(return_value=None)
+        recon = StrategyPositionReconciler(mgr, store, min_age_seconds=0)
+
+        result = await recon.reconcile_once()
+
+        assert result["evicted"] == 0
+        assert "bnb-long" in mgr.strategy_positions
+
+
+# ---------------------------------------------------------------------------
+# start/stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_runs_initial_pass(self) -> None:
+        # AC1 — start() must run an immediate reconcile before the
+        # periodic loop, so a pod that restarted with ghosts cleans up
+        # before accepting new work.
+        store = await _build_store({})
+        ghost = _spos(
+            "ghost-init",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+        )
+        mgr = _manager_with(ghost)
+        mgr._update_strategy_position_closure = AsyncMock(return_value=None)
+        recon = StrategyPositionReconciler(
+            mgr, store, interval_seconds=10_000, min_age_seconds=0
+        )
+
+        await recon.start()
+        try:
+            # Eviction must have happened during start(), not by the loop.
+            assert "ghost-init" not in mgr.strategy_positions
+        finally:
+            await recon.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self) -> None:
+        store = await _build_store({})
+        mgr = _manager_with()
+        recon = StrategyPositionReconciler(mgr, store)
+        await recon.stop()  # never started
+        await recon.start()
+        await recon.stop()
+        await recon.stop()  # second stop is a no-op
+
+    @pytest.mark.asyncio
+    async def test_loop_calls_reconcile_repeatedly(self) -> None:
+        store = await _build_store({})
+        mgr = _manager_with()
+        recon = StrategyPositionReconciler(
+            mgr, store, interval_seconds=1, min_age_seconds=0
+        )
+        # Wrap reconcile_once so we can count invocations.
+        original = recon.reconcile_once
+        counter = {"n": 0}
+
+        async def _wrapped() -> dict[str, int]:
+            counter["n"] += 1
+            return await original()
+
+        recon.reconcile_once = _wrapped  # type: ignore[assignment]
+        await recon.start()
+        # Sleep just long enough for the loop to fire at least once
+        # (interval_seconds=1).
+        await asyncio.sleep(1.2)
+        await recon.stop()
+        # start() runs one pass synchronously; the loop should add
+        # at least one more on top.
+        assert counter["n"] >= 2
+
+
+# ---------------------------------------------------------------------------
+# AC5 — post-reconcile invariant
+# ---------------------------------------------------------------------------
+
+
+class TestPostReconcileInvariant:
+    @pytest.mark.asyncio
+    async def test_no_remaining_strategy_pos_lacks_exchange_match(self) -> None:
+        # AC5 — after a clean pass with no young positions, every open
+        # strategy position must have a matching exchange position.  This
+        # is the property /positions/stops-health relies on to align with
+        # /positions.
+        live = PositionSnapshot(
+            symbol="BTCUSDT",
+            side="LONG",
+            quantity=0.5,
+            entry_price=50_000,
+            unrealized_pnl=0,
+        )
+        store = await _build_store({("BTCUSDT", "LONG"): live})
+        real_pos = _spos(
+            "real-1",
+            "BTCUSDT",
+            "LONG",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+        )
+        ghost_a = _spos(
+            "g1",
+            "DOTUSDT",
+            "SHORT",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+        )
+        ghost_b = _spos(
+            "g2",
+            "ETHUSDT",
+            "SHORT",
+            entry_time=datetime.now(UTC) - timedelta(hours=2),
+        )
+        mgr = _manager_with(real_pos, ghost_a, ghost_b)
+        mgr._update_strategy_position_closure = AsyncMock(return_value=None)
+        recon = StrategyPositionReconciler(mgr, store, min_age_seconds=0)
+
+        await recon.reconcile_once()
+
+        exchange_positions = store.get_positions()
+        remaining = mgr.get_all_open_strategy_positions()
+        for pos in remaining:
+            assert _has_matching_exchange_position(pos, exchange_positions), (
+                f"AC5 violation: {pos['strategy_position_id']} has no exchange match"
+            )

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -37,6 +37,7 @@ from tradeengine.services.halt_suspected_detector import halt_suspected_detector
 from tradeengine.services.heartbeat_monitor import HeartbeatMonitor
 from tradeengine.signal_aggregator import SignalAggregator
 from tradeengine.strategy_position_manager import strategy_position_manager
+from tradeengine.strategy_position_reconciler import StrategyPositionReconciler
 
 # Prometheus metrics for signal flow tracking
 signals_received = Counter(
@@ -1448,6 +1449,9 @@ class Dispatcher:
         self.order_to_strategy_position: dict[str, str] = {}
 
         self.user_data_consumer: UserDataStreamConsumer | None = None
+        # #480 — periodic ghost-position eviction for the strategy-layer
+        # tracker.  Started after user_data_consumer wires the truth store.
+        self.strategy_position_reconciler: StrategyPositionReconciler | None = None
 
         # Initialize Heartbeat Monitor for ecosystem fail-safe (AC: Gate behind nats_enabled)
         self.heartbeat_monitor = None
@@ -1547,6 +1551,25 @@ class Dispatcher:
                     self.user_data_consumer.store
                 )
 
+                # #480 — start the strategy-layer ghost reconciler now that
+                # the truth store is available.  AC1 runs an immediate pass
+                # inside start() so any positions left over from a previous
+                # boot get reconciled before the dispatcher accepts work.
+                self.strategy_position_reconciler = StrategyPositionReconciler(
+                    strategy_pos_manager=strategy_position_manager,
+                    store=self.user_data_consumer.store,
+                )
+                try:
+                    await self.strategy_position_reconciler.start()
+                except Exception as recon_err:
+                    # Reconciler is a safety net — never block startup if
+                    # the first pass hiccups (e.g. truth store still warming
+                    # up).  The periodic loop will pick up on the next tick.
+                    self.logger.warning(
+                        "StrategyPositionReconciler start failed (non-fatal): %s",
+                        recon_err,
+                    )
+
             self.logger.info(
                 "Dispatcher initialized successfully with distributed state management"
             )
@@ -1559,6 +1582,8 @@ class Dispatcher:
         try:
             if self.heartbeat_monitor is not None:
                 await self.heartbeat_monitor.stop()
+            if self.strategy_position_reconciler is not None:
+                await self.strategy_position_reconciler.stop()
             if self.user_data_consumer is not None:
                 await self.user_data_consumer.stop()
             await self.order_manager.close()

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -169,6 +169,34 @@ position_persist_failed_total = Counter(
     ["symbol", "position_side", "operation", "reason"],
 )
 
+# #480 — StrategyPositionManager ghost evictions. A strategy position is a
+# "ghost" when StrategyPositionManager has it open but no matching position
+# exists in the ExchangeTruthStore. The reconciler removes ghosts older than
+# the min-age threshold and increments this counter per eviction.
+strategy_position_ghost_evicted_total = Counter(
+    "petrosa_tradeengine_strategy_position_ghost_evicted_total",
+    "Strategy positions evicted as ghosts (no matching exchange position)",
+    ["symbol", "side", "reason"],
+)
+
+# #480 — Strategy-layer reconciliation runs. Result label:
+# "ok"                      — pass completed (eviction count is on the ghost counter)
+# "error"                   — exception during pass
+# "skipped_store_not_ready" — ExchangeTruthStore not ready yet (post-boot grace)
+strategy_position_reconcile_runs_total = Counter(
+    "petrosa_tradeengine_strategy_position_reconcile_runs_total",
+    "Strategy-layer reconciliation runs",
+    ["result"],
+)
+
+# #480 — current number of strategy positions with no matching exchange
+# position (pre-eviction view, refreshed each pass). Useful for alerting when
+# ghosts accumulate faster than the reconciler can age them out.
+strategy_position_ghost_gauge = Gauge(
+    "petrosa_tradeengine_strategy_position_ghost_count",
+    "Current count of strategy positions with no matching exchange position",
+)
+
 # ========================================
 # Business Metrics for Trade Execution Monitoring
 # ========================================

--- a/tradeengine/position_health_guard.py
+++ b/tradeengine/position_health_guard.py
@@ -281,11 +281,18 @@ async def check_position_stops(
         close_needed = False
         sl_placed_now = False
         tp_placed_now = False
+        new_sl_order_id: str | None = None
+        new_tp_order_id: str | None = None
 
+        # AC3 of #480: remediation must be atomic.  `sl_placed_now=True` may
+        # only be set when the exchange response actually carries a real
+        # Binance algo-order ID — otherwise the stops-health endpoint will
+        # claim `has_sl_order=true` while `sl_order_id` stays null, which is
+        # what the 2026-06-18 testnet diagnosis surfaced.  Same for TP.
         if not has_sl:
             if stop_loss_price is not None:
                 try:
-                    await exchange.execute(
+                    sl_result = await exchange.execute(
                         TradeOrder(
                             type="stop",
                             symbol=symbol,
@@ -295,7 +302,27 @@ async def check_position_stops(
                             position_side=position_side,
                         )
                     )
-                    sl_placed_now = True
+                    candidate_sl_id = (
+                        (sl_result or {}).get("order_id")
+                        if isinstance(sl_result, dict)
+                        else None
+                    )
+                    if _is_real_algo_id(candidate_sl_id):
+                        sl_placed_now = True
+                        new_sl_order_id = str(candidate_sl_id)
+                    else:
+                        logger.error(
+                            "SL placement for %s returned no real algo-id; "
+                            "result_status=%s order_id=%r — treating as failure",
+                            spid,
+                            (
+                                (sl_result or {}).get("status")
+                                if isinstance(sl_result, dict)
+                                else None
+                            ),
+                            candidate_sl_id,
+                        )
+                        close_needed = True
                 except Exception as exc:
                     logger.error("SL placement failed for %s: %s", spid, exc)
                     close_needed = True
@@ -305,7 +332,7 @@ async def check_position_stops(
         if not close_needed and not has_tp:
             if take_profit_price is not None:
                 try:
-                    await exchange.execute(
+                    tp_result = await exchange.execute(
                         TradeOrder(
                             type="take_profit",
                             symbol=symbol,
@@ -315,12 +342,60 @@ async def check_position_stops(
                             position_side=position_side,
                         )
                     )
-                    tp_placed_now = True
+                    candidate_tp_id = (
+                        (tp_result or {}).get("order_id")
+                        if isinstance(tp_result, dict)
+                        else None
+                    )
+                    if _is_real_algo_id(candidate_tp_id):
+                        tp_placed_now = True
+                        new_tp_order_id = str(candidate_tp_id)
+                    else:
+                        logger.error(
+                            "TP placement for %s returned no real algo-id; "
+                            "result_status=%s order_id=%r — treating as failure",
+                            spid,
+                            (
+                                (tp_result or {}).get("status")
+                                if isinstance(tp_result, dict)
+                                else None
+                            ),
+                            candidate_tp_id,
+                        )
+                        close_needed = True
                 except Exception as exc:
                     logger.error("TP placement failed for %s: %s", spid, exc)
                     close_needed = True
             else:
                 close_needed = True
+
+        # AC3 of #480: atomic boolean+id contract.  Once a real algo-id is
+        # captured locally, mirror it into the response variables BEFORE
+        # touching the manager — that way a manager exception cannot leave
+        # the response with has_sl_order=True and sl_order_id=null.  The
+        # manager call below is best-effort; even if it fails, the local
+        # variables already hold a consistent (boolean, id) pair.
+        if new_sl_order_id:
+            sl_order_id = new_sl_order_id
+        if new_tp_order_id:
+            tp_order_id = new_tp_order_id
+
+        if (new_sl_order_id or new_tp_order_id) and hasattr(
+            strategy_pos_manager, "set_strategy_position_orders"
+        ):
+            try:
+                await strategy_pos_manager.set_strategy_position_orders(
+                    strategy_position_id=spid,
+                    sl_order_id=new_sl_order_id,
+                    tp_order_id=new_tp_order_id,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to propagate remediation order IDs back to "
+                    "strategy_position %s: %s",
+                    spid,
+                    exc,
+                )
 
         if close_needed:
             outcome = "position_closed"

--- a/tradeengine/strategy_position_manager.py
+++ b/tradeengine/strategy_position_manager.py
@@ -638,6 +638,48 @@ class StrategyPositionManager:
             if pos.get("status") == "open"
         ]
 
+    async def evict_ghost_position(
+        self, strategy_position_id: str, reason: str = "no_exchange_position"
+    ) -> bool:
+        """Evict a strategy position that has no matching exchange position (#480).
+
+        Unlike ``close_strategy_position``, this does NOT touch the aggregated
+        exchange_position record because the underlying exchange position
+        never existed (or was already closed externally). The in-memory row
+        is removed and Data Manager is updated with ``status="closed_externally"``
+        so the audit journal still shows what happened.
+
+        Returns True if the position was found and evicted, False otherwise.
+        Never raises — eviction errors are logged but must not break the
+        reconcile loop.
+        """
+        position = self.strategy_positions.get(strategy_position_id)
+        if position is None:
+            return False
+
+        position["status"] = "closed_externally"
+        position["exit_time"] = datetime.now(UTC)
+        position["close_reason"] = reason
+
+        try:
+            await self._update_strategy_position_closure(strategy_position_id, position)
+        except Exception as exc:
+            logger.error(
+                "evict_ghost_position: Data Manager update failed for %s: %s",
+                strategy_position_id,
+                exc,
+            )
+
+        self.strategy_positions.pop(strategy_position_id, None)
+        logger.info(
+            "Evicted ghost strategy position %s (%s %s) — reason=%s",
+            strategy_position_id,
+            position.get("symbol"),
+            position.get("side"),
+            reason,
+        )
+        return True
+
     def get_strategy_position(self, strategy_position_id: str) -> dict[str, Any] | None:
         """Get strategy position by ID"""
         return self.strategy_positions.get(strategy_position_id)

--- a/tradeengine/strategy_position_reconciler.py
+++ b/tradeengine/strategy_position_reconciler.py
@@ -1,0 +1,241 @@
+"""Strategy-layer position reconciliation (#480).
+
+The :class:`PositionReconciler` family already reconciles the aggregated
+``PositionManager`` against Binance.  This module is its analogue for the
+``StrategyPositionManager`` — the per-signal virtual tracker — and exists
+because the 2026-06-18 testnet diagnosis surfaced 9 ghost strategy
+positions that no exchange-layer reconciler could see.
+
+Behaviour
+---------
+On each pass:
+
+1. Pull all open strategy positions from ``StrategyPositionManager``.
+2. Pull the authoritative position view from ``ExchangeTruthStore``.
+3. For every strategy position whose ``(symbol, side)`` is absent from the
+   exchange view AND whose ``entry_time`` is older than ``min_age_seconds``,
+   call ``StrategyPositionManager.evict_ghost_position`` and increment
+   ``strategy_position_ghost_evicted_total``.
+
+Read-only with respect to Binance — the reconciler never places or cancels
+orders.  Its only side effect is removing already-orphaned strategy rows
+from the in-memory tracker and journaling the eviction to Data Manager.
+
+AC1: startup pass.
+AC2: periodic 60s task (configurable via ``interval_seconds``).
+AC4: regression test in ``tests/test_strategy_position_reconciler.py``.
+
+The reconciler intentionally does **not** depend on ``TE_EXCHANGE_TRUTH_STORE_ENABLED``
+— the flag governs *risk reads* (#459) where a wrong source can mis-size
+a new trade.  Ghost eviction is purely housekeeping: if the store is
+populated, ghosts are real; if not, we skip the pass (no-op).  This means
+the reconciler is always-on regardless of the flag.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from shared.constants import UTC
+from tradeengine.metrics import (
+    strategy_position_ghost_evicted_total,
+    strategy_position_ghost_gauge,
+    strategy_position_reconcile_runs_total,
+)
+
+if TYPE_CHECKING:
+    from tradeengine.exchange_truth_store import ExchangeTruthStore, PositionSnapshot
+    from tradeengine.strategy_position_manager import StrategyPositionManager
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_INTERVAL_SECONDS = 60
+_DEFAULT_MIN_AGE_SECONDS = 300  # 5 minutes
+
+
+def _position_age_seconds(position: dict, now: datetime) -> float:
+    """Return the age of a strategy position in seconds.
+
+    Positions without an ``entry_time`` (legacy rows) are treated as
+    arbitrarily old so they are eligible for eviction.
+    """
+    entry_time = position.get("entry_time")
+    if entry_time is None:
+        return float("inf")
+    if isinstance(entry_time, str):
+        try:
+            entry_time = datetime.fromisoformat(entry_time)
+        except ValueError:
+            return float("inf")
+    if entry_time.tzinfo is None:
+        entry_time = entry_time.replace(tzinfo=UTC)
+    return max(0.0, (now - entry_time).total_seconds())
+
+
+def _has_matching_exchange_position(
+    strategy_position: dict,
+    exchange_positions: dict[tuple[str, str], PositionSnapshot],
+) -> bool:
+    """True when the strategy position's (symbol, side) has a live exchange
+    counterpart.
+
+    Hedge mode keys are ``(symbol, "LONG")`` / ``(symbol, "SHORT")`` and
+    match directly.  One-way mode keys are ``(symbol, "BOTH")`` with a
+    signed quantity — positive amount = LONG, negative = SHORT.
+    """
+    symbol = strategy_position.get("symbol")
+    side = str(strategy_position.get("side", "")).upper()
+    if not symbol or side not in ("LONG", "SHORT"):
+        # Defensive: malformed strategy position.  Treat as ghost-eligible
+        # so the reconciler can drop the bad row instead of carrying it
+        # forever.
+        return False
+
+    if (symbol, side) in exchange_positions:
+        return True
+
+    snap = exchange_positions.get((symbol, "BOTH"))
+    if snap is None:
+        return False
+    if side == "LONG" and snap.quantity > 0:
+        return True
+    if side == "SHORT" and snap.quantity < 0:
+        return True
+    return False
+
+
+class StrategyPositionReconciler:
+    """Periodic ghost-eviction reconciler for ``StrategyPositionManager``."""
+
+    def __init__(
+        self,
+        strategy_pos_manager: StrategyPositionManager,
+        store: ExchangeTruthStore,
+        interval_seconds: int = _DEFAULT_INTERVAL_SECONDS,
+        min_age_seconds: int = _DEFAULT_MIN_AGE_SECONDS,
+    ) -> None:
+        self._manager = strategy_pos_manager
+        self._store = store
+        self._interval = max(1, int(interval_seconds))
+        self._min_age = max(0, int(min_age_seconds))
+        self._task: asyncio.Task | None = None  # type: ignore[type-arg]
+        self._running: bool = False
+
+    @property
+    def interval_seconds(self) -> int:
+        return self._interval
+
+    @property
+    def min_age_seconds(self) -> int:
+        return self._min_age
+
+    async def start(self) -> None:
+        """Launch the reconcile loop after running one immediate pass."""
+        if self._task is not None and not self._task.done():
+            return
+        self._running = True
+        # AC1: startup pass before the periodic loop kicks in so ghosts
+        # left over from the previous boot get cleaned up immediately.
+        await self.reconcile_once()
+        self._task = asyncio.create_task(
+            self._loop(), name="strategy-position-reconciler"
+        )
+        logger.info(
+            "StrategyPositionReconciler started (interval=%ds, min_age=%ds)",
+            self._interval,
+            self._min_age,
+        )
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+        logger.info("StrategyPositionReconciler stopped")
+
+    async def _loop(self) -> None:
+        while self._running:
+            try:
+                await asyncio.sleep(self._interval)
+            except asyncio.CancelledError:
+                raise
+            if not self._running:
+                break
+            try:
+                await self.reconcile_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("StrategyPositionReconciler loop pass failed")
+
+    async def reconcile_once(self) -> dict[str, int]:
+        """Run one reconciliation pass.
+
+        Returns a summary dict ``{open, ghosts, evicted, skipped_young}``.
+        Never raises — exceptions are recorded against the runs counter.
+        """
+        try:
+            if not getattr(self._store, "is_ready", False):
+                strategy_position_reconcile_runs_total.labels(
+                    result="skipped_store_not_ready"
+                ).inc()
+                return {"open": 0, "ghosts": 0, "evicted": 0, "skipped_young": 0}
+
+            open_positions = self._manager.get_all_open_strategy_positions()
+            exchange_positions = self._store.get_positions()
+            now = datetime.now(UTC)
+
+            ghosts = 0
+            evicted = 0
+            skipped_young = 0
+
+            for pos in open_positions:
+                if _has_matching_exchange_position(pos, exchange_positions):
+                    continue
+                ghosts += 1
+                age = _position_age_seconds(pos, now)
+                if age < self._min_age:
+                    skipped_young += 1
+                    continue
+                spid = pos.get("strategy_position_id")
+                if not spid:
+                    continue
+                ok = await self._manager.evict_ghost_position(
+                    strategy_position_id=spid,
+                    reason="no_exchange_position",
+                )
+                if ok:
+                    strategy_position_ghost_evicted_total.labels(
+                        symbol=str(pos.get("symbol", "unknown")),
+                        side=str(pos.get("side", "unknown")),
+                        reason="no_exchange_position",
+                    ).inc()
+                    evicted += 1
+
+            strategy_position_ghost_gauge.set(ghosts)
+            strategy_position_reconcile_runs_total.labels(result="ok").inc()
+            if ghosts:
+                logger.info(
+                    "StrategyPositionReconciler: open=%d ghosts=%d evicted=%d skipped_young=%d",
+                    len(open_positions),
+                    ghosts,
+                    evicted,
+                    skipped_young,
+                )
+            return {
+                "open": len(open_positions),
+                "ghosts": ghosts,
+                "evicted": evicted,
+                "skipped_young": skipped_young,
+            }
+        except Exception:
+            logger.exception("StrategyPositionReconciler pass failed")
+            strategy_position_reconcile_runs_total.labels(result="error").inc()
+            return {"open": 0, "ghosts": 0, "evicted": 0, "skipped_young": 0}


### PR DESCRIPTION
Implements #480.

## What changed

**Strategy-layer ghost reconciler** (`tradeengine/strategy_position_reconciler.py`)

A new periodic reconciler that operates on `StrategyPositionManager`, mirroring what `PositionReconciler` already does for `PositionManager`. The 2026-06-18 testnet diagnosis surfaced 9 ghost strategy positions that no exchange-layer reconciler could see; this closes that gap.

- AC1 — `start()` runs an immediate `reconcile_once()` before launching the periodic loop so pods that restart with leftover ghosts clean up before accepting work.
- AC2 — default 60s interval (configurable), uses the already-injected `ExchangeTruthStore` from #459, no extra Binance client.
- Eviction is a no-op when the truth store is cold (`is_ready=False`) — same fallback contract as #459, so a warming-up consumer can't trigger spurious evictions.
- Young positions (< `min_age_seconds`, default 300s) are observed-as-ghost but not evicted — protects against placement-race scenarios.

**Atomic boolean+order_id contract** (`tradeengine/position_health_guard.py`, AC3)

The previous remediation path set `sl_placed_now=True` based purely on "no exception thrown" from `exchange.execute()`. Since `execute()` does not raise on `BinanceAPIException` — it returns `{"order_id": None, "status": "failed"}` — a silent-null-id placement was sailing through as success. That's the symptom from the bug report:

```
has_sl_order: true
sl_order_id:  null
remediation_outcome: both_placed
```

After the fix, remediation:

1. Captures the `execute()` result dict.
2. Verifies `result["order_id"]` matches `_BINANCE_ALGO_ID_RE` (13+ digits).
3. Mirrors the captured id into the response variables BEFORE invoking `set_strategy_position_orders` — so even if the manager-side propagation raises, the response can't end up with `has_sl_order=true, sl_order_id=null`.
4. Treats a null/non-algo response as placement failure (triggers force-close).

**New metrics** (`tradeengine/metrics.py`)

- `petrosa_tradeengine_strategy_position_ghost_evicted_total{symbol, side, reason}`
- `petrosa_tradeengine_strategy_position_reconcile_runs_total{result=ok|error|skipped_store_not_ready}`
- `petrosa_tradeengine_strategy_position_ghost_count` (gauge)

**Dispatcher wiring** (`tradeengine/dispatcher.py`)

`StrategyPositionReconciler` is instantiated and started right after the existing `strategy_position_manager.exchange_truth_store = …` injection (#459, line 1546), and stopped in `close()`. A startup failure of the reconciler is non-fatal — the periodic loop will pick up on the next tick.

## Acceptance criteria

- [x] **AC1** — startup reconciliation pass (`reconcile_once()` called inside `start()`)
- [x] **AC2** — periodic 60s task + counter `strategy_position_ghost_evicted_total{reason}`
- [x] **AC3** — atomic boolean+id contract enforced; setter exception cannot break atomicity
- [x] **AC4** — regression test seeds a ghost row, reconciles, asserts eviction within one cycle (`test_ghost_is_evicted_when_old_enough`)
- [x] **AC5** — post-reconcile invariant test asserts every remaining strategy position has a matching exchange position (`test_no_remaining_strategy_pos_lacks_exchange_match`)

## Out of scope (per the ticket)

- The SL geometry / -2021 bug that produced the null-id responses initially (separate P0 — #479 partially addresses this).
- The OCO partial-leg orphan bug (separate P1 — #482).
- The -4130 retry-without-reconciliation bug (separate P1 — #483).

## Test evidence

- `tests/test_strategy_position_reconciler.py` — 19 new tests (helpers, reconcile_once, lifecycle, invariant).
- `tests/test_position_stops_health.py` — 3 new AC3 atomicity tests + updated mock to reflect new contract.
- Full local suite: **1737 passed, 13 skipped** (`pytest tests/`).
- `ruff check` + `ruff format --check`: clean.

## MemPalace pre-flight

Posted as comment on #480 — recorded the #446 EPIC family context (#457, #458, #459, #461 all shipped) and the architectural decision from 2026-06-03 that local = audit, exchange = authority.

Closes #480
