### PR TITLE
fix: 482 - OCO orphan-leg cancel counter with cancel_outcome label

### DIFF
--- a/tests/test_oco_manager.py
+++ b/tests/test_oco_manager.py
@@ -125,15 +125,21 @@ async def test_both_legs_fail_does_not_call_cancel(
 async def test_orphan_counter_increments_when_cancel_raises(
     logger: logging.Logger,
 ) -> None:
-    """When the cancel itself raises, ``oco_orphan_leg_total`` MUST tick."""
+    """When the cancel itself raises, ``oco_orphan_leg_total{cancel_outcome=failed}`` MUST tick."""
     from tradeengine.metrics import oco_orphan_leg_total
 
     exch = _make_exchange(sl_ok=True, tp_ok=False)
     exch.client._request_futures_api.side_effect = RuntimeError("binance down")
     oco = OCOManager(exchange=exch, logger=logger)
 
-    sample = oco_orphan_leg_total.labels(symbol="BCHUSDT", side="LONG", leg="SL")
-    before = sample._value.get()
+    failed_sample = oco_orphan_leg_total.labels(
+        symbol="BCHUSDT", side="LONG", leg="SL", cancel_outcome="failed"
+    )
+    success_sample = oco_orphan_leg_total.labels(
+        symbol="BCHUSDT", side="LONG", leg="SL", cancel_outcome="success"
+    )
+    before_failed = failed_sample._value.get()
+    before_success = success_sample._value.get()
     result = await oco.place_oco_orders(
         position_id="ac1-cancel-failed",
         symbol="BCHUSDT",
@@ -142,7 +148,50 @@ async def test_orphan_counter_increments_when_cancel_raises(
         stop_loss_price=300.0,
         take_profit_price=310.0,
     )
-    after = sample._value.get()
+    after_failed = failed_sample._value.get()
+    after_success = success_sample._value.get()
 
     assert result["status"] == "failed"
-    assert after - before == 1.0
+    assert after_failed - before_failed == 1.0
+    # success bucket must NOT tick when cancel raised
+    assert after_success - before_success == 0.0
+
+
+@pytest.mark.asyncio
+async def test_orphan_counter_increments_when_cancel_succeeds(
+    logger: logging.Logger,
+) -> None:
+    """#482 AC2: cancel_outcome="success" bucket ticks when cancel goes through cleanly."""
+    from tradeengine.metrics import oco_orphan_leg_total
+
+    exch = _make_exchange(sl_ok=False, tp_ok=True)
+    oco = OCOManager(exchange=exch, logger=logger)
+
+    success_sample = oco_orphan_leg_total.labels(
+        symbol="ETHUSDT", side="SHORT", leg="TP", cancel_outcome="success"
+    )
+    failed_sample = oco_orphan_leg_total.labels(
+        symbol="ETHUSDT", side="SHORT", leg="TP", cancel_outcome="failed"
+    )
+    before_success = success_sample._value.get()
+    before_failed = failed_sample._value.get()
+    result = await oco.place_oco_orders(
+        position_id="ac2-cancel-success",
+        symbol="ETHUSDT",
+        position_side="SHORT",
+        quantity=0.22,
+        stop_loss_price=2500.0,
+        take_profit_price=2400.0,
+    )
+    after_success = success_sample._value.get()
+    after_failed = failed_sample._value.get()
+
+    assert result["status"] == "failed"
+    # surviving TP leg was cancelled cleanly → success bucket ticks
+    assert after_success - before_success == 1.0
+    # failed bucket must NOT tick when cancel went through
+    assert after_failed - before_failed == 0.0
+    # And the cancel call itself was issued with the right algoId
+    assert exch.client._request_futures_api.call_count == 1
+    call = exch.client._request_futures_api.call_args
+    assert call.kwargs["data"]["algoId"] == "1000000091274546"

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -389,6 +389,8 @@ class OCOManager:
                         f"(algoId={surviving_id}) but counterparty failed for "
                         f"{symbol} {position_side}. Cancelling surviving leg."
                     )
+                    from tradeengine.metrics import oco_orphan_leg_total
+
                     try:
                         self.exchange.client._request_futures_api(
                             "delete",
@@ -401,16 +403,28 @@ class OCOManager:
                             f"✅ Cancelled orphan {leg_label} algoId={surviving_id} "
                             f"for {symbol} {position_side}"
                         )
+                        # #482 AC2: every partial-OCO event ticks the counter so
+                        # operators can see how often the path is non-atomic at
+                        # the exchange, not just the unrecoverable subset.
+                        oco_orphan_leg_total.labels(
+                            symbol=symbol,
+                            side=position_side,
+                            leg=leg_label,
+                            cancel_outcome="success",
+                        ).inc()
                     except Exception as cancel_err:
-                        from tradeengine.metrics import oco_orphan_leg_total
-
                         self.logger.error(
                             f"❌ FAILED to cancel orphan {leg_label} "
                             f"algoId={surviving_id} for {symbol} {position_side}: "
                             f"{cancel_err}"
                         )
+                        # #482 AC2: cancel_outcome="failed" is the alert bucket
+                        # — surviving leg still on Binance, position unhedged.
                         oco_orphan_leg_total.labels(
-                            symbol=symbol, side=position_side, leg=leg_label
+                            symbol=symbol,
+                            side=position_side,
+                            leg=leg_label,
+                            cancel_outcome="failed",
                         ).inc()
 
                 self.logger.error("❌ FAILED TO PLACE OCO ORDERS")

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -142,13 +142,17 @@ active_oco_pairs_per_position = Gauge(
     ["symbol", "position_side", "exchange"],
 )
 
-# #425 (RC#1 of #424): orphan leg from partial OCO failure that could not be cancelled.
-# Incremented when one leg posts, the counterpart fails, and the surviving-leg cancel
-# attempt itself errors — i.e., the position remains unhedged on Binance.
+# #425 (RC#1 of #424) + #482 AC2: orphan leg from partial OCO failure.
+# Incremented every time one leg posts and the counterpart fails. The
+# cancel_outcome label distinguishes between (a) we cancelled the orphan
+# cleanly (cancel_outcome="success") and (b) the surviving-leg cancel itself
+# errored so the position remains unhedged on Binance (cancel_outcome="failed").
+# Operators alert on the failed bucket; success-bucket counts are visibility
+# into how often the OCO path is non-atomic at the exchange.
 oco_orphan_leg_total = Counter(
     "petrosa_tradeengine_oco_orphan_leg_total",
-    "OCO partial-failure events where the surviving leg could not be cancelled",
-    ["symbol", "side", "leg"],
+    "OCO partial-failure events split by surviving-leg cancel outcome",
+    ["symbol", "side", "leg", "cancel_outcome"],
 )
 
 # #426 (RC#2 of #424): the atomic-rollback path itself failed — the


### PR DESCRIPTION
Implements petrosa-tradeengine#482.

## Scope

#482 carries 5 ACs. Three were already shipped via prior tickets; this PR closes the AC2 gap with a focused, minimal change.

| AC | Status | Where |
|----|--------|-------|
| AC1 — cancel surviving leg on partial OCO failure | ✅ Already shipped | `tradeengine/dispatcher.py` `OCOManager.place_oco_orders` (#425, RC#1 of #424) + 4 tests in `tests/test_oco_manager.py` |
| AC2 — counter with `cancel_outcome=success\|failed`; visibility into how often the path is non-atomic | ✅ **This PR** | `tradeengine/metrics.py` + `tradeengine/dispatcher.py` |
| AC3 — atomic `has_sl_order`/`has_tp_order` + order_id contract | ✅ Already shipped | `tradeengine/position_health_guard.py` (#480, PR #487) |
| AC4 — regression test mocking Binance partial failure | ✅ **This PR** (expanded) | `tests/test_oco_manager.py` (4 pre-existing + 1 new = 5 cases) |
| AC5 — operator dashboard "OCO partial-leg failures (last 24h)" | ⏭️ Defer | Cross-repo: panel lives in `petrosa_k8s` Grafana stack. Follow-up sub-ticket once the new label is in the metric stream. |

## What changes

1. `tradeengine/metrics.py` — `oco_orphan_leg_total` gains a `cancel_outcome` label. Old labels `(symbol, side, leg)`, new labels `(symbol, side, leg, cancel_outcome)` where `cancel_outcome ∈ {"success", "failed"}`.
2. `tradeengine/dispatcher.py` — `OCOManager.place_oco_orders` partial-leg branch now increments the counter on *both* paths:
   - cancel succeeded → `cancel_outcome="success"` (visibility into non-atomicity at the exchange)
   - cancel raised → `cancel_outcome="failed"` (the alert bucket — position remains unhedged)
3. `tests/test_oco_manager.py` — `test_orphan_counter_increments_when_cancel_raises` updated to use the new label and assert the success bucket stays flat; new `test_orphan_counter_increments_when_cancel_succeeds` asserts the success bucket ticks when cancel goes through cleanly.

## Why the metric label change is safe

The counter was introduced as part of #425 and has had no Grafana panels built on it yet — AC5 of #482 is the panel work. Adding a label here is a one-time schema decision before the metric reaches operator dashboards.

## Validation

```
.venv/bin/python -m pytest                  → 1738 passed, 13 skipped, coverage 79.98%
.venv/bin/python -m ruff check  <files>     → All checks passed
.venv/bin/python -m ruff format --check     → 3 files already formatted
```

`make pipeline` mypy step surfaces 110 pre-existing errors in 10 unrelated files (`naked_position_remediator.py`, `health_evaluator.py`, `consumer.py`, `api.py`); none touch the files in this PR — verified by running the same `make type-check` against `origin/main`.

## Operator follow-up

After deploy, the operator can see the new buckets via:

```
sum by (cancel_outcome) (
  rate(petrosa_tradeengine_oco_orphan_leg_total[5m])
)
```

A non-zero `cancel_outcome="failed"` rate is the alert condition (existing semantics, just now explicitly labelled).

Closes #482.
