### PR TITLE
fix(exchange): #483 reconcile -4130 against /openOrders + /openAlgoOrders truth before retry

### DIFF
--- a/tests/test_binance_4130_reconciliation.py
+++ b/tests/test_binance_4130_reconciliation.py
@@ -1,0 +1,434 @@
+"""Regression tests for #483 — -4130 'already existing' retry reconciliation.
+
+Verifies that BinanceFuturesExchange._execute_with_retry, when the underlying
+algo-order placement raises BinanceAPIException(code=-4130), reconciles against
+exchange truth (/openOrders + /openAlgoOrders) BEFORE retrying:
+
+- AC1 / AC4: if a matching closePosition stop/TP exists in /openOrders → return
+  the existing order id, no retry, increment ``already_protected`` counter.
+- AC3: if it exists only in /openAlgoOrders (the most likely "phantom" source) →
+  same behavior. Algo orders are NOT in /openOrders.
+- If a non-matching order occupies the slot → log conflict with clientOrderId,
+  increment ``conflicting_order`` counter, fall through to backoff retry.
+- If nothing matches → fall through to backoff retry (existing behavior),
+  terminal outcome counted as ``retry_succeeded`` or ``retry_failed``.
+- Other Binance error codes are NOT affected (regression guard).
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+mock_binance = MagicMock()
+mock_binance.exceptions = MagicMock()
+sys.modules["binance"] = mock_binance
+sys.modules["binance.exceptions"] = mock_binance.exceptions
+mock_binance.enums = MagicMock()
+mock_binance.enums.FUTURE_ORDER_TYPE_STOP = "STOP"
+mock_binance.enums.FUTURE_ORDER_TYPE_STOP_MARKET = "STOP_MARKET"
+mock_binance.enums.FUTURE_ORDER_TYPE_TAKE_PROFIT = "TAKE_PROFIT"
+mock_binance.enums.FUTURE_ORDER_TYPE_TAKE_PROFIT_MARKET = "TAKE_PROFIT_MARKET"
+sys.modules["binance.enums"] = mock_binance.enums
+
+
+class _MockBinanceAPIException(Exception):
+    def __init__(self, code: int, message: str = ""):
+        self.code = code
+        self.message = message
+        super().__init__(message or f"code={code}")
+
+
+mock_binance.exceptions.BinanceAPIException = _MockBinanceAPIException
+
+from tradeengine.exchange.binance import BinanceFuturesExchange  # noqa: E402
+from tradeengine.metrics import binance_4130_resolution_total  # noqa: E402
+
+BinanceAPIException = _MockBinanceAPIException
+
+
+def _counter_value(outcome: str, symbol: str) -> float:
+    return binance_4130_resolution_total.labels(
+        outcome=outcome, symbol=symbol
+    )._value.get()
+
+
+@pytest.fixture
+def exchange():
+    """BinanceFuturesExchange wired with a Mock client. Reconciliation reads from
+    ``client.futures_get_open_orders`` and ``client._request_futures_api``
+    (the latter is how ``get_open_algo_orders`` calls /openAlgoOrders).
+    """
+    ex = BinanceFuturesExchange()
+    ex.client = Mock()
+    ex.client.futures_get_open_orders = Mock(return_value=[])
+    ex.client._request_futures_api = Mock(return_value=[])
+    ex.initialized = True
+    return ex
+
+
+ALGO_PARAMS = {
+    "symbol": "BTCUSDT",
+    "side": "SELL",
+    "positionSide": "LONG",
+    "type": "STOP_MARKET",
+    "algoType": "CONDITIONAL",
+    "closePosition": True,
+    "triggerPrice": "60000.0",
+    "workingType": "MARK_PRICE",
+    "priceProtect": True,
+}
+
+
+class TestAlreadyProtectedViaOpenOrders:
+    """AC1 + AC4: matching closePosition stop in /openOrders → no retry, success."""
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_orderid_without_retry(self, exchange):
+        baseline = _counter_value("already_protected", "BTCUSDT")
+        existing = {
+            "orderId": 999111,
+            "symbol": "BTCUSDT",
+            "side": "SELL",
+            "positionSide": "LONG",
+            "type": "STOP_MARKET",
+            "closePosition": True,
+            "clientOrderId": "preexisting-sl-abc",
+        }
+        exchange.client.futures_get_open_orders = Mock(return_value=[existing])
+
+        func = Mock(side_effect=BinanceAPIException(-4130, "already existing"))
+
+        result = await exchange._execute_with_retry(func, **ALGO_PARAMS)
+
+        # No retry: func called exactly once.
+        assert func.call_count == 1
+        assert result["status"] == "ALREADY_EXISTS"
+        assert result["orderId"] == 999111
+        assert result["algoId"] == 999111
+        assert result["matched_order"] is existing
+        assert _counter_value("already_protected", "BTCUSDT") == baseline + 1
+
+    @pytest.mark.asyncio
+    async def test_response_shape_is_dict_so_caller_check_passes(self, exchange):
+        """The four _execute_*_order callers do ``isinstance(result, dict)``.
+        The synthetic ALREADY_EXISTS response must satisfy that without raising.
+        """
+        exchange.client.futures_get_open_orders = Mock(
+            return_value=[
+                {
+                    "orderId": 1,
+                    "symbol": "BTCUSDT",
+                    "side": "SELL",
+                    "positionSide": "LONG",
+                    "type": "STOP_MARKET",
+                    "closePosition": True,
+                }
+            ]
+        )
+        result = await exchange._execute_with_retry(
+            Mock(side_effect=BinanceAPIException(-4130, "already existing")),
+            **ALGO_PARAMS,
+        )
+        assert isinstance(result, dict)
+
+
+class TestAlreadyProtectedViaAlgoOrders:
+    """AC3: phantom source is /openAlgoOrders; algo orders are NOT in /openOrders."""
+
+    @pytest.mark.asyncio
+    async def test_algo_endpoint_only_match(self, exchange):
+        baseline = _counter_value("already_protected", "BTCUSDT")
+        algo_order = {
+            "algoId": 1000000095179762,
+            "symbol": "BTCUSDT",
+            "side": "SELL",
+            "positionSide": "LONG",
+            "type": "STOP_MARKET",
+            "algoType": "CONDITIONAL",
+            "closePosition": True,
+            "clientAlgoId": "algo-xyz",
+        }
+        exchange.client.futures_get_open_orders = Mock(return_value=[])
+        exchange.client._request_futures_api = Mock(return_value=[algo_order])
+
+        func = Mock(side_effect=BinanceAPIException(-4130, "already existing"))
+
+        result = await exchange._execute_with_retry(func, **ALGO_PARAMS)
+
+        assert func.call_count == 1
+        assert result["algoId"] == 1000000095179762
+        assert _counter_value("already_protected", "BTCUSDT") == baseline + 1
+        # The algo-orders endpoint must have been consulted (AC3).
+        exchange.client._request_futures_api.assert_called_with(
+            "get", "openAlgoOrders", signed=True, data={"symbol": "BTCUSDT"}
+        )
+
+
+class TestNoMatchFallsThroughToRetry:
+    @pytest.mark.asyncio
+    async def test_no_match_retries_and_can_succeed(self, exchange, monkeypatch):
+        """No protective order is present (truly phantom -4130). Existing
+        backoff+retry path runs, the next call succeeds, counter logs
+        ``retry_succeeded``.
+        """
+
+        # Patch asyncio.sleep so the test does not actually wait for backoff.
+        async def _sleep_noop(_):
+            return None
+
+        monkeypatch.setattr("tradeengine.exchange.binance.asyncio.sleep", _sleep_noop)
+
+        baseline_ok = _counter_value("retry_succeeded", "BTCUSDT")
+        success = {"algoId": 42, "status": "NEW", "algoStatus": "NEW"}
+        func = Mock(
+            side_effect=[BinanceAPIException(-4130, "already existing"), success]
+        )
+
+        result = await exchange._execute_with_retry(func, **ALGO_PARAMS)
+
+        assert func.call_count == 2
+        assert result["algoId"] == 42
+        assert _counter_value("retry_succeeded", "BTCUSDT") == baseline_ok + 1
+
+    @pytest.mark.asyncio
+    async def test_no_match_exhausted_retries_counts_retry_failed(
+        self, exchange, monkeypatch
+    ):
+        async def _sleep_noop(_):
+            return None
+
+        monkeypatch.setattr("tradeengine.exchange.binance.asyncio.sleep", _sleep_noop)
+
+        baseline_fail = _counter_value("retry_failed", "BTCUSDT")
+        func = Mock(side_effect=BinanceAPIException(-4130, "already existing"))
+
+        with pytest.raises(BinanceAPIException) as excinfo:
+            await exchange._execute_with_retry(func, **ALGO_PARAMS)
+
+        assert excinfo.value.code == -4130
+        assert _counter_value("retry_failed", "BTCUSDT") == baseline_fail + 1
+
+
+class TestConflictingOrderDetected:
+    @pytest.mark.asyncio
+    async def test_wrong_position_side_logged_as_conflict(
+        self, exchange, monkeypatch, caplog
+    ):
+        async def _sleep_noop(_):
+            return None
+
+        monkeypatch.setattr("tradeengine.exchange.binance.asyncio.sleep", _sleep_noop)
+
+        baseline_conflict = _counter_value("conflicting_order", "BTCUSDT")
+        conflicting = {
+            "orderId": 5555,
+            "symbol": "BTCUSDT",
+            "side": "BUY",  # opposite side
+            "positionSide": "SHORT",  # different hedge bucket
+            "type": "STOP_MARKET",
+            "closePosition": True,
+            "clientOrderId": "different-leg-zzz",
+        }
+        exchange.client.futures_get_open_orders = Mock(return_value=[conflicting])
+
+        # Eventually succeed on retry so the wrapper exits cleanly.
+        func = Mock(
+            side_effect=[
+                BinanceAPIException(-4130, "already existing"),
+                {"algoId": 7, "status": "NEW", "algoStatus": "NEW"},
+            ]
+        )
+
+        with caplog.at_level("WARNING"):
+            result = await exchange._execute_with_retry(func, **ALGO_PARAMS)
+
+        assert result["algoId"] == 7
+        assert _counter_value("conflicting_order", "BTCUSDT") == baseline_conflict + 1
+        assert any(
+            "conflicting_order_detected" in rec.message
+            and "different-leg-zzz" in rec.message
+            for rec in caplog.records
+        )
+
+
+class TestUnrelatedErrorsUnchanged:
+    """Regression: only -4130 triggers reconciliation; other codes behave as before."""
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_code_still_raises_immediately(self, exchange):
+        func = Mock(side_effect=BinanceAPIException(-2010, "insufficient balance"))
+
+        with pytest.raises(BinanceAPIException) as excinfo:
+            await exchange._execute_with_retry(func, **ALGO_PARAMS)
+
+        assert excinfo.value.code == -2010
+        assert func.call_count == 1
+        # Reconciliation must not have been consulted for a non-4130 error.
+        exchange.client.futures_get_open_orders.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_4130_on_non_algo_call_does_not_reconcile(
+        self, exchange, monkeypatch
+    ):
+        """If closePosition is not set, this is a market/limit call and the
+        reconciler must not be invoked — preserve generic retry semantics.
+        """
+
+        async def _sleep_noop(_):
+            return None
+
+        monkeypatch.setattr("tradeengine.exchange.binance.asyncio.sleep", _sleep_noop)
+
+        func = Mock(
+            side_effect=[
+                BinanceAPIException(-4130, "already existing"),
+                {"orderId": 99, "status": "NEW"},
+            ]
+        )
+        result = await exchange._execute_with_retry(
+            func, symbol="BTCUSDT", side="BUY", type="MARKET"
+        )
+
+        assert result["orderId"] == 99
+        exchange.client.futures_get_open_orders.assert_not_called()
+
+
+class TestReconcilerHelperDirect:
+    """Direct unit tests of _reconcile_4130_against_truth (the helper itself)."""
+
+    @pytest.mark.asyncio
+    async def test_match_in_std_orders(self, exchange):
+        exchange.client.futures_get_open_orders = Mock(
+            return_value=[
+                {
+                    "orderId": 1,
+                    "symbol": "ETHUSDT",
+                    "side": "SELL",
+                    "positionSide": "LONG",
+                    "type": "STOP_MARKET",
+                    "closePosition": True,
+                }
+            ]
+        )
+        outcome, payload = await exchange._reconcile_4130_against_truth(
+            symbol="ETHUSDT",
+            side="SELL",
+            position_side="LONG",
+            order_type="STOP_MARKET",
+        )
+        assert outcome == "already_protected"
+        assert payload["orderId"] == 1
+
+    @pytest.mark.asyncio
+    async def test_match_in_algo_orders_with_string_closePosition(self, exchange):
+        # Binance algo-order response may serialize bool as string "true".
+        exchange.client.futures_get_open_orders = Mock(return_value=[])
+        exchange.client._request_futures_api = Mock(
+            return_value=[
+                {
+                    "algoId": 999,
+                    "symbol": "ETHUSDT",
+                    "side": "SELL",
+                    "positionSide": "LONG",
+                    "type": "STOP_MARKET",
+                    "algoType": "CONDITIONAL",
+                    "closePosition": "true",
+                }
+            ]
+        )
+        outcome, payload = await exchange._reconcile_4130_against_truth(
+            symbol="ETHUSDT",
+            side="SELL",
+            position_side="LONG",
+            order_type="STOP_MARKET",
+        )
+        assert outcome == "already_protected"
+        assert payload["algoId"] == 999
+
+    @pytest.mark.asyncio
+    async def test_no_orders_returns_none_found(self, exchange):
+        outcome, payload = await exchange._reconcile_4130_against_truth(
+            symbol="ETHUSDT",
+            side="SELL",
+            position_side="LONG",
+            order_type="STOP_MARKET",
+        )
+        assert outcome == "none_found"
+        assert payload is None
+
+    @pytest.mark.asyncio
+    async def test_one_way_mode_position_side_none_accepts_both(self, exchange):
+        exchange.client.futures_get_open_orders = Mock(
+            return_value=[
+                {
+                    "orderId": 1,
+                    "symbol": "BTCUSDT",
+                    "side": "SELL",
+                    "positionSide": "BOTH",
+                    "type": "STOP_MARKET",
+                    "closePosition": True,
+                }
+            ]
+        )
+        outcome, _ = await exchange._reconcile_4130_against_truth(
+            symbol="BTCUSDT",
+            side="SELL",
+            position_side=None,
+            order_type="STOP_MARKET",
+        )
+        assert outcome == "already_protected"
+
+    @pytest.mark.asyncio
+    async def test_reduce_only_partial_close_classified_as_conflict(self, exchange):
+        """Same kind + same direction but closePosition=False is a partial-close
+        order that still occupies the protective slot."""
+        exchange.client.futures_get_open_orders = Mock(
+            return_value=[
+                {
+                    "orderId": 2,
+                    "symbol": "BTCUSDT",
+                    "side": "SELL",
+                    "positionSide": "LONG",
+                    "type": "STOP_MARKET",
+                    "closePosition": False,
+                    "reduceOnly": True,
+                    "clientOrderId": "partial-sl",
+                }
+            ]
+        )
+        outcome, payload = await exchange._reconcile_4130_against_truth(
+            symbol="BTCUSDT",
+            side="SELL",
+            position_side="LONG",
+            order_type="STOP_MARKET",
+        )
+        assert outcome == "conflicting_order_detected"
+        assert payload["clientOrderId"] == "partial-sl"
+
+    @pytest.mark.asyncio
+    async def test_different_kind_returns_conflict(self, exchange):
+        """Placing an SL while a closePosition TP already occupies the direction
+        is a conflict (not already_protected): the position is missing its SL.
+        """
+        exchange.client.futures_get_open_orders = Mock(
+            return_value=[
+                {
+                    "orderId": 3,
+                    "symbol": "BTCUSDT",
+                    "side": "SELL",
+                    "positionSide": "LONG",
+                    "type": "TAKE_PROFIT_MARKET",
+                    "closePosition": True,
+                    "clientOrderId": "existing-tp",
+                }
+            ]
+        )
+        outcome, payload = await exchange._reconcile_4130_against_truth(
+            symbol="BTCUSDT",
+            side="SELL",
+            position_side="LONG",
+            order_type="STOP_MARKET",
+        )
+        assert outcome == "conflicting_order_detected"
+        assert payload["clientOrderId"] == "existing-tp"

--- a/tests/test_binance_4130_reconciliation.py
+++ b/tests/test_binance_4130_reconciliation.py
@@ -15,36 +15,38 @@ exchange truth (/openOrders + /openAlgoOrders) BEFORE retrying:
 - Other Binance error codes are NOT affected (regression guard).
 """
 
-import sys
-from unittest.mock import AsyncMock, MagicMock, Mock
+# `tests/test_binance_exchange_comprehensive.py` does module-level monkey-patching
+# of ``sys.modules["binance"]`` BEFORE importing the production module, which is
+# what binds ``BinanceAPIException`` inside ``tradeengine.exchange.binance``. If
+# two test files each install their own mock class, pytest's alphabetical
+# collection order causes a race: whichever module is collected first binds its
+# class to production, and the other file's tests raise a different class that
+# production's ``except BinanceAPIException`` no longer matches. To avoid the
+# race we import the comprehensive test module FIRST (forcing its mocks to be
+# the canonical ones) and reuse its ``MockBinanceAPIException`` here. This is
+# the cheapest, narrowest fix; the proper solution is to lift the mock setup
+# into ``conftest.py``, but that is out of scope for this ticket.
+from unittest.mock import Mock  # noqa: E402
 
-import pytest
+import pytest  # noqa: E402
 
-mock_binance = MagicMock()
-mock_binance.exceptions = MagicMock()
-sys.modules["binance"] = mock_binance
-sys.modules["binance.exceptions"] = mock_binance.exceptions
-mock_binance.enums = MagicMock()
-mock_binance.enums.FUTURE_ORDER_TYPE_STOP = "STOP"
-mock_binance.enums.FUTURE_ORDER_TYPE_STOP_MARKET = "STOP_MARKET"
-mock_binance.enums.FUTURE_ORDER_TYPE_TAKE_PROFIT = "TAKE_PROFIT"
-mock_binance.enums.FUTURE_ORDER_TYPE_TAKE_PROFIT_MARKET = "TAKE_PROFIT_MARKET"
-sys.modules["binance.enums"] = mock_binance.enums
-
-
-class _MockBinanceAPIException(Exception):
-    def __init__(self, code: int, message: str = ""):
-        self.code = code
-        self.message = message
-        super().__init__(message or f"code={code}")
-
-
-mock_binance.exceptions.BinanceAPIException = _MockBinanceAPIException
-
-from tradeengine.exchange.binance import BinanceFuturesExchange  # noqa: E402
+import tests.test_binance_exchange_comprehensive as _shared_mocks  # noqa: E402, F401
+from tradeengine.exchange.binance import (
+    BinanceAPIException,  # noqa: E402
+    BinanceFuturesExchange,  # noqa: E402
+)
 from tradeengine.metrics import binance_4130_resolution_total  # noqa: E402
 
-BinanceAPIException = _MockBinanceAPIException
+
+def _make_api_exc(code: int, message: str = "") -> BinanceAPIException:
+    """Build a ``BinanceAPIException`` using the shared mock class signature
+    (response_dict, message). ``e.code`` is force-set defensively so the test
+    contract holds regardless of which mock signature actually wins the
+    sys.modules race at collection time.
+    """
+    exc = BinanceAPIException({"code": code}, message or f"code={code}")
+    exc.code = code
+    return exc
 
 
 def _counter_value(outcome: str, symbol: str) -> float:
@@ -97,7 +99,7 @@ class TestAlreadyProtectedViaOpenOrders:
         }
         exchange.client.futures_get_open_orders = Mock(return_value=[existing])
 
-        func = Mock(side_effect=BinanceAPIException(-4130, "already existing"))
+        func = Mock(side_effect=_make_api_exc(-4130, "already existing"))
 
         result = await exchange._execute_with_retry(func, **ALGO_PARAMS)
 
@@ -127,7 +129,7 @@ class TestAlreadyProtectedViaOpenOrders:
             ]
         )
         result = await exchange._execute_with_retry(
-            Mock(side_effect=BinanceAPIException(-4130, "already existing")),
+            Mock(side_effect=_make_api_exc(-4130, "already existing")),
             **ALGO_PARAMS,
         )
         assert isinstance(result, dict)
@@ -152,7 +154,7 @@ class TestAlreadyProtectedViaAlgoOrders:
         exchange.client.futures_get_open_orders = Mock(return_value=[])
         exchange.client._request_futures_api = Mock(return_value=[algo_order])
 
-        func = Mock(side_effect=BinanceAPIException(-4130, "already existing"))
+        func = Mock(side_effect=_make_api_exc(-4130, "already existing"))
 
         result = await exchange._execute_with_retry(func, **ALGO_PARAMS)
 
@@ -181,9 +183,7 @@ class TestNoMatchFallsThroughToRetry:
 
         baseline_ok = _counter_value("retry_succeeded", "BTCUSDT")
         success = {"algoId": 42, "status": "NEW", "algoStatus": "NEW"}
-        func = Mock(
-            side_effect=[BinanceAPIException(-4130, "already existing"), success]
-        )
+        func = Mock(side_effect=[_make_api_exc(-4130, "already existing"), success])
 
         result = await exchange._execute_with_retry(func, **ALGO_PARAMS)
 
@@ -201,7 +201,7 @@ class TestNoMatchFallsThroughToRetry:
         monkeypatch.setattr("tradeengine.exchange.binance.asyncio.sleep", _sleep_noop)
 
         baseline_fail = _counter_value("retry_failed", "BTCUSDT")
-        func = Mock(side_effect=BinanceAPIException(-4130, "already existing"))
+        func = Mock(side_effect=_make_api_exc(-4130, "already existing"))
 
         with pytest.raises(BinanceAPIException) as excinfo:
             await exchange._execute_with_retry(func, **ALGO_PARAMS)
@@ -235,7 +235,7 @@ class TestConflictingOrderDetected:
         # Eventually succeed on retry so the wrapper exits cleanly.
         func = Mock(
             side_effect=[
-                BinanceAPIException(-4130, "already existing"),
+                _make_api_exc(-4130, "already existing"),
                 {"algoId": 7, "status": "NEW", "algoStatus": "NEW"},
             ]
         )
@@ -257,7 +257,7 @@ class TestUnrelatedErrorsUnchanged:
 
     @pytest.mark.asyncio
     async def test_non_retryable_code_still_raises_immediately(self, exchange):
-        func = Mock(side_effect=BinanceAPIException(-2010, "insufficient balance"))
+        func = Mock(side_effect=_make_api_exc(-2010, "insufficient balance"))
 
         with pytest.raises(BinanceAPIException) as excinfo:
             await exchange._execute_with_retry(func, **ALGO_PARAMS)
@@ -282,7 +282,7 @@ class TestUnrelatedErrorsUnchanged:
 
         func = Mock(
             side_effect=[
-                BinanceAPIException(-4130, "already existing"),
+                _make_api_exc(-4130, "already existing"),
                 {"orderId": 99, "status": "NEW"},
             ]
         )

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -616,9 +616,126 @@ class BinanceFuturesExchange:
         )
         return cast(dict[str, Any], result)
 
+    async def _reconcile_4130_against_truth(
+        self,
+        symbol: str,
+        side: str,
+        position_side: Any,
+        order_type: str,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """Reconcile a -4130 'already existing' error against exchange truth.
+
+        Per #483, before retrying a -4130 the exchange layer asks Binance whether the
+        protective order it complained about actually exists. AC1 reads
+        ``GET /fapi/v1/openOrders`` and AC3 also reads ``GET /openAlgoOrders`` because
+        CONDITIONAL closePosition algo orders do not appear in the standard
+        ``/openOrders`` list and are the most likely source of the "phantom existing"
+        order observed in the 2026-06-18 testnet evidence.
+
+        Outcomes:
+
+        - ``already_protected``: a closePosition order of the same kind (stop vs TP)
+          on the same ``(symbol, side, positionSide)`` already exists. The new
+          placement is redundant; the caller should treat the existing order as the
+          resolution.
+        - ``conflicting_order_detected``: a different protective order is in the slot
+          Binance is guarding (wrong kind, wrong ``positionSide``, or
+          ``closePosition=False`` partial close on the same side). The caller should
+          log the conflicting ``clientOrderId`` and fall through to backoff retry.
+        - ``none_found``: no protective order is present. The -4130 was phantom (most
+          likely eventual-consistency lag against a fill/cancel). The caller should
+          retry with the existing backoff.
+        """
+
+        def _classify_kind(t: Any) -> str:
+            tu = str(t or "").upper()
+            if tu in ("STOP_MARKET", "STOP"):
+                return "stop"
+            if tu in ("TAKE_PROFIT_MARKET", "TAKE_PROFIT"):
+                return "tp"
+            return "other"
+
+        placement_kind = _classify_kind(order_type)
+
+        def _is_close_position(o: dict[str, Any]) -> bool:
+            v = o.get("closePosition")
+            return v in (True, "true", "True")
+
+        side_upper = str(side or "").upper()
+
+        def _matches_direction(o: dict[str, Any]) -> bool:
+            if str(o.get("side", "")).upper() != side_upper:
+                return False
+            # Hedge mode: positionSide is set on both placement and the response.
+            if position_side is not None:
+                return (
+                    str(o.get("positionSide", "")).upper() == str(position_side).upper()
+                )
+            # One-way mode: response uses "BOTH" (or is empty).
+            ps = str(o.get("positionSide", "")).upper()
+            return ps in ("", "BOTH")
+
+        matches: list[dict[str, Any]] = []
+        conflicts: list[dict[str, Any]] = []
+
+        if self.client is None:
+            return "none_found", None
+
+        # AC1: standard open orders.
+        try:
+            std_orders = self.client.futures_get_open_orders(symbol=symbol) or []
+        except Exception as exc:
+            logger.warning(f"4130 reconcile: futures_get_open_orders failed: {exc}")
+            std_orders = []
+
+        # AC3: algo orders (CONDITIONAL closePosition stops/TPs live here).
+        try:
+            algo_orders = await self.get_open_algo_orders(symbol=symbol) or []
+        except Exception as exc:
+            logger.warning(f"4130 reconcile: get_open_algo_orders failed: {exc}")
+            algo_orders = []
+
+        symbol_upper = str(symbol or "").upper()
+
+        for o in list(std_orders) + list(algo_orders):
+            if str(o.get("symbol", "")).upper() != symbol_upper:
+                continue
+            kind = _classify_kind(o.get("type"))
+            if kind == "other":
+                continue
+            if not _is_close_position(o):
+                # Same kind on same direction but reduceOnly partial — still
+                # occupies the slot from Binance's perspective.
+                if kind == placement_kind and _matches_direction(o):
+                    conflicts.append(o)
+                continue
+            if kind == placement_kind and _matches_direction(o):
+                matches.append(o)
+            else:
+                conflicts.append(o)
+
+        if matches:
+            return "already_protected", matches[0]
+        if conflicts:
+            return "conflicting_order_detected", conflicts[0]
+        return "none_found", None
+
     async def _execute_with_retry(self, func: Any, **kwargs: Any) -> Any:
-        """Execute function with retry logic"""
+        """Execute function with retry logic.
+
+        Per #483: when the underlying ``func`` is the algo-order placement endpoint
+        (identified by the ``closePosition=True`` parameter) and Binance reports
+        ``-4130`` ('already existing'), reconcile against exchange truth
+        (``/openOrders`` + ``/openAlgoOrders``) BEFORE retrying. If a matching
+        ``closePosition`` stop/TP already exists, treat the call as success —
+        skipping a naive retry that would just hit the same conflict.
+        """
         last_exception: Exception | None = None
+        # Per #483: track -4130 across attempts so the terminal counter can tag
+        # retry_succeeded vs retry_failed.
+        saw_4130 = False
+        is_algo_order = kwargs.get("closePosition") in (True, "true", "True")
+        symbol_for_metric = str(kwargs.get("symbol") or "unknown")
 
         for attempt in range(MAX_RETRY_ATTEMPTS):
             try:
@@ -632,6 +749,19 @@ class BinanceFuturesExchange:
                 ):
                     headers = getattr(self.client.response, "headers", {})
                     await self.rate_monitor.update_from_headers(headers)
+
+                if saw_4130:
+                    try:
+                        from tradeengine.metrics import (
+                            binance_4130_resolution_total,
+                        )
+
+                        binance_4130_resolution_total.labels(
+                            outcome="retry_succeeded",
+                            symbol=symbol_for_metric,
+                        ).inc()
+                    except Exception:  # pragma: no cover - metrics never crash hot path
+                        pass
 
                 return result
             except BinanceAPIException as e:
@@ -655,6 +785,83 @@ class BinanceFuturesExchange:
                         f"This error cannot be fixed by retrying."
                     )
                     raise
+
+                # Per #483: -4130 on an algo-order placement -> reconcile against
+                # truth (/openOrders + /openAlgoOrders) BEFORE retrying.
+                if e.code == -4130 and is_algo_order:
+                    saw_4130 = True
+                    try:
+                        outcome, payload = await self._reconcile_4130_against_truth(
+                            symbol=str(kwargs.get("symbol", "")),
+                            side=str(kwargs.get("side", "")),
+                            position_side=kwargs.get("positionSide"),
+                            order_type=str(kwargs.get("type", "")),
+                        )
+                    except Exception as reconcile_exc:
+                        logger.warning(
+                            "-4130 reconciliation failed (continuing with normal "
+                            f"retry): {reconcile_exc}"
+                        )
+                        outcome, payload = "none_found", None
+
+                    if outcome == "already_protected" and payload is not None:
+                        existing_id = (
+                            payload.get("algoId")
+                            or payload.get("orderId")
+                            or payload.get("clientOrderId")
+                        )
+                        logger.info(
+                            "4130_already_protected: matching closePosition order "
+                            f"already exists for {kwargs.get('symbol')} "
+                            f"{kwargs.get('positionSide') or kwargs.get('side')} "
+                            f"(id={existing_id}); skipping retry."
+                        )
+                        try:
+                            from tradeengine.metrics import (
+                                binance_4130_resolution_total,
+                            )
+
+                            binance_4130_resolution_total.labels(
+                                outcome="already_protected",
+                                symbol=symbol_for_metric,
+                            ).inc()
+                        except Exception:  # pragma: no cover
+                            pass
+                        # Mirror the algo-order POST response shape so downstream
+                        # isinstance(result, dict) + id extraction continue to work.
+                        return {
+                            "algoId": existing_id,
+                            "orderId": existing_id,
+                            "status": "ALREADY_EXISTS",
+                            "algoStatus": "ALREADY_EXISTS",
+                            "reconciled": True,
+                            "matched_order": payload,
+                        }
+
+                    if outcome == "conflicting_order_detected" and payload is not None:
+                        conflicting_client_id = payload.get(
+                            "clientOrderId"
+                        ) or payload.get("clientAlgoId")
+                        logger.warning(
+                            "conflicting_order_detected: -4130 received but truth "
+                            "shows a non-matching order on "
+                            f"{kwargs.get('symbol')} "
+                            f"{kwargs.get('positionSide') or kwargs.get('side')}; "
+                            f"conflicting_clientOrderId={conflicting_client_id}. "
+                            "Falling through to normal retry."
+                        )
+                        try:
+                            from tradeengine.metrics import (
+                                binance_4130_resolution_total,
+                            )
+
+                            binance_4130_resolution_total.labels(
+                                outcome="conflicting_order",
+                                symbol=symbol_for_metric,
+                            ).inc()
+                        except Exception:  # pragma: no cover
+                            pass
+
                 last_exception = e
             except Exception as e:
                 last_exception = e
@@ -666,6 +873,17 @@ class BinanceFuturesExchange:
                     f"{wait_time}s: {last_exception}"
                 )
                 await asyncio.sleep(wait_time)
+
+        if saw_4130:
+            try:
+                from tradeengine.metrics import binance_4130_resolution_total
+
+                binance_4130_resolution_total.labels(
+                    outcome="retry_failed",
+                    symbol=symbol_for_metric,
+                ).inc()
+            except Exception:  # pragma: no cover
+                pass
 
         if last_exception is None:
             raise RuntimeError("No exception captured during retry")

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -289,6 +289,18 @@ exchange_truth_shadow_delta_total = Counter(
     ["symbol", "side", "field"],
 )
 
+# Per #483: outcome of -4130 ("already existing") retry reconciliation against
+# /openOrders + /openAlgoOrders truth. Outcomes:
+#   - already_protected: matching closePosition stop/TP found → no retry, early success.
+#   - retry_succeeded:   no match found → fell through to backoff retry → succeeded.
+#   - retry_failed:      no match found → fell through to backoff retry → all attempts failed.
+#   - conflicting_order: a non-matching order occupies the slot; logged for investigation.
+binance_4130_resolution_total = Counter(
+    "tradeengine_binance_4130_resolution_total",
+    "Outcome of -4130 'already existing' retry reconciliation against /openOrders + /openAlgoOrders truth",
+    ["outcome", "symbol"],
+)
+
 # ========================================
 # NATS Heartbeat & Fail-Safe Observability
 # ========================================


### PR DESCRIPTION
## Summary

Per #483, the naive `_execute_with_retry` loop in `tradeengine/exchange/binance.py` re-issued the same algo-order placement on `BinanceAPIException(code=-4130, "already existing")` without inspecting actual exchange state. When the conflict was a phantom (eventual-consistency lag, fill/cancel race, or an algo order living outside `/openOrders`) all three attempts hit the same wall and the call surfaced as a hard failure.

This PR makes the exchange layer **reconcile against truth before retrying**: on -4130 + the algo-order parameter shape (`closePosition=True`), the wrapper consults `/fapi/v1/openOrders` *and* `/openAlgoOrders` (the latter is critical — algo orders are not in `/openOrders` and are the most likely "phantom" source) and decides one of three outcomes.

## Acceptance criteria

- [x] **AC1**: On `-4130 "already existing"`, before retrying, the exchange layer queries `GET /fapi/v1/openOrders?symbol=X`. Matching closePosition stop/TP on the same `(symbol, side, positionSide)` ⇒ `already_protected`: no retry, return the existing order id. Nothing matches ⇒ wait backoff and retry. Something else exists ⇒ structured `conflicting_order_detected` log carrying the conflicting `clientOrderId`.
- [x] **AC2**: New counter `tradeengine_binance_4130_resolution_total{outcome, symbol}` with outcomes `already_protected | retry_succeeded | retry_failed | conflicting_order`.
- [x] **AC3**: `/openAlgoOrders` is also consulted in the reconciliation pass — algo orders (`algoType=CONDITIONAL`) live there and are the most likely phantom source per the 2026-06-18 testnet evidence.
- [x] **AC4**: Regression test mocks Binance to return `-4130` and then `[{closePosition=True stop in same direction}]` on `futures_get_open_orders` — asserts no retry and that the synthetic success carries the existing order id (`tests/test_binance_4130_reconciliation.py::TestAlreadyProtectedViaOpenOrders::test_returns_existing_orderid_without_retry`). A parallel AC3 regression covers the algo-orders-only path.

## What changed

- `tradeengine/exchange/binance.py` — new `_reconcile_4130_against_truth(symbol, side, position_side, order_type)` helper; `_execute_with_retry` calls it on `-4130 + closePosition=True`. Match logic is stop/TP-class-aware: placing an SL when a closePosition TP already occupies the direction is classified as `conflicting_order_detected`, not `already_protected` — the position is missing its SL.
- `tradeengine/metrics.py` — `binance_4130_resolution_total` Counter.
- `tests/test_binance_4130_reconciliation.py` — 14 new tests across five classes covering AC1/AC3/AC4 happy paths, retry fall-through, conflict detection (with `clientOrderId` carried into the log), one-way vs hedge mode matching, reduce-only partial-close classification, wrong-kind classification, and the regression guard that non-4130 codes are untouched.

## Out of scope (per ticket)

- OCO atomicity (#482).
- SL geometry / -2021 bug (#479 — shipped 2026-06-19).
- Algo-order cancel path bug (`algo_cancel_bug.md`).

The reconciler is wired only for -4130 + the algo-order parameter shape; the -2021 retry path can adopt the same helper later without re-doing the plumbing, but that is not in scope here.

## Validation

- `ruff check` ✓
- `ruff format --check` ✓
- `mypy --strict` on changed files ✓
- Full test suite: **1752 passed, 13 skipped, 0 failed**, coverage 80.15% (gate 40%). `tradeengine/exchange/binance.py` 82%, `tradeengine/metrics.py` 100%.

Closes #483
