### PR TITLE
fix(dispatcher): #490 cancel orphaned algo orders via algoId, fix swapped cancel_order args

### DIFF
--- a/tests/test_orphan_algo_cancel.py
+++ b/tests/test_orphan_algo_cancel.py
@@ -1,0 +1,112 @@
+"""Regression tests for issue #490.
+
+Startup orphaned-TP cancellation sent ``orderId`` (and, due to swapped
+positional args at the call site, a *symbol string*) to the regular
+``futures_cancel_order`` endpoint for **algo** orders, yielding
+``APIError(-1102)`` on every pod restart. Orphaned closePosition TP/SL orders
+live in ``/openAlgoOrders`` (disjoint from ``/openOrders``, #483) and must be
+cancelled with ``algoId`` via ``cancel_algo_order``.
+
+These tests assert:
+  * scan-time recording of algo-ness (``tp_is_algo``/``sl_is_algo``) so the
+    cancel path routes by source, never by id length (AC2);
+  * the dispatcher routes algo orphans to ``cancel_algo_order`` (AC1/AC2);
+  * the standard-order path calls ``cancel_order(symbol, order_id)`` in the
+    correct argument order (the swapped-arg root cause);
+  * a ``-4029`` ("order does not exist") is swallowed as already-gone (AC6).
+
+All four FAIL against ``main`` (no ``_cancel_orphaned_order`` helper, no
+``cancel_algo_order`` method, no scan-time algo flag).
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tradeengine.dispatcher import OCOManager
+
+
+class _FakeAPIError(Exception):
+    """Minimal stand-in for binance's APIError (carries a numeric ``code``)."""
+
+    def __init__(self, code: int, message: str = "") -> None:
+        super().__init__(message or f"APIError(code={code})")
+        self.code = code
+
+
+@pytest.fixture
+def oco_manager():
+    exchange = MagicMock()
+    exchange.cancel_algo_order = AsyncMock()
+    exchange.cancel_order = AsyncMock()
+    return OCOManager(exchange=exchange, logger=logging.getLogger("test-490"))
+
+
+class TestOrphanAlgoCancelRouting:
+    @pytest.mark.asyncio
+    async def test_algo_orphan_routes_to_cancel_algo_order(self, oco_manager):
+        """An orphan known to be an algo order must cancel via algoId."""
+        await oco_manager._cancel_orphaned_order(
+            "LINKUSDT", "1000000110444048", is_algo=True
+        )
+
+        oco_manager.exchange.cancel_algo_order.assert_awaited_once_with(
+            "LINKUSDT", "1000000110444048"
+        )
+        oco_manager.exchange.cancel_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_standard_orphan_uses_correct_arg_order(self, oco_manager):
+        """Non-algo orphan must call cancel_order(symbol, order_id) — not swapped."""
+        await oco_manager._cancel_orphaned_order("ADAUSDT", "12345", is_algo=False)
+
+        # The root-cause bug passed (order_id, symbol). Assert correct order.
+        oco_manager.exchange.cancel_order.assert_awaited_once_with("ADAUSDT", "12345")
+        oco_manager.exchange.cancel_algo_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_algo_cancel_4029_is_swallowed(self, oco_manager):
+        """-4029 (already cancelled out-of-band) must not raise or log ERROR."""
+        oco_manager.exchange.cancel_algo_order = AsyncMock(
+            side_effect=_FakeAPIError(-4029, "order does not exist")
+        )
+
+        # Must not raise.
+        await oco_manager._cancel_orphaned_order("BNBUSDT", "999", is_algo=True)
+
+        oco_manager.exchange.cancel_algo_order.assert_awaited_once_with(
+            "BNBUSDT", "999"
+        )
+
+
+class TestOrphanScanRecordsAlgoNess:
+    @pytest.mark.asyncio
+    async def test_reconcile_marks_unpaired_algo_tp_as_algo(self):
+        """An unpaired TP sourced from /openAlgoOrders is recorded tp_is_algo=True."""
+        exchange = MagicMock()
+        exchange.client = MagicMock()  # truthy → reconcile proceeds
+        exchange.get_open_algo_orders = AsyncMock(
+            return_value=[
+                {
+                    "algoId": 1000000110444048,
+                    "symbol": "LINKUSDT",
+                    "type": "TAKE_PROFIT_MARKET",
+                    "positionSide": "LONG",
+                    "origQty": "1.0",
+                    "createTime": 1,
+                }
+            ]
+        )
+        oco = OCOManager(exchange=exchange, logger=logging.getLogger("test-490b"))
+        # Don't spin up the background monitor loop in a unit test.
+        oco.start_monitoring = AsyncMock()
+
+        rebuilt = await oco.reconcile_from_exchange()
+
+        assert rebuilt == 1
+        entries = oco.active_oco_pairs["LINKUSDT_LONG"]
+        orphan = next(e for e in entries if e.get("orphaned"))
+        assert orphan["tp_is_algo"] is True
+        assert orphan["sl_order_id"] is None
+        assert str(orphan["tp_order_id"]) == "1000000110444048"

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -883,6 +883,9 @@ class OCOManager:
                     "quantity": float(sl_o.get("quantity", sl_o.get("origQty", 0))),
                     "sl_order_id": sl_id,
                     "tp_order_id": None,
+                    # #490: record algo-ness at scan time so the cancel path
+                    # routes by source (/openAlgoOrders) not by id length.
+                    "sl_is_algo": "algoId" in sl_o,
                     "symbol": sym,
                     "position_side": pos_side,
                     "status": "active",
@@ -908,6 +911,9 @@ class OCOManager:
                     "quantity": float(tp_o.get("quantity", tp_o.get("origQty", 0))),
                     "sl_order_id": None,
                     "tp_order_id": tp_id,
+                    # #490: record algo-ness at scan time so the cancel path
+                    # routes by source (/openAlgoOrders) not by id length.
+                    "tp_is_algo": "algoId" in tp_o,
                     "symbol": sym,
                     "position_side": pos_side,
                     "status": "active",
@@ -1064,6 +1070,53 @@ class OCOManager:
                     f"❌ Deferred OCO placement failed for {symbol} (entry {entry_id}): {e}"
                 )
 
+    async def _cancel_orphaned_order(
+        self, symbol: str, order_id: str, is_algo: bool
+    ) -> None:
+        """Cancel a single orphaned reconciled order, routing algo vs standard.
+
+        Per #490: orphaned closePosition TP/SL orders discovered at startup are
+        algo orders (disjoint from ``/openOrders``, #483) and MUST be cancelled
+        via ``cancel_algo_order`` (``algoId``) — never ``cancel_order``
+        (``orderId``), which returns ``APIError(-1102)``. Whether the order is an
+        algo order is recorded at scan time (``sl_is_algo``/``tp_is_algo``); we
+        never re-classify by id length. A ``-4029`` ("order does not exist")
+        means it was already cancelled out-of-band — INFO, not ERROR (AC6).
+        """
+        from tradeengine.metrics import orphan_algo_cancel_total
+
+        try:
+            if is_algo:
+                await self.exchange.cancel_algo_order(symbol, order_id)
+            else:
+                # NOTE: cancel_order signature is (symbol, order_id). The legacy
+                # call here passed them swapped, which is what actually produced
+                # the -1102 in production (orderId received a symbol string).
+                await self.exchange.cancel_order(symbol, order_id)
+            self.logger.info(f"🗑️  Cancelled orphaned order {order_id} for {symbol}")
+            if is_algo:
+                orphan_algo_cancel_total.labels(
+                    outcome="succeeded", symbol=symbol
+                ).inc()
+        except Exception as cancel_err:
+            code = getattr(cancel_err, "code", None)
+            if is_algo and code == -4029:
+                self.logger.info(
+                    f"Orphaned algo order {order_id} for {symbol} already "
+                    f"cancelled (-4029); nothing to do"
+                )
+                orphan_algo_cancel_total.labels(
+                    outcome="not_found_4029", symbol=symbol
+                ).inc()
+            else:
+                self.logger.warning(
+                    f"Failed to cancel orphaned order {order_id}: {cancel_err}"
+                )
+                if is_algo:
+                    orphan_algo_cancel_total.labels(
+                        outcome="failed_other", symbol=symbol
+                    ).inc()
+
     async def _monitor_orders(self) -> None:
         """
         Monitor active orders for fills and trigger OCO logic
@@ -1117,16 +1170,18 @@ class OCOManager:
                         # Cancel whichever order still exists and mark completed.
                         if oco_info.get("orphaned"):
                             live_id = sl_order_id or tp_order_id
+                            # #490: route by the side that actually carries the
+                            # live order, using the algo-ness recorded at scan
+                            # time — never re-classify by id length.
+                            live_is_algo = (
+                                oco_info.get("sl_is_algo")
+                                if sl_order_id
+                                else oco_info.get("tp_is_algo")
+                            )
                             if live_id and live_id in open_order_ids:
-                                try:
-                                    await self.exchange.cancel_order(live_id, symbol)
-                                    self.logger.info(
-                                        f"🗑️  Cancelled orphaned order {live_id} for {symbol}"
-                                    )
-                                except Exception as _cancel_err:
-                                    self.logger.warning(
-                                        f"Failed to cancel orphaned order {live_id}: {_cancel_err}"
-                                    )
+                                await self._cancel_orphaned_order(
+                                    symbol, live_id, bool(live_is_algo)
+                                )
                             oco_info["status"] = "completed"
                             continue
 
@@ -1369,7 +1424,11 @@ class OCOManager:
             )
 
             try:
-                await self.exchange.cancel_order(other_order_id, symbol)
+                # #490: cancel_order signature is (symbol, order_id) — the args
+                # were swapped here, the same defect that produced -1102 on the
+                # orphan path. Algo orders fall through to the algo-cancel
+                # fallback inside cancel_order (triggered on -2011/-4132).
+                await self.exchange.cancel_order(symbol, other_order_id)
                 self.logger.info(f"✅ Cancelled paired order: {other_order_id}")
             except Exception as e:
                 self.logger.warning(

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -1475,6 +1475,42 @@ class BinanceFuturesExchange:
             logger.error(f"Failed to cancel order {order_id}: {e}")
             raise
 
+    async def cancel_algo_order(
+        self, symbol: str, algo_id: int | str
+    ) -> dict[str, Any]:
+        """Cancel an algo order (conditional closePosition SL/TP) by ``algoId``.
+
+        Binance Futures keeps algo orders in a list disjoint from ``/openOrders``
+        (see ``get_open_algo_orders`` / #483). They must be cancelled with
+        ``algoId`` against the Algo Order DELETE endpoint, NOT ``orderId`` against
+        ``/order`` — the latter returns ``APIError(-1102)``. The orphan-scan
+        already knows an order is an algo order at scan time (#490), so callers
+        route here directly instead of round-tripping through ``cancel_order``.
+
+        Uses ``params=`` (query string), mirroring the proven #475 fallback in
+        ``cancel_order``; passing the params via ``data=`` (body) re-introduces
+        the -1102 bug for DELETE requests.
+        """
+        if not self.initialized:
+            await self.initialize()
+
+        if self.client is None:
+            raise RuntimeError("Binance Futures client not initialized")
+
+        result = self.client._request_futures_api(
+            "delete",
+            "algoOrder",
+            signed=True,
+            params={"symbol": symbol, "algoId": algo_id},
+        )
+        result = result or {}
+        return {
+            "order_id": result.get("algoId", algo_id),
+            "status": "CANCELED",
+            "symbol": result.get("symbol", symbol),
+            "timestamp": int(time.time() * 1000),
+        }
+
     async def get_order_status(self, symbol: str, order_id: int) -> dict[str, Any]:
         """Get order status"""
         if not self.initialized:

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -301,6 +301,20 @@ binance_4130_resolution_total = Counter(
     ["outcome", "symbol"],
 )
 
+# Per #490: outcome of startup orphaned algo-order (closePosition TP/SL)
+# cancellation. Orphans are discovered via /openAlgoOrders (disjoint from
+# /openOrders, #483) and must be cancelled with algoId, not orderId (the
+# latter yields APIError(-1102)). Outcomes:
+#   - succeeded:       algo order cancelled via the Algo Order DELETE endpoint.
+#   - not_found_4029:  -4029 "order does not exist" → already cancelled
+#                      out-of-band; treated as success, logged INFO not ERROR.
+#   - failed_other:    any other failure (network, signature, unexpected code).
+orphan_algo_cancel_total = Counter(
+    "tradeengine_orphan_algo_cancel_total",
+    "Outcome of startup orphaned algo-order (closePosition TP/SL) cancellation",
+    ["outcome", "symbol"],
+)
+
 # ========================================
 # NATS Heartbeat & Fail-Safe Observability
 # ========================================


### PR DESCRIPTION
## Summary

Fixes `APIError(-1102)` on every tradeengine pod restart when cancelling orphaned TP/SL orders discovered at startup.

Closes #490.

## Root cause (corrected from the ticket diagnosis)

The ticket diagnosed "uses `orderId` for algo orders". The actual root cause is a **swapped-argument bug**: `BinanceFuturesExchange.cancel_order` has signature `(symbol, order_id)` — all four `api.py` callers pass `(symbol, order_id)` correctly, but both `dispatcher.py` call sites passed them **reversed**:

```python
await self.exchange.cancel_order(live_id, symbol)        # orphan path
await self.exchange.cancel_order(other_order_id, symbol) # paired-fill path
```

So `futures_cancel_order(symbol=<19-digit algoId>, orderId="LINKUSDT")` sent a *symbol string* as `orderId` → `-1102` ("orderid malformed"). This exactly matches the production log `Failed to cancel order LINKUSDT`. #475's `params=` fallback never engaged because it only triggers on `-2011`/`-4132`, not `-1102`.

Orphaned closePosition TP/SL orders are also **algo orders** (disjoint from `/openOrders`, see #483) and should be cancelled by `algoId` directly rather than round-tripping a guaranteed-to-fail regular cancel.

## Changes

- **AC1** — `BinanceFuturesExchange.cancel_algo_order(symbol, algo_id)`: DELETE `algoOrder` with `params=` (query string), mirroring the proven #475 fallback. (Deviates from the ticket's literal `openAlgoOrders`+`data=` prescription, which would re-introduce #475's `-1102` body-param bug.)
- **AC2** — record `sl_is_algo`/`tp_is_algo` at scan time (`"algoId" in order`); route orphan cancellation through a new `_cancel_orphaned_order` helper that picks algo vs standard **by source, never by id length**. Both swapped-arg call sites corrected.
- **AC3** — `tradeengine_orphan_algo_cancel_total{outcome,symbol}` (`succeeded` / `not_found_4029` / `failed_other`).
- **AC6** — `-4029` ("order does not exist", already cancelled out-of-band) → INFO + `not_found_4029`, not ERROR.
- **AC4** — `tests/test_orphan_algo_cancel.py`: 4 tests covering algo routing, correct standard arg order, `-4029` handling, and scan-time algo recording. **All 4 fail on `main`**, pass here.

## Verification

- Ruff lint + format: clean
- Full suite: **1756 passed, 13 skipped, 80.12% coverage**
- AC4 tests confirmed failing on `main` (stash test) and passing on branch

## AC5 (operator, post-deploy)

After rollout, confirm restart logs no longer show `-1102` for LINK/ADA/BNB/BCH/LTC and `futures_get_open_algo_orders(symbol=...)` returns `[]` for each.
