### PR TITLE
fix(exchange): #490 cancel_algo_order must use force_params=True + data= (KeyError 'data')

### DIFF
--- a/tests/test_orphan_algo_cancel.py
+++ b/tests/test_orphan_algo_cancel.py
@@ -110,3 +110,35 @@ class TestOrphanScanRecordsAlgoNess:
         assert orphan["tp_is_algo"] is True
         assert orphan["sl_order_id"] is None
         assert str(orphan["tp_order_id"]) == "1000000110444048"
+
+
+class TestCancelAlgoOrderCallShape:
+    """The real cancel_algo_order must hit the algo DELETE endpoint correctly.
+
+    Regression for the v1.2.17-r147 production failure (#490): the first fix
+    used ``params=``, which raises ``KeyError('data')`` inside python-binance's
+    ``_request``. The working shape — proven by ``cancel_oco_pair`` (#334) — is
+    ``force_params=True`` + ``data=``. This test exercises the real method (no
+    mock of cancel_algo_order itself) and FAILS on the params= version.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_force_params_and_data(self):
+        from tradeengine.exchange.binance import BinanceFuturesExchange
+
+        exchange = BinanceFuturesExchange()
+        exchange.initialized = True
+        exchange.client = MagicMock()
+        exchange.client._request_futures_api = MagicMock(
+            return_value={"algoId": 1000000110444048, "symbol": "LINKUSDT"}
+        )
+
+        await exchange.cancel_algo_order("LINKUSDT", 1000000110444048)
+
+        exchange.client._request_futures_api.assert_called_once_with(
+            "delete",
+            "algoOrder",
+            signed=True,
+            force_params=True,
+            data={"symbol": "LINKUSDT", "algoId": 1000000110444048},
+        )

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -1487,9 +1487,11 @@ class BinanceFuturesExchange:
         already knows an order is an algo order at scan time (#490), so callers
         route here directly instead of round-tripping through ``cancel_order``.
 
-        Uses ``params=`` (query string), mirroring the proven #475 fallback in
-        ``cancel_order``; passing the params via ``data=`` (body) re-introduces
-        the -1102 bug for DELETE requests.
+        Uses ``force_params=True`` + ``data=``, mirroring the proven
+        ``OCOManager.cancel_oco_pair`` path (#334). python-binance's ``_request``
+        only forwards DELETE params as a query string under ``force_params=True``;
+        passing ``params=`` (without ``data=``) raises ``KeyError('data')`` inside
+        ``_get_request_kwargs`` — observed in production on v1.2.17-r147 (#490).
         """
         if not self.initialized:
             await self.initialize()
@@ -1501,7 +1503,8 @@ class BinanceFuturesExchange:
             "delete",
             "algoOrder",
             signed=True,
-            params={"symbol": symbol, "algoId": algo_id},
+            force_params=True,
+            data={"symbol": symbol, "algoId": algo_id},
         )
         result = result or {}
         return {


### PR DESCRIPTION
## Summary

Corrective follow-up to PR #491. AC5 post-deploy verification on `v1.2.17-r147-6a4f498` confirmed the `-1102` is **gone** (the swapped-arg fix works — orphan cancels now route to `cancel_algo_order`), but they then failed with `KeyError('data')`:

```
WARNING - Failed to cancel orphaned order 1000000112069277: 'data'
```

## Root cause

`cancel_algo_order` used `params={...}`. python-binance's `_request` only forwards DELETE params as a query string when called with `force_params=True` **and** `data={...}`; `params=` alone trips `KeyError('data')` inside `_get_request_kwargs`. The proven `OCOManager.cancel_oco_pair` (#334, with passing tests) already uses `force_params=True, data=` — this aligns to it.

The original PR #491 unit tests mocked `cancel_algo_order` wholesale, so the real `_request_futures_api` call shape was never asserted — that gap let the wrong shape ship.

## Changes
- `cancel_algo_order`: `params=` → `force_params=True, data={symbol, algoId}`
- `TestCancelAlgoOrderCallShape`: exercises the **real** method (no mock of the method itself) and asserts the `_request_futures_api` call shape; fails on the `params=` version

## Verification
- Ruff clean; full suite **1757 passed, 13 skipped**
- AC5 re-verification will follow after this rolls out (confirm no `-1102` **and** no `'data'`; orphans actually cancelled; `openAlgoOrders` empty)

Refs #490