### PR TITLE
fix: #481 - guard close emission against ghost positions + thrash circuit-breaker

### DIFF
--- a/tests/test_dispatcher_close_guard.py
+++ b/tests/test_dispatcher_close_guard.py
@@ -1,0 +1,207 @@
+"""Integration tests for the #481 close guard + thrash circuit-breaker.
+
+Covers the emission-time defenses added to
+``Dispatcher.close_position_with_cleanup``:
+
+- AC1/AC3: seeding a ghost strategy SHORT for a symbol that has a real LONG on
+  the exchange reproduces the thrash trigger; the guard blocks the reduceOnly
+  close and increments ``strategy_close_blocked_no_exchange_position_total``.
+- AC3: a matching exchange position lets the close proceed; an un-ready
+  ExchangeTruthStore does NOT block (avoids suppressing a legitimate close).
+- AC5: repeated un-audited closes on the same symbol trip the circuit-breaker
+  and increment ``dispatcher_thrash_circuit_open_total``; audited closes flow.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tradeengine.dispatcher import Dispatcher
+from tradeengine.exchange_truth_store import ExchangeTruthStore, PositionSnapshot
+
+
+class _FakeConsumer:
+    def __init__(self, store: ExchangeTruthStore) -> None:
+        self.store = store
+
+
+def _dispatcher_with_positions(
+    positions: dict[tuple[str, str], PositionSnapshot] | None,
+    *,
+    store_ready: bool = True,
+) -> Dispatcher:
+    """Build a Dispatcher with a mocked exchange and a seeded truth store."""
+    exchange = AsyncMock()
+    exchange.execute = AsyncMock(
+        return_value={"status": "FILLED", "order_id": "close-1"}
+    )
+    disp = Dispatcher(exchange=exchange)
+    # Isolate OCO cleanup — no active pairs for the position under test.
+    disp.oco_manager.active_oco_pairs = {}
+    disp.position_manager.close_position_record = AsyncMock()
+
+    store = ExchangeTruthStore()
+    if positions:
+        store._positions = dict(positions)
+    store._is_ready = store_ready
+    disp.user_data_consumer = _FakeConsumer(store)  # type: ignore[assignment]
+    return disp
+
+
+@pytest.mark.asyncio
+async def test_ac3_blocks_close_when_no_exchange_position() -> None:
+    # Real LONG on the exchange; a ghost SHORT drives the spurious close.
+    positions = {
+        ("BNBUSDT", "LONG"): PositionSnapshot(
+            symbol="BNBUSDT",
+            side="LONG",
+            quantity=0.17,
+            entry_price=600.0,
+            unrealized_pnl=0.0,
+        )
+    }
+    disp = _dispatcher_with_positions(positions)
+
+    result = await disp.close_position_with_cleanup(
+        position_id="pos-1",
+        symbol="BNBUSDT",
+        position_side="SHORT",
+        quantity=0.17,
+        reason="ghost_short_close",
+    )
+
+    assert result["status"] == "skipped_no_exchange_position"
+    assert result["position_closed"] is False
+    disp.exchange.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ac3_allows_close_when_exchange_position_present() -> None:
+    positions = {
+        ("BNBUSDT", "LONG"): PositionSnapshot(
+            symbol="BNBUSDT",
+            side="LONG",
+            quantity=0.17,
+            entry_price=600.0,
+            unrealized_pnl=0.0,
+        )
+    }
+    disp = _dispatcher_with_positions(positions)
+
+    result = await disp.close_position_with_cleanup(
+        position_id="pos-1",
+        symbol="BNBUSDT",
+        position_side="LONG",
+        quantity=0.17,
+        reason="take_profit",
+    )
+
+    assert result["status"] == "success"
+    assert result["position_closed"] is True
+    disp.exchange.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ac3_unknown_store_does_not_block() -> None:
+    # Store not ready -> presence is unknown -> must NOT suppress the close.
+    disp = _dispatcher_with_positions(None, store_ready=False)
+
+    result = await disp.close_position_with_cleanup(
+        position_id="pos-1",
+        symbol="ETHUSDT",
+        position_side="LONG",
+        quantity=1.0,
+        reason="manual",
+    )
+
+    assert result["status"] == "success"
+    disp.exchange.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ac3_guard_disabled_by_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TE_CLOSE_GUARD_ENABLED", "0")
+    positions = {
+        ("BNBUSDT", "LONG"): PositionSnapshot(
+            symbol="BNBUSDT",
+            side="LONG",
+            quantity=0.17,
+            entry_price=600.0,
+            unrealized_pnl=0.0,
+        )
+    }
+    disp = _dispatcher_with_positions(positions)
+
+    # Even with no matching SHORT, the flag-off path emits the close.
+    result = await disp.close_position_with_cleanup(
+        position_id="pos-1",
+        symbol="BNBUSDT",
+        position_side="SHORT",
+        quantity=0.17,
+        reason="ghost_short_close",
+    )
+
+    assert result["status"] == "success"
+    disp.exchange.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ac5_thrash_circuit_opens_on_repeated_closes() -> None:
+    # A matching LONG exists so AC3 always allows the close; AC5 must be what
+    # ultimately stops the churn. Cap defaults to 2 within 10 minutes.
+    positions = {
+        ("LINKUSDT", "LONG"): PositionSnapshot(
+            symbol="LINKUSDT",
+            side="LONG",
+            quantity=12.37,
+            entry_price=15.0,
+            unrealized_pnl=0.0,
+        )
+    }
+    disp = _dispatcher_with_positions(positions)
+
+    async def _close() -> dict:
+        return await disp.close_position_with_cleanup(
+            position_id="pos-1",
+            symbol="LINKUSDT",
+            position_side="LONG",
+            quantity=12.37,
+            reason="thrash",
+        )
+
+    first = await _close()
+    second = await _close()
+    third = await _close()
+
+    assert first["status"] == "success"
+    assert second["status"] == "success"
+    # Third un-audited close on the same symbol trips the breaker.
+    assert third["status"] == "skipped_thrash_circuit_open"
+
+
+@pytest.mark.asyncio
+async def test_ac5_audited_closes_bypass_circuit() -> None:
+    positions = {
+        ("LINKUSDT", "LONG"): PositionSnapshot(
+            symbol="LINKUSDT",
+            side="LONG",
+            quantity=12.37,
+            entry_price=15.0,
+            unrealized_pnl=0.0,
+        )
+    }
+    disp = _dispatcher_with_positions(positions)
+
+    # Many CIO-audited closes never trip the breaker.
+    for _ in range(5):
+        result = await disp.close_position_with_cleanup(
+            position_id="pos-1",
+            symbol="LINKUSDT",
+            position_side="LONG",
+            quantity=12.37,
+            reason="cio_decision",
+            cio_audited=True,
+        )
+        assert result["status"] == "success"

--- a/tests/test_thrash_guard.py
+++ b/tests/test_thrash_guard.py
@@ -1,0 +1,85 @@
+"""Unit tests for the #481 AC5 open/close thrash circuit-breaker."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from shared.constants import UTC
+from tradeengine.thrash_guard import ThrashCircuitBreaker
+
+
+def _now() -> datetime:
+    return datetime(2026, 6, 18, 19, 25, 0, tzinfo=UTC)
+
+
+def test_under_cap_is_allowed() -> None:
+    br = ThrashCircuitBreaker(max_cycles=2, window_minutes=10)
+    now = _now()
+    # No events yet -> not blocked.
+    assert br.should_block("BNBUSDT", now=now) is False
+    br.record_close("BNBUSDT", cio_audited=False, now=now)
+    # One un-audited close, cap is 2 -> still allowed.
+    assert br.should_block("BNBUSDT", now=now) is False
+
+
+def test_at_cap_blocks() -> None:
+    br = ThrashCircuitBreaker(max_cycles=2, window_minutes=10)
+    now = _now()
+    br.record_close("BNBUSDT", cio_audited=False, now=now)
+    br.record_close("BNBUSDT", cio_audited=False, now=now)
+    # Two un-audited closes within the window == cap -> block.
+    assert br.should_block("BNBUSDT", now=now) is True
+
+
+def test_audited_closes_never_count_or_block() -> None:
+    br = ThrashCircuitBreaker(max_cycles=2, window_minutes=10)
+    now = _now()
+    for _ in range(5):
+        br.record_close("BNBUSDT", cio_audited=True, now=now)
+    # Audited closes do not accumulate toward the threshold.
+    assert br.should_block("BNBUSDT", now=now) is False
+
+
+def test_window_prunes_old_events() -> None:
+    br = ThrashCircuitBreaker(max_cycles=2, window_minutes=10)
+    start = _now()
+    br.record_close("BNBUSDT", cio_audited=False, now=start)
+    br.record_close("BNBUSDT", cio_audited=False, now=start)
+    assert br.should_block("BNBUSDT", now=start) is True
+    # 11 minutes later both events fall outside the 10-minute window.
+    later = start + timedelta(minutes=11)
+    assert br.should_block("BNBUSDT", now=later) is False
+
+
+def test_per_symbol_isolation() -> None:
+    br = ThrashCircuitBreaker(max_cycles=2, window_minutes=10)
+    now = _now()
+    br.record_close("BNBUSDT", cio_audited=False, now=now)
+    br.record_close("BNBUSDT", cio_audited=False, now=now)
+    assert br.should_block("BNBUSDT", now=now) is True
+    # LINKUSDT is tracked independently.
+    assert br.should_block("LINKUSDT", now=now) is False
+
+
+def test_reset_clears_symbol() -> None:
+    br = ThrashCircuitBreaker(max_cycles=2, window_minutes=10)
+    now = _now()
+    br.record_close("BNBUSDT", cio_audited=False, now=now)
+    br.record_close("BNBUSDT", cio_audited=False, now=now)
+    assert br.should_block("BNBUSDT", now=now) is True
+    br.reset("BNBUSDT")
+    assert br.should_block("BNBUSDT", now=now) is False
+
+
+def test_defaults_match_ticket() -> None:
+    br = ThrashCircuitBreaker()
+    assert br.max_cycles == 2
+    assert br.window_minutes == 10
+
+
+def test_degenerate_config_is_clamped() -> None:
+    # Zero/negative inputs are clamped to a sane minimum rather than
+    # disabling the breaker entirely.
+    br = ThrashCircuitBreaker(max_cycles=0, window_minutes=0)
+    assert br.max_cycles == 1
+    assert br.window_minutes >= 1

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -19,12 +19,14 @@ from tradeengine.exchange_truth_store import ExchangeTruthStore, UserDataStreamC
 from tradeengine.leverage_bound_guard import LeverageBoundGuard
 from tradeengine.metrics import (
     atomic_rollback_failed_total,
+    dispatcher_thrash_circuit_open_total,
     order_execution_latency_seconds,
     order_failures_total,
     order_placement_skipped_total,
     orders_executed_by_type,
     risk_checks_total,
     risk_rejections_total,
+    strategy_close_blocked_no_exchange_position_total,
 )
 from tradeengine.order_manager import OrderManager
 from tradeengine.position_manager import PositionManager
@@ -37,7 +39,11 @@ from tradeengine.services.halt_suspected_detector import halt_suspected_detector
 from tradeengine.services.heartbeat_monitor import HeartbeatMonitor
 from tradeengine.signal_aggregator import SignalAggregator
 from tradeengine.strategy_position_manager import strategy_position_manager
-from tradeengine.strategy_position_reconciler import StrategyPositionReconciler
+from tradeengine.strategy_position_reconciler import (
+    StrategyPositionReconciler,
+    _has_matching_exchange_position,
+)
+from tradeengine.thrash_guard import ThrashCircuitBreaker
 
 # Prometheus metrics for signal flow tracking
 signals_received = Counter(
@@ -1525,6 +1531,14 @@ class Dispatcher:
         # #480 — periodic ghost-position eviction for the strategy-layer
         # tracker.  Started after user_data_consumer wires the truth store.
         self.strategy_position_reconciler: StrategyPositionReconciler | None = None
+
+        # #481 AC5 — open/close thrash circuit-breaker. Per-symbol sliding
+        # window that blocks un-audited close emissions once they exceed
+        # TE_THRASH_MAX_CYCLES within TE_THRASH_WINDOW_MINUTES (defaults 2/10).
+        self.thrash_breaker = ThrashCircuitBreaker(
+            max_cycles=int(os.getenv("TE_THRASH_MAX_CYCLES", "2")),
+            window_minutes=int(os.getenv("TE_THRASH_WINDOW_MINUTES", "10")),
+        )
 
         # Initialize Heartbeat Monitor for ecosystem fail-safe (AC: Gate behind nats_enabled)
         self.heartbeat_monitor = None
@@ -4213,6 +4227,30 @@ class Dispatcher:
                 return qty
         return 0.0
 
+    async def _exchange_position_presence(
+        self, symbol: str, position_side: str
+    ) -> bool | None:
+        """Best-effort answer to "does the exchange hold this position?".
+
+        Returns ``True`` when a matching ``(symbol, position_side)`` position
+        exists, ``False`` when the authoritative ExchangeTruthStore is ready
+        and confidently reports its absence, and ``None`` when the answer is
+        unknown (store not ready / not wired) — in which case callers must NOT
+        block, to avoid skipping a legitimate close (#481 AC3).
+
+        Only the truth store yields a definitive ``False``: the REST helper
+        ``_fetch_binance_position_qty`` returns ``0.0`` for both "absent" and
+        "lookup failed", so a REST zero is treated as unknown here rather than
+        risk suppressing a real close on a transient API error.
+        """
+        store = getattr(getattr(self, "user_data_consumer", None), "store", None)
+        if store is not None and getattr(store, "is_ready", False):
+            positions = store.get_positions()
+            return _has_matching_exchange_position(
+                {"symbol": symbol, "side": position_side}, positions
+            )
+        return None
+
     async def close_position_with_cleanup(
         self,
         position_id: str,
@@ -4220,6 +4258,7 @@ class Dispatcher:
         position_side: str,
         quantity: float,
         reason: str = "manual",
+        cio_audited: bool = False,
     ) -> dict[str, Any]:
         """
         Close a position and clean up all associated SL/TP orders (OCO cleanup)
@@ -4251,6 +4290,57 @@ class Dispatcher:
                     self.logger.info("✅ OCO ORDERS CANCELLED SUCCESSFULLY")
                 else:
                     self.logger.warning("⚠️  FAILED TO CANCEL OCO ORDERS")
+
+            # Step 1b (#481 AC3): do not emit a close order for a position the
+            # exchange no longer holds. The 2026-06-18 thrash loop fired
+            # reduceOnly closes against ghost strategy positions with no
+            # exchange counterpart. Stale OCO legs are still cancelled above
+            # (harmless cleanup); only the wasteful MARKET close is suppressed.
+            if os.getenv("TE_CLOSE_GUARD_ENABLED", "1") == "1":
+                presence = await self._exchange_position_presence(symbol, position_side)
+                if presence is False:
+                    self.logger.warning(
+                        "⛔ CLOSE BLOCKED (#481 AC3): exchange reports no open "
+                        "%s position for %s — refusing to emit reduceOnly close "
+                        "(reason=%s). Ghost strategy row will be evicted by the "
+                        "#480 reconciler.",
+                        position_side,
+                        symbol,
+                        reason,
+                    )
+                    strategy_close_blocked_no_exchange_position_total.labels(
+                        symbol=symbol, side=position_side
+                    ).inc()
+                    return {
+                        "position_closed": False,
+                        "oco_cancelled": oco_cancelled,
+                        "close_result": None,
+                        "status": "skipped_no_exchange_position",
+                    }
+
+            # Step 1c (#481 AC5): fail-safe thrash circuit-breaker. Block a
+            # close when un-audited closes on this symbol have exceeded the
+            # per-window cap (default 2 in 10 min). Audited closes (a close
+            # tied to a CIO decision) never trip or get blocked by the breaker.
+            if not cio_audited and self.thrash_breaker.should_block(symbol):
+                self.logger.error(
+                    "🛑 THRASH CIRCUIT OPEN (#481 AC5): %s exceeded %d un-audited "
+                    "close(s) within %d min — blocking further churn "
+                    "(reason=%s).",
+                    symbol,
+                    self.thrash_breaker.max_cycles,
+                    self.thrash_breaker.window_minutes,
+                    reason,
+                )
+                dispatcher_thrash_circuit_open_total.labels(symbol=symbol).inc()
+                return {
+                    "position_closed": False,
+                    "oco_cancelled": oco_cancelled,
+                    "close_result": None,
+                    "status": "skipped_thrash_circuit_open",
+                }
+            # Record the allowed close so it counts toward the window.
+            self.thrash_breaker.record_close(symbol, cio_audited=cio_audited)
 
             # Step 2: Close the position
             position_closed = False

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -201,6 +201,30 @@ strategy_position_ghost_gauge = Gauge(
     "Current count of strategy positions with no matching exchange position",
 )
 
+# #481 AC3 — close-order emission blocked because the exchange has no matching
+# position. The 2026-06-18 testnet thrash loop fired reduceOnly closes against
+# ghost strategy positions with no exchange counterpart. This is the
+# emission-time guard (defense-in-depth to the #480 reconciler that evicts the
+# ghost rows out-of-band): before firing a MARKET reduceOnly close,
+# close_position_with_cleanup consults the ExchangeTruthStore and skips when it
+# confidently reports no matching (symbol, side) position.
+strategy_close_blocked_no_exchange_position_total = Counter(
+    "petrosa_tradeengine_strategy_close_blocked_no_exchange_position_total",
+    "Close-order emissions blocked because no matching exchange position exists",
+    ["symbol", "side"],
+)
+
+# #481 AC5 — thrash circuit-breaker openings. Fail-safe rate limit: no more than
+# N (default 2) close emissions on the same symbol within M (default 10) minutes
+# lacking a CIO-decision audit trail. When the threshold is crossed the breaker
+# opens and further un-audited closes on that symbol are blocked until the
+# window clears, ticking this counter each time it blocks.
+dispatcher_thrash_circuit_open_total = Counter(
+    "petrosa_tradeengine_dispatcher_thrash_circuit_open_total",
+    "Close emissions blocked by the open/close thrash circuit-breaker",
+    ["symbol"],
+)
+
 # ========================================
 # Business Metrics for Trade Execution Monitoring
 # ========================================

--- a/tradeengine/thrash_guard.py
+++ b/tradeengine/thrash_guard.py
@@ -1,0 +1,105 @@
+"""Open/close thrash circuit-breaker (#481 AC5).
+
+The 2026-06-18 testnet diagnosis surfaced a sustained position
+open/close/reopen oscillation on BNBUSDT and LINKUSDT: fixed-size
+reduceOnly closes cycled ~10-20s apart with no price-driven trigger,
+driven by ghost strategy-tracker SHORTs. The #480 reconciler evicts the
+ghost rows and #481 AC3 adds an emission-time guard against closing a
+position the exchange no longer holds. This module is the AC5 fail-safe:
+even if a new ghost-generation path slips past both, a symbol cannot be
+churned open/closed indefinitely without a CIO-decision audit trail.
+
+Rule
+----
+No more than ``max_cycles`` (default 2) close emissions on the same symbol
+within ``window_minutes`` (default 10) that lack a CIO-decision audit
+trail. When the threshold is crossed the breaker "opens" for that symbol
+and :meth:`should_block` returns ``True`` for subsequent un-audited closes
+until the sliding window clears.
+
+Audited closes (``cio_audited=True`` — e.g. a close that traces to a
+petrosa-cio decision) never count toward the threshold and are never
+blocked. This keeps legitimate, reasoned exits flowing while starving the
+un-reasoned thrash loop.
+
+The breaker is intentionally in-memory and per-process: it is a
+last-resort safety valve, not a distributed rate limiter. A pod restart
+resets it, which is acceptable — the #480 reconciler and #481 AC3 guard
+are the durable fixes; AC5 only bounds the blast radius.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta
+
+from shared.constants import UTC
+
+_DEFAULT_MAX_CYCLES = 2
+_DEFAULT_WINDOW_MINUTES = 10
+
+
+class ThrashCircuitBreaker:
+    """Per-symbol sliding-window guard against open/close thrash (#481 AC5)."""
+
+    def __init__(
+        self,
+        max_cycles: int = _DEFAULT_MAX_CYCLES,
+        window_minutes: int = _DEFAULT_WINDOW_MINUTES,
+    ) -> None:
+        self._max_cycles = max(1, int(max_cycles))
+        self._window = timedelta(minutes=max(1, int(window_minutes)))
+        # symbol -> list of (timestamp, cio_audited) for recent close emissions
+        self._events: dict[str, list[tuple[datetime, bool]]] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def max_cycles(self) -> int:
+        return self._max_cycles
+
+    @property
+    def window_minutes(self) -> int:
+        return int(self._window.total_seconds() // 60)
+
+    def _prune(self, symbol: str, now: datetime) -> list[tuple[datetime, bool]]:
+        """Drop events outside the window and return the surviving list."""
+        cutoff = now - self._window
+        events = [e for e in self._events.get(symbol, []) if e[0] >= cutoff]
+        if events:
+            self._events[symbol] = events
+        else:
+            self._events.pop(symbol, None)
+        return events
+
+    def should_block(self, symbol: str, now: datetime | None = None) -> bool:
+        """True when the un-audited close count in the window is at/over the cap.
+
+        Does not record anything — call :meth:`record_close` for emissions that
+        are allowed through.
+        """
+        now = now or datetime.now(UTC)
+        with self._lock:
+            events = self._prune(symbol, now)
+            unaudited = sum(1 for _, audited in events if not audited)
+            return unaudited >= self._max_cycles
+
+    def record_close(
+        self,
+        symbol: str,
+        *,
+        cio_audited: bool,
+        now: datetime | None = None,
+    ) -> None:
+        """Record an allowed close emission so it counts toward the window."""
+        now = now or datetime.now(UTC)
+        with self._lock:
+            self._prune(symbol, now)
+            self._events.setdefault(symbol, []).append((now, bool(cio_audited)))
+
+    def reset(self, symbol: str | None = None) -> None:
+        """Clear tracked events for one symbol (or all)."""
+        with self._lock:
+            if symbol is None:
+                self._events.clear()
+            else:
+                self._events.pop(symbol, None)


### PR DESCRIPTION
## Summary

Fixes the open/close thrash loop (P0 #481) where ghost strategy-tracker SHORTs drove unsolicited reduceOnly fills on BNBUSDT/LINKUSDT (2026-06-18 testnet). Adds two emission-time defenses to the close path, complementing the #480 `StrategyPositionReconciler` (which evicts the ghost rows out-of-band) and #479 SL/TP direction guard.

Implements `Closes #481`.

## Acceptance criteria

- **AC1 (reproduce)** — `tests/test_dispatcher_close_guard.py::test_ac3_blocks_close_when_no_exchange_position` seeds a real LONG on the exchange truth store and drives a close on a ghost SHORT (the exact thrash trigger), asserting the guard blocks it.
- **AC2 (identify code path)** — Root-caused to `Dispatcher.close_position_with_cleanup` (`tradeengine/dispatcher.py`), the single MARKET `reduceOnly` close-emitter. The spurious closes reach the exchange here regardless of whether the trigger originates in CIO, the dispatcher lifecycle, or the strategy tracker — so the guard lives at the emission boundary (dispatcher lifecycle layer).
- **AC3 (guard + counter)** — Before emitting the MARKET close, `close_position_with_cleanup` consults the authoritative `ExchangeTruthStore` via `_exchange_position_presence()`. When the store is ready and confidently reports **no** matching `(symbol, side)` position, the close is skipped and `strategy_close_blocked_no_exchange_position_total{symbol,side}` is incremented. An un-ready/unwired store returns `None` (unknown) and does **not** block — avoids suppressing a legitimate close on a transient read. Gated by `TE_CLOSE_GUARD_ENABLED` (default `1`). Stale OCO legs are still cancelled (harmless cleanup); only the wasteful MARKET close is suppressed.
- **AC4 (testnet observation)** — Post-deploy operator step: observe testnet for 1h with seeded ghost rows and confirm zero unsolicited fills + the two counters behaving. Cannot be exercised in CI.
- **AC5 (thrash circuit-breaker + counter)** — New `tradeengine/thrash_guard.py::ThrashCircuitBreaker`: per-symbol sliding window blocking un-audited closes once they exceed `N` within `M` minutes (defaults N=2, M=10 via `TE_THRASH_MAX_CYCLES` / `TE_THRASH_WINDOW_MINUTES`). Closes tied to a CIO decision (`cio_audited=True`) never count toward or get blocked by the breaker. Blocked emissions tick `dispatcher_thrash_circuit_open_total{symbol}`.

## Out of scope (per ticket)

- Ghost-position **generation** fix — addressed upstream by #480 reconciler.
- SL-direction bug — #479 (shipped).

## Changes

- `tradeengine/metrics.py` — two new counters.
- `tradeengine/thrash_guard.py` — new `ThrashCircuitBreaker` (in-memory, per-process last-resort valve).
- `tradeengine/dispatcher.py` — `_exchange_position_presence()` helper; AC3 guard + AC5 breaker wired into `close_position_with_cleanup`; new optional `cio_audited` param (backward-compatible with the `NakedPositionRemediator` callback and rollback caller).
- `tests/test_thrash_guard.py`, `tests/test_dispatcher_close_guard.py` — 14 new tests.

## Verification

- `ruff check` + `ruff format` clean.
- `mypy` clean on changed files.
- Full suite: **1771 passed, 13 skipped**, coverage **80.58%**.
