### PR TITLE
fix: #484 - stops-health alarm path no longer silent on violations

### DIFF
--- a/docs/grafana-trade-execution-dashboard.json
+++ b/docs/grafana-trade-execution-dashboard.json
@@ -400,6 +400,63 @@
             "unit": "short"
           }
         }
+      },
+      {
+        "title": "Stops-Health: Violations vs Alarms Delivered (#484)",
+        "type": "timeseries",
+        "gridPos": { "x": 0, "y": 36, "w": 12, "h": 8 },
+        "description": "Every stops-health violation must raise an operator alarm. 'violations' = alarms emitted + suppressed; 'alarms delivered' = alarms actually published to the NATS alerts.> path. A persistent gap between the two means alarms are being silenced — see the companion 'Silenced Alarms' stat panel.",
+        "targets": [
+          {
+            "expr": "sum(increase(petrosa_tradeengine_stops_health_alarm_emitted_total[5m])) + sum(increase(petrosa_tradeengine_stops_health_alarm_suppressed_total[5m]))",
+            "legendFormat": "violations",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(increase(petrosa_tradeengine_stops_health_alarm_emitted_total[5m]))",
+            "legendFormat": "alarms delivered",
+            "refId": "B"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short"
+          }
+        }
+      },
+      {
+        "title": "Stops-Health Silenced Alarms (gap, #484)",
+        "type": "stat",
+        "gridPos": { "x": 12, "y": 36, "w": 12, "h": 8 },
+        "description": "Alarms raised for a stops-health violation but NOT delivered to NATS — i.e. violation_count > 0 while alarms are not reaching operators. Any non-zero value is highlighted red: this is the exact silent-alarm condition (violations>0, alarms=0) that #484 fixed.",
+        "targets": [
+          {
+            "expr": "sum by (reason) (increase(petrosa_tradeengine_stops_health_alarm_suppressed_total[1h]))",
+            "legendFormat": "{{reason}}",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "green" },
+                { "value": 1, "color": "red" }
+              ]
+            }
+          }
+        },
+        "options": {
+          "reduceOptions": {
+            "values": false,
+            "calcs": ["lastNotNull"]
+          },
+          "orientation": "auto",
+          "textMode": "auto",
+          "colorMode": "background"
+        }
       }
     ],
     "templating": {

--- a/tests/test_position_stops_health.py
+++ b/tests/test_position_stops_health.py
@@ -465,3 +465,194 @@ async def test_ac3_480_atomicity_preserved_even_if_setter_raises():
     assert p.sl_order_id == sl_id
     assert p.tp_order_id == tp_id
     assert p.remediation_outcome == "both_placed"
+
+
+# ---------------------------------------------------------------------------
+# #484 — stops-health alarm path must fire on EVERY violation, regardless of
+# what remediation later claims. The 2026-06-18 testnet diagnosis surfaced
+# violation_count=12 with alarms_emitted=0 because alarms only fired on the
+# force-close branch. Alarms now route through the alerts.tradeengine.> NATS
+# path (AlertsConsumer -> Telegram, petrosa_k8s#810).
+# ---------------------------------------------------------------------------
+
+
+def _alert(delivered: bool = True):
+    """A stand-in alert publisher matching AlertPublisher.publish's kwargs."""
+    a = MagicMock()
+    a.publish = AsyncMock(return_value=delivered)
+    return a
+
+
+@pytest.mark.asyncio
+async def test_ac5_484_single_null_sl_emits_exactly_one_alarm():
+    """AC5: seed 1 position with a null SL order_id, hit stops-health, and
+    assert exactly one alarm is emitted on the alerts.> path."""
+    pos = _pos(
+        sl_order_id=None, tp_order_id="1398104567890124", stop_loss_price=45000.0
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos])
+    alert = _alert()
+
+    resp = await check_position_stops(spm, pc, exc, pub, alert_pub=alert)
+
+    assert resp.violation_count == 1
+    assert resp.alarms_emitted == 1
+    alert.publish.assert_awaited_once()
+    kwargs = alert.publish.call_args.kwargs
+    # AC2: alert_name maps to the alerts.tradeengine.stops_health_violation subject
+    assert kwargs["alert_name"] == "stops_health_violation"
+    assert kwargs["severity"] == "critical"
+    assert kwargs["payload"]["reason"] == "missing_sl"
+    assert kwargs["payload"]["strategy_position_id"] == "pos-1"
+
+
+@pytest.mark.asyncio
+async def test_ac1_484_alarm_fires_even_when_remediation_reports_both_placed():
+    """AC1: the exact production shape — positions missing BOTH stops while
+    remediation "succeeds" (both_placed). Before #484 alarms_emitted stayed 0;
+    now every violation raises an alarm regardless of remediation_outcome."""
+    positions = [
+        _pos(
+            spid=f"pos-{i}",
+            sl_order_id=None,
+            tp_order_id=None,
+            stop_loss_price=45000.0,
+            take_profit_price=55000.0,
+        )
+        for i in range(3)
+    ]
+    spm, pc, exc, pub = _mocks(memory=positions)
+    alert = _alert()
+
+    resp = await check_position_stops(spm, pc, exc, pub, alert_pub=alert)
+
+    assert resp.violation_count == 3
+    assert resp.alarms_emitted == 3
+    assert all(p.remediation_outcome == "both_placed" for p in resp.positions)
+    assert alert.publish.await_count == 3
+    assert all(
+        c.kwargs["payload"]["reason"] == "both" for c in alert.publish.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_ac1_484_force_close_path_emits_single_alarm():
+    """AC1: the force-close path (missing SL, no stop_loss_price) must raise
+    exactly one alarm — not double-counted — and still publish the legacy
+    force-close execution event for backward compatibility."""
+    pos = _pos(sl_order_id=None, tp_order_id="1398104567890124", stop_loss_price=None)
+    spm, pc, exc, pub = _mocks(memory=[pos])
+    alert = _alert()
+
+    resp = await check_position_stops(spm, pc, exc, pub, alert_pub=alert)
+
+    assert resp.positions[0].remediation_outcome == "position_closed"
+    assert resp.alarms_emitted == 1
+    alert.publish.assert_awaited_once()
+    # Backward compat: the force-close execution event is still published.
+    pub.publish.assert_called_once()
+    assert (
+        pub.publish.call_args.kwargs["event_type"] == "position_force_closed_no_stops"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ac1_484_stale_order_id_divergence_alarms_with_reason():
+    """AC1: a stored-id divergence (real-shape IDs not live on Binance) must
+    alarm with reason=stale_order_id."""
+    real_sl = "1398104567890123"
+    real_tp = "1398104567890124"
+    pos = _pos(
+        sl_order_id=real_sl,
+        tp_order_id=real_tp,
+        stop_loss_price=45000.0,
+        take_profit_price=55000.0,
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos], binance_open_ids={"9999999999999"})
+    alert = _alert()
+
+    resp = await check_position_stops(spm, pc, exc, pub, alert_pub=alert)
+
+    assert resp.alarms_emitted == 1
+    assert len(resp.divergences) == 1
+    alert.publish.assert_awaited_once()
+    assert alert.publish.call_args.kwargs["payload"]["reason"] == "stale_order_id"
+
+
+@pytest.mark.asyncio
+async def test_ac3_484_emitted_counter_increments_on_delivery():
+    """AC3: stops_health_alarm_emitted_total{reason} increments when the
+    alarm is delivered to NATS."""
+    from prometheus_client import REGISTRY
+
+    name = "petrosa_tradeengine_stops_health_alarm_emitted_total"
+    before = REGISTRY.get_sample_value(name, {"reason": "missing_sl"}) or 0.0
+
+    pos = _pos(
+        sl_order_id=None, tp_order_id="1398104567890124", stop_loss_price=45000.0
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos])
+    await check_position_stops(spm, pc, exc, pub, alert_pub=_alert(delivered=True))
+
+    after = REGISTRY.get_sample_value(name, {"reason": "missing_sl"}) or 0.0
+    assert after - before == 1.0
+
+
+@pytest.mark.asyncio
+async def test_ac3_484_suppressed_counter_increments_when_not_delivered():
+    """AC3: stops_health_alarm_suppressed_total{reason} increments when the
+    alarm is raised but NOT delivered (NATS disabled/unavailable) — the
+    silencing is operator-visible. The alarm is still counted as raised so the
+    AC1 invariant (violations>0 => alarms_emitted>0) holds."""
+    from prometheus_client import REGISTRY
+
+    name = "petrosa_tradeengine_stops_health_alarm_suppressed_total"
+    before = REGISTRY.get_sample_value(name, {"reason": "both"}) or 0.0
+
+    pos = _pos(
+        sl_order_id=None,
+        tp_order_id=None,
+        stop_loss_price=45000.0,
+        take_profit_price=55000.0,
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos])
+    resp = await check_position_stops(
+        spm, pc, exc, pub, alert_pub=_alert(delivered=False)
+    )
+
+    after = REGISTRY.get_sample_value(name, {"reason": "both"}) or 0.0
+    assert after - before == 1.0
+    assert resp.alarms_emitted == 1
+
+
+@pytest.mark.asyncio
+async def test_484_no_alarm_emitted_when_all_healthy():
+    """No violation => no alarm published and alarms_emitted stays 0."""
+    real_sl = "1398104567890123"
+    real_tp = "1398104567890124"
+    pos = _pos(sl_order_id=real_sl, tp_order_id=real_tp)
+    spm, pc, exc, pub = _mocks(memory=[pos], binance_open_ids={real_sl, real_tp})
+    alert = _alert()
+
+    resp = await check_position_stops(spm, pc, exc, pub, alert_pub=alert)
+
+    assert resp.violation_count == 0
+    assert resp.alarms_emitted == 0
+    alert.publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_484_alarm_publish_exception_never_breaks_endpoint():
+    """The alarm path is best-effort: a publisher that raises must not break
+    the endpoint, and the violation is counted as suppressed."""
+    pos = _pos(
+        sl_order_id=None, tp_order_id="1398104567890124", stop_loss_price=45000.0
+    )
+    spm, pc, exc, pub = _mocks(memory=[pos])
+    alert = MagicMock()
+    alert.publish = AsyncMock(side_effect=RuntimeError("nats exploded"))
+
+    resp = await check_position_stops(spm, pc, exc, pub, alert_pub=alert)
+
+    assert resp.violation_count == 1
+    assert resp.alarms_emitted == 1

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -225,6 +225,30 @@ dispatcher_thrash_circuit_open_total = Counter(
     ["symbol"],
 )
 
+# #484 — stops-health violation alarms. The 2026-06-18 testnet diagnosis showed
+# violation_count=12 with alarms_emitted=0: alarms only fired on the force-close
+# branch, so a "successful" (or lying) remediation silenced the operator-facing
+# alert. Every violation now raises exactly one alarm on the
+# alerts.tradeengine.> NATS path (AlertsConsumer -> Telegram, petrosa_k8s#810)
+# regardless of remediation_outcome. reason: missing_sl|missing_tp|both|stale_order_id.
+#   - emitted:    alarm published successfully to NATS (delivered).
+#   - suppressed: alarm raised but NOT delivered (NATS disabled/unavailable) so
+#                 the silencing is operator-visible instead of a silent drop.
+# emitted + suppressed partition every violation, so a dashboard can derive
+# violation_count = sum(emitted)+sum(suppressed) and the gap = suppressed with
+# zero emitted. Prometheus-only, consistent with the #480/#481 counters above.
+stops_health_alarm_emitted_total = Counter(
+    "petrosa_tradeengine_stops_health_alarm_emitted_total",
+    "Stops-health violation alarms delivered to the NATS alerts.> path",
+    ["reason"],
+)
+
+stops_health_alarm_suppressed_total = Counter(
+    "petrosa_tradeengine_stops_health_alarm_suppressed_total",
+    "Stops-health violation alarms raised but not delivered (NATS disabled/unavailable)",
+    ["reason"],
+)
+
 # ========================================
 # Business Metrics for Trade Execution Monitoring
 # ========================================

--- a/tradeengine/position_health_guard.py
+++ b/tradeengine/position_health_guard.py
@@ -7,6 +7,11 @@ from pydantic import BaseModel, field_validator
 
 from contracts.order import TradeOrder
 from shared.constants import UTC
+from tradeengine.metrics import (
+    stops_health_alarm_emitted_total,
+    stops_health_alarm_suppressed_total,
+)
+from tradeengine.services.alert_publisher import alert_publisher
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +111,12 @@ async def check_position_stops(
     position_client: Any,
     exchange: Any,
     event_publisher: Any,
+    alert_pub: Any | None = None,
 ) -> PositionStopsHealthResponse:
+    # #484: alarms route through the alerts.tradeengine.> NATS path
+    # (AlertsConsumer -> Telegram, petrosa_k8s#810). Default to the module
+    # singleton; injectable so tests can assert emission without NATS.
+    publisher = alert_pub if alert_pub is not None else alert_publisher
     try:
         memory_positions: list[dict[str, Any]] = (
             strategy_pos_manager.get_all_open_strategy_positions()
@@ -188,6 +198,10 @@ async def check_position_stops(
         has_tp = tp_order_id is not None
         src = source_map.get(spid, "memory")
         symbol_for_pos = pos.get("symbol", "unknown")
+        # #484: track whether this violation is a stored-id divergence
+        # (stored order id not live on Binance / not a real algo id) so the
+        # alarm reason is "stale_order_id" rather than a plain missing_*.
+        is_divergence = False
 
         if has_sl and has_tp:
             # AC3 of #424: verify on Binance before declaring healthy.
@@ -229,6 +243,7 @@ async def check_position_stops(
 
             # Verification ran AND the stored IDs are not both present on
             # Binance — record a divergence and fall through to remediation.
+            is_divergence = True
             divergences.append(
                 StopsDivergence(
                     strategy_position_id=spid,
@@ -266,6 +281,53 @@ async def check_position_stops(
             pstatus = "missing_sl"
         else:
             pstatus = "missing_tp"
+
+        # AC1/AC2/AC3 of #484: every violation raises exactly one operator
+        # alarm on the alerts.tradeengine.> NATS path, BEFORE (and independent
+        # of) remediation. The 2026-06-18 testnet diagnosis (violation_count=12,
+        # alarms_emitted=0) happened because alarms only fired on the
+        # force-close branch, so a "successful"/lying remediation silenced the
+        # alert. The alarm fires off the ground-truth missing/stale state.
+        if is_divergence:
+            alarm_reason = "stale_order_id"
+        elif pstatus == "missing_both":
+            alarm_reason = "both"
+        elif pstatus == "missing_sl":
+            alarm_reason = "missing_sl"
+        else:
+            alarm_reason = "missing_tp"
+
+        try:
+            alarm_delivered = await publisher.publish(
+                alert_name="stops_health_violation",
+                severity="critical",
+                payload={
+                    "strategy_position_id": spid,
+                    "symbol": symbol_for_pos,
+                    "side": pos.get("side", "unknown"),
+                    "reason": alarm_reason,
+                    "status": pstatus,
+                    "sl_order_id": (
+                        str(sl_order_id) if sl_order_id is not None else None
+                    ),
+                    "tp_order_id": (
+                        str(tp_order_id) if tp_order_id is not None else None
+                    ),
+                },
+            )
+        except Exception as exc:
+            # The alarm path is best-effort and must never break the endpoint.
+            logger.error("stops-health alarm publish raised for %s: %s", spid, exc)
+            alarm_delivered = False
+
+        # AC1: an alarm is RAISED for every violation regardless of delivery,
+        # so alarms_emitted > 0 whenever violation_count > 0. The emitted vs
+        # suppressed counters (AC3) split raised alarms by NATS delivery.
+        alarms_emitted += 1
+        if alarm_delivered:
+            stops_health_alarm_emitted_total.labels(reason=alarm_reason).inc()
+        else:
+            stops_health_alarm_suppressed_total.labels(reason=alarm_reason).inc()
 
         symbol = pos.get("symbol", "unknown")
         position_side = pos.get("side", "LONG")
@@ -416,7 +478,10 @@ async def check_position_stops(
                     spid,
                     strategy_id,
                 )
-                alarms_emitted += 1
+                # #484: alarms_emitted is now incremented once per violation
+                # (above, at detection) regardless of remediation outcome, so
+                # the force-close branch no longer counts a second alarm. The
+                # force-close execution event below remains for backward compat.
             except Exception as exc:
                 logger.error("Failed to close position %s: %s", spid, exc)
                 outcome = "close_failed"


### PR DESCRIPTION
## Summary

Fixes the silent stops-health alarm path. On 2026-06-18 testnet, `/positions/stops-health` reported `violation_count=12` with `alarms_emitted=0` because `alarms_emitted` was only incremented inside the **force-close** branch. Any remediation that "succeeded" (or lied about `remediation_outcome=both_placed`) therefore silenced the operator-facing alert during exactly the conditions the probe was built to detect.

## Root cause

`check_position_stops()` incremented `alarms_emitted` in one place only — after a successful force-close. Violations that were remediated (`sl_placed`/`tp_placed`/`both_placed`) raised no alarm, and even the force-close alarm went to the `execution.events` path, not the `alerts.>` path operators watch.

## Changes (by AC)

- **AC1** — Every violation now raises exactly one alarm at *detection*, before and independent of remediation, off the ground-truth missing/stale state. `alarms_emitted` counts raised alarms, so `violation_count > 0` ⇒ `alarms_emitted > 0`.
- **AC2** — Alarms route through the canonical `AlertPublisher` on subject `alerts.tradeengine.stops_health_violation` (AlertsConsumer → Telegram, petrosa_k8s#810). The publisher is injectable so tests assert emission without NATS.
- **AC3** — New counters `petrosa_tradeengine_stops_health_alarm_emitted_total{reason}` (delivered) and `petrosa_tradeengine_stops_health_alarm_suppressed_total{reason}` (raised but not delivered — makes silencing operator-visible). `reason = missing_sl | missing_tp | both | stale_order_id`. Prometheus-only, matching the #480/#481 counter precedent.
- **AC4** — Two panels in `docs/grafana-trade-execution-dashboard.json`: "Violations vs Alarms Delivered" (violations = emitted+suppressed) and a red-highlighted "Silenced Alarms (gap)" stat that lights up on any `violations>0, alarms=0` condition.
- **AC5** — Regression tests: seed a position with a null SL order_id → assert exactly 1 alarm; the production `both_placed` shape still alarms; divergence → `stale_order_id`; force-close counts a single alarm; emitted/suppressed counters; and best-effort behaviour when the publisher raises.

The alarm path is best-effort and never breaks the endpoint. The legacy force-close execution event is retained for backward compatibility.

## Testing

- `tests/test_position_stops_health.py`: 26 passed (19 existing + 7 new).
- Full suite: **1779 passed, 13 skipped, 80.62% coverage**.
- `ruff check`/`ruff format`/`gitleaks`/`bandit`/`check-test-assertions`: all pass. No new `mypy` errors (50 pre-existing on `main`, unchanged).

## Notes

- Naming: metrics use the repo-dominant `petrosa_tradeengine_*` prefix; the `{reason}` label and semantics match AC3 exactly.
- Out of scope (per ticket): the ghost-remediation `both_placed` lie, OCO atomicity null-id bug, and SL-geometry bug are separate tickets.

Closes #484
