### PR TITLE
[BUG] fix: datetime JSON serialization errors in strategy position persist paths (#495)

### DIFF
--- a/shared/logger.py
+++ b/shared/logger.py
@@ -144,9 +144,15 @@ class AuditLogger:
                         ),
                         {
                             "timestamp": audit_record["timestamp"],
-                            "order_data": json.dumps(audit_record["order_data"]),
-                            "result_data": json.dumps(audit_record["result_data"]),
-                            "signal_meta": json.dumps(audit_record["signal_meta"]),
+                            "order_data": json.dumps(
+                                audit_record["order_data"], default=str
+                            ),
+                            "result_data": json.dumps(
+                                audit_record["result_data"], default=str
+                            ),
+                            "signal_meta": json.dumps(
+                                audit_record["signal_meta"], default=str
+                            ),
                         },
                     )
                     await session.commit()

--- a/shared/mysql_client.py
+++ b/shared/mysql_client.py
@@ -288,7 +288,7 @@ class DataManagerPositionClient:
                 record={
                     "date": date,
                     "daily_pnl": daily_pnl,
-                    "updated_at": datetime.now(UTC),
+                    "updated_at": datetime.now(UTC).isoformat(),
                 },
             )
             logger.info(

--- a/tests/integration/test_duplicate_signals.py
+++ b/tests/integration/test_duplicate_signals.py
@@ -68,6 +68,38 @@ def mock_audit_logger():
             yield
 
 
+@pytest.fixture(autouse=True)
+def mock_strategy_position_data_manager():
+    """Mock data-manager HTTP client used by StrategyPositionManager.
+
+    Without this mock, strategy position persistence makes real HTTP calls to
+    data-manager (which is not running in unit/integration test environments).
+    Before the fix for #495 these calls failed with a TypeError on datetime
+    serialization before reaching the network; after the fix they fail with a
+    ConnectionError.  The ConnectionError triggers retry backoff (1.7s) which
+    corrupts the timing-sensitive TTL assertions in this test module.
+
+    Mocking the transport layer (not the high-level client) prevents any
+    network calls while leaving the in-memory business logic intact.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": "ok", "data": []}
+
+    async def _fake_request(*args, **kwargs):
+        return mock_response
+
+    with patch(
+        "tradeengine.services.data_manager_client.BaseDataManagerClient._retry_request",
+        new_callable=lambda: lambda self: AsyncMock(
+            return_value={"status": "ok", "data": []}
+        ),
+    ):
+        yield
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_duplicate_signal_rejected(dispatcher_with_fakes):

--- a/tests/test_data_manager_config_client.py
+++ b/tests/test_data_manager_config_client.py
@@ -76,7 +76,12 @@ class TestSetGlobalConfig:
 
     @pytest.mark.asyncio
     async def test_set_global_config_updates_timestamp(self, data_manager_client):
-        """Test that set_global_config adds updated_at timestamp"""
+        """Test that set_global_config adds updated_at as an ISO-8601 string.
+
+        After the fix for petrosa-tradeengine#495 (datetime not JSON serializable),
+        updated_at is pre-converted to an ISO-8601 string so the httpx transport
+        never encounters a raw datetime object.
+        """
         # Arrange
         config = TradingConfig(parameters={"enabled": True}, created_by="test_agent")
 
@@ -87,7 +92,13 @@ class TestSetGlobalConfig:
         call_args = data_manager_client._client.upsert_one.call_args
         record = call_args.kwargs["record"]
         assert "updated_at" in record
-        assert isinstance(record["updated_at"], datetime)
+        # Must be a pre-serialized ISO-8601 string, not a raw datetime (#495 fix)
+        assert isinstance(record["updated_at"], str), (
+            "updated_at must be a pre-serialized ISO-8601 string, not a raw datetime"
+        )
+        # Must parse as valid ISO-8601
+        parsed = datetime.fromisoformat(record["updated_at"])
+        assert parsed is not None
 
     @pytest.mark.asyncio
     async def test_set_global_config_excludes_id(self, data_manager_client):

--- a/tests/test_data_manager_position_client.py
+++ b/tests/test_data_manager_position_client.py
@@ -60,7 +60,13 @@ class TestUpdateDailyPnL:
 
     @pytest.mark.asyncio
     async def test_update_daily_pnl_uses_timezone_aware_datetime(self, position_client):
-        """Test that update_daily_pnl uses timezone-aware datetime"""
+        """Test that update_daily_pnl stores updated_at as an ISO-8601 string.
+
+        After the fix for petrosa-tradeengine#495 (datetime not JSON serializable),
+        updated_at is pre-converted to an ISO-8601 string before being stored
+        so that the httpx transport layer never encounters a raw datetime object.
+        The string must include timezone offset information (+00:00 or similar).
+        """
         # Arrange
         position_client.data_manager_client._client.upsert_one = AsyncMock(
             return_value={"upserted_id": "test_id"}
@@ -72,9 +78,13 @@ class TestUpdateDailyPnL:
         # Assert
         call_args = position_client.data_manager_client._client.upsert_one.call_args
         updated_at = call_args.kwargs["record"]["updated_at"]
-        # Verify it's a datetime object with timezone info
-        assert isinstance(updated_at, datetime)
-        assert updated_at.tzinfo is not None
+        # Verify it's an ISO-8601 string (not a raw datetime — #495 fix)
+        assert isinstance(updated_at, str), (
+            "updated_at must be a pre-serialized ISO-8601 string, not a raw datetime"
+        )
+        # Must be parseable as ISO-8601 and carry timezone info
+        parsed = datetime.fromisoformat(updated_at)
+        assert parsed.tzinfo is not None, "updated_at string must encode timezone info"
 
     @pytest.mark.asyncio
     async def test_update_daily_pnl_failure(self, position_client):

--- a/tests/test_datetime_serialization.py
+++ b/tests/test_datetime_serialization.py
@@ -1,0 +1,332 @@
+"""Tests for datetime JSON serialization fixes (petrosa-tradeengine#495).
+
+AC1: Reproduce the 'Object of type datetime is not JSON serializable' failure
+     in unit tests that persist strategy positions / exchange positions /
+     contributions / daily P&L carrying datetime fields.
+AC3: Assert that a round-trip persist succeeds with tz-aware and naive datetimes.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shared.constants import UTC
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_http_client():
+    """An httpx.AsyncClient mock that captures the json= argument."""
+    mock = MagicMock()
+    mock.request = AsyncMock()
+    mock.request.return_value = MagicMock(
+        status_code=200, json=MagicMock(return_value={"status": "ok"})
+    )
+    return mock
+
+
+@pytest.fixture
+def dm_client(mock_http_client):
+    """A BaseDataManagerClient with an injected mock HTTP client."""
+    from tradeengine.services.data_manager_client import BaseDataManagerClient
+
+    client = BaseDataManagerClient.__new__(BaseDataManagerClient)
+    client._client = mock_http_client
+    client.max_retries = 1
+    client.retry_delay = 0.0
+    client.base_url = "http://localhost:8001"
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests for _serialize_for_http helper
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeForHttp:
+    """Unit tests for the _serialize_for_http / _json_default helpers."""
+
+    def test_tz_aware_datetime_is_serialized_to_isoformat(self):
+        """A tz-aware datetime inside a dict round-trips through JSON as a string."""
+        from tradeengine.services.data_manager_client import _serialize_for_http
+
+        now = datetime.now(UTC)
+        payload = {"entry_time": now, "symbol": "BTCUSDT"}
+        result = _serialize_for_http(payload)
+
+        assert isinstance(result["entry_time"], str), (
+            "datetime must be converted to str by _serialize_for_http"
+        )
+        # Verify the string is parseable ISO-8601
+        parsed = datetime.fromisoformat(result["entry_time"])
+        assert parsed is not None
+
+    def test_naive_datetime_is_serialized_to_isoformat(self):
+        """A naive datetime (no tzinfo) is also serialized without error."""
+        from tradeengine.services.data_manager_client import _serialize_for_http
+
+        naive = datetime(2026, 7, 1, 12, 0, 0)  # no tzinfo
+        payload = {"created_at": naive}
+        result = _serialize_for_http(payload)
+
+        assert isinstance(result["created_at"], str)
+        assert "2026-07-01" in result["created_at"]
+
+    def test_none_body_returns_none(self):
+        """None body is returned unchanged."""
+        from tradeengine.services.data_manager_client import _serialize_for_http
+
+        assert _serialize_for_http(None) is None
+
+    def test_non_datetime_values_are_preserved(self):
+        """Strings, ints, floats, bools, and None values are left unchanged."""
+        from tradeengine.services.data_manager_client import _serialize_for_http
+
+        payload = {
+            "symbol": "BTCUSDT",
+            "qty": 0.001,
+            "price": 50000.0,
+            "active": True,
+            "note": None,
+        }
+        result = _serialize_for_http(payload)
+        assert result == payload
+
+    def test_nested_datetime_is_serialized(self):
+        """Datetimes nested in sub-dicts or lists are also converted."""
+        from tradeengine.services.data_manager_client import _serialize_for_http
+
+        now = datetime.now(UTC)
+        payload = {
+            "position": {"entry_time": now, "symbol": "ETHUSDT"},
+            "timestamps": [now],
+        }
+        result = _serialize_for_http(payload)
+
+        assert isinstance(result["position"]["entry_time"], str)
+        assert isinstance(result["timestamps"][0], str)
+
+    def test_unknown_non_serializable_type_raises_type_error(self):
+        """A non-datetime, non-JSON-native object still raises TypeError."""
+        from tradeengine.services.data_manager_client import _serialize_for_http
+
+        class _Custom:
+            pass
+
+        with pytest.raises(TypeError) as exc_info:
+            _serialize_for_http({"bad": _Custom()})
+        assert "not JSON serializable" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# AC1: Reproduce the original failure (before the fix this would crash)
+# AC3: After fix, the round-trip succeeds
+# ---------------------------------------------------------------------------
+
+
+class TestRetryRequestDatetimeSerialization:
+    """_retry_request must not raise TypeError for datetime-bearing payloads."""
+
+    @pytest.mark.asyncio
+    async def test_strategy_position_with_entry_time_does_not_raise(
+        self, dm_client, mock_http_client
+    ):
+        """AC1+AC3: persist a strategy position carrying a tz-aware entry_time."""
+        now = datetime.now(UTC)
+        body = {
+            "strategy_id": "test-strategy",
+            "symbol": "BTCUSDT",
+            "side": "LONG",
+            "status": "open",
+            "entry_price": 50000.0,
+            "entry_time": now,  # ← this was the crash field
+        }
+
+        # Should NOT raise TypeError
+        await dm_client._retry_request("POST", "/api/v1/data/insert", json_body=body)
+
+        mock_http_client.request.assert_called_once()
+        # The actual json= arg passed to httpx must be JSON-safe
+        call_kwargs = mock_http_client.request.call_args.kwargs
+        serialized_body = call_kwargs["json"]
+        # Verify the datetime was converted to an ISO string
+        assert isinstance(serialized_body["entry_time"], str)
+        json.dumps(serialized_body)  # Must not raise
+
+    @pytest.mark.asyncio
+    async def test_exchange_position_with_last_update_time_does_not_raise(
+        self, dm_client, mock_http_client
+    ):
+        """AC1+AC3: persist an exchange position carrying last_update_time."""
+        now = datetime.now(UTC)
+        body = {
+            "symbol": "BNBUSDT",
+            "side": "SHORT",
+            "first_entry_time": now,
+            "last_update_time": now,
+            "notional": 100.0,
+        }
+
+        await dm_client._retry_request("POST", "/api/v1/data/insert", json_body=body)
+
+        call_kwargs = mock_http_client.request.call_args.kwargs
+        serialized_body = call_kwargs["json"]
+        assert isinstance(serialized_body["first_entry_time"], str)
+        assert isinstance(serialized_body["last_update_time"], str)
+        json.dumps(serialized_body)
+
+    @pytest.mark.asyncio
+    async def test_contribution_with_contribution_time_does_not_raise(
+        self, dm_client, mock_http_client
+    ):
+        """AC1+AC3: persist a contribution carrying contribution_time."""
+        now = datetime.now(UTC)
+        body = {
+            "strategy_position_id": "uuid-abc",
+            "symbol": "LTCUSDT",
+            "contribution_time": now,
+            "amount": 0.5,
+        }
+
+        await dm_client._retry_request("POST", "/api/v1/data/insert", json_body=body)
+
+        call_kwargs = mock_http_client.request.call_args.kwargs
+        serialized_body = call_kwargs["json"]
+        assert isinstance(serialized_body["contribution_time"], str)
+        json.dumps(serialized_body)
+
+    @pytest.mark.asyncio
+    async def test_naive_datetime_in_payload_does_not_raise(
+        self, dm_client, mock_http_client
+    ):
+        """AC3: naive datetime (no tzinfo) is also handled without error."""
+        naive = datetime(2026, 7, 2, 8, 0, 0)  # no tzinfo
+        body = {"entry_time": naive, "symbol": "DOTUSDT"}
+
+        await dm_client._retry_request("POST", "/api/v1/data/insert", json_body=body)
+
+        call_kwargs = mock_http_client.request.call_args.kwargs
+        assert isinstance(call_kwargs["json"]["entry_time"], str)
+
+    @pytest.mark.asyncio
+    async def test_exit_time_in_close_payload_does_not_raise(
+        self, dm_client, mock_http_client
+    ):
+        """AC1+AC3: closing a position sets exit_time — must not raise."""
+        now = datetime.now(UTC)
+        body = {
+            "strategy_position_id": "uuid-xyz",
+            "status": "closed",
+            "exit_time": now,
+            "exit_price": 51000.0,
+        }
+
+        await dm_client._retry_request("PUT", "/api/v1/data/update", json_body=body)
+
+        call_kwargs = mock_http_client.request.call_args.kwargs
+        assert isinstance(call_kwargs["json"]["exit_time"], str)
+
+
+# ---------------------------------------------------------------------------
+# AC1+AC3: DataManagerPositionClient.update_daily_pnl — updated_at is now str
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateDailyPnLSerializesDatetime:
+    """The updated_at field in update_daily_pnl must arrive as a string (not datetime)."""
+
+    @pytest.mark.asyncio
+    async def test_updated_at_is_isoformat_string(self):
+        """AC3: update_daily_pnl stores updated_at as ISO string, not raw datetime."""
+        from shared.mysql_client import DataManagerPositionClient
+
+        mock_dm = MagicMock()
+        mock_dm._client = AsyncMock()
+        mock_dm._client.upsert_one = AsyncMock(return_value={"upserted_id": "x"})
+
+        with patch("shared.mysql_client.DataManagerClient", return_value=mock_dm):
+            client = DataManagerPositionClient()
+            client.data_manager_client = mock_dm
+
+        await client.update_daily_pnl("2026-07-02", 250.0)
+
+        call_args = mock_dm._client.upsert_one.call_args
+        updated_at = call_args.kwargs["record"]["updated_at"]
+
+        # Must be a string, not a datetime
+        assert isinstance(updated_at, str), (
+            "updated_at must be an ISO-8601 string, not a raw datetime object"
+        )
+        # Must parse as ISO-8601
+        parsed = datetime.fromisoformat(updated_at)
+        assert parsed is not None
+
+    @pytest.mark.asyncio
+    async def test_updated_at_contains_timezone_info(self):
+        """AC3: The ISO-8601 string retains timezone offset information."""
+        from shared.mysql_client import DataManagerPositionClient
+
+        mock_dm = MagicMock()
+        mock_dm._client = AsyncMock()
+        mock_dm._client.upsert_one = AsyncMock(return_value={"upserted_id": "x"})
+
+        with patch("shared.mysql_client.DataManagerClient", return_value=mock_dm):
+            client = DataManagerPositionClient()
+            client.data_manager_client = mock_dm
+
+        await client.update_daily_pnl("2026-07-02", 250.0)
+
+        call_args = mock_dm._client.upsert_one.call_args
+        updated_at = call_args.kwargs["record"]["updated_at"]
+
+        # ISO-8601 UTC string includes '+00:00' or 'Z'
+        assert "+" in updated_at or updated_at.endswith("Z") or "UTC" in updated_at, (
+            f"updated_at '{updated_at}' does not appear to have timezone info"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC1+AC3: logger.py json.dumps with default=str
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLoggerJsonDumps:
+    """shared/logger.py json.dumps calls must not crash on datetime-bearing dicts."""
+
+    def _make_order_data_with_datetime(self) -> dict:
+        return {
+            "type": "LIMIT",
+            "side": "BUY",
+            "symbol": "BCHUSDT",
+            "created_at": datetime.now(UTC),  # raw datetime in order payload
+        }
+
+    def test_json_dumps_order_data_with_datetime_does_not_raise(self):
+        """AC1: json.dumps with default=str handles datetime in order_data."""
+        order_data = self._make_order_data_with_datetime()
+        # This is what logger.py does after the fix
+        result = json.dumps(order_data, default=str)
+        parsed = json.loads(result)
+        assert isinstance(parsed["created_at"], str)
+
+    def test_json_dumps_result_data_with_datetime_does_not_raise(self):
+        """AC1: json.dumps with default=str handles datetime in result_data."""
+        result_data = {
+            "order_id": "12345678901234",
+            "executed_at": datetime.now(UTC),
+        }
+        serialized = json.dumps(result_data, default=str)
+        parsed = json.loads(serialized)
+        assert isinstance(parsed["executed_at"], str)
+
+    def test_json_dumps_without_default_raises_for_datetime(self):
+        """Baseline: confirms the original bug — json.dumps without default= raises."""
+        order_data = self._make_order_data_with_datetime()
+        with pytest.raises(TypeError, match="not JSON serializable") as exc_info:
+            json.dumps(order_data)  # no default= — must raise
+        assert "datetime" in str(exc_info.value).lower()

--- a/tradeengine/services/data_manager_client.py
+++ b/tradeengine/services/data_manager_client.py
@@ -11,10 +11,11 @@ endpoints with bounded retry-with-backoff.
 """
 
 import asyncio
+import json
 import logging
 import os
 import random
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Optional
 
 import httpx
@@ -23,6 +24,26 @@ from contracts.trading_config import LeverageStatus, TradingConfig, TradingConfi
 from shared.constants import UTC
 
 logger = logging.getLogger(__name__)
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON serializer for objects not serializable by default json module.
+
+    Converts datetime/date objects to ISO-8601 strings so they can be sent
+    over the wire via httpx's json= parameter (which uses stdlib json.dumps
+    internally).  Fixes the 'Object of type datetime is not JSON serializable'
+    error seen at ~3.5/min on the live pod (petrosa-tradeengine#495).
+    """
+    if isinstance(obj, datetime | date):
+        return obj.isoformat()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def _serialize_for_http(body: Any) -> Any:
+    """Round-trip body through json.dumps/_json_default so httpx never sees a datetime."""
+    if body is None:
+        return None
+    return json.loads(json.dumps(body, default=_json_default))
 
 
 class APIError(Exception):
@@ -112,6 +133,11 @@ class BaseDataManagerClient:
         params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Issue an HTTP request with bounded retry-with-backoff."""
+        # Pre-serialize datetime/date objects to ISO-8601 strings so that
+        # httpx's internal json.dumps never encounters them.
+        # Fixes petrosa-tradeengine#495 ('Object of type datetime is not JSON
+        # serializable' at ~3.5/min on the live pod).
+        json_body = _serialize_for_http(json_body)
         client = await self._get_client()
         last_exc: Exception | None = None
         for attempt in range(self.max_retries):
@@ -401,7 +427,7 @@ class DataManagerClient:
         """Set global trading configuration."""
         try:
             config_dict = config.model_dump(exclude={"id"})
-            config_dict["updated_at"] = datetime.now(UTC)
+            config_dict["updated_at"] = datetime.now(UTC).isoformat()
 
             result = await self._client.upsert_one(
                 database="mongodb",
@@ -467,7 +493,7 @@ class DataManagerClient:
                 return False
 
             config_dict = config.model_dump(exclude={"id"})
-            config_dict["updated_at"] = datetime.now(UTC)
+            config_dict["updated_at"] = datetime.now(UTC).isoformat()
 
             result = await self._client.upsert_one(
                 database="mongodb",
@@ -537,7 +563,7 @@ class DataManagerClient:
                 return False
 
             config_dict = config.model_dump(exclude={"id"})
-            config_dict["updated_at"] = datetime.now(UTC)
+            config_dict["updated_at"] = datetime.now(UTC).isoformat()
 
             result = await self._client.upsert_one(
                 database="mongodb",
@@ -659,7 +685,7 @@ class DataManagerClient:
         """Set leverage status for symbol."""
         try:
             status_dict = status.model_dump(exclude={"id"})
-            status_dict["updated_at"] = datetime.now(UTC)
+            status_dict["updated_at"] = datetime.now(UTC).isoformat()
 
             result = await self._client.upsert_one(
                 database="mongodb",


### PR DESCRIPTION
## Summary

Fixes #495

## Root Cause

Raw `datetime` objects in position/contribution/exchange-position payloads were passed to `httpx`'s `json=` parameter, which calls `stdlib json.dumps` internally with no custom encoder. This raised `'Object of type datetime is not JSON serializable'` at ~3.5/min on the live pod.

## Changes

### Primary fix (transport boundary)
`tradeengine/services/data_manager_client.py`
- Added `_json_default(obj)` — custom JSON encoder for `datetime`/`date` → ISO-8601 string
- Added `_serialize_for_http(body)` — pre-serializes any payload via `json.dumps(default=_json_default)` before passing to httpx
- `_retry_request()` now calls `_serialize_for_http(json_body)` before the HTTP loop — covers all callers

### Defensive fixes (explicit .isoformat())
- 4 sites in `data_manager_client.py`: `set_global_config`, `set_symbol_config`, `set_symbol_side_config`, `set_leverage_status`
- 1 site in `shared/mysql_client.py`: `update_daily_pnl`

### Audit logger
- `shared/logger.py`: added `default=str` to all 3 `json.dumps()` calls for `order_data`, `result_data`, `signal_meta`

## Tests

- **New** `tests/test_datetime_serialization.py`: 16 tests covering AC1 (reproduce original failure) and AC3 (round-trip succeeds with tz-aware + naive datetimes)
- **Updated** `test_data_manager_position_client.py`, `test_data_manager_config_client.py`: assert `updated_at` is now ISO-8601 string
- **Fixed** `tests/integration/test_duplicate_signals.py`: added `autouse` mock for data-manager transport (was masked by datetime TypeError; now reaches network causing timing drift)

## Coverage & CI

- 1796 passed, 0 failed, 12 skipped
- Coverage: **80.55%** (required: 40%)
- All pre-commit hooks pass (ruff, bandit, gitleaks, test-assertions)