### PR TITLE
test: adversarial red-first suite for naked-position cluster (#500–#505)

### DIFF
--- a/tests/test_adversarial_500_watchdog_mode.py
+++ b/tests/test_adversarial_500_watchdog_mode.py
@@ -1,0 +1,157 @@
+"""Adversarial tests for tradeengine#500 — naked-position watchdog runs 'off' in prod.
+
+The `NakedPositionRemediator` is constructed and started every boot, but in
+production ``TE_NAKED_POSITION_REMEDIATION_MODE`` is unset so it defaults to
+``off`` (shared/config.py:100). In ``off`` mode ``remediate()`` only increments
+``naked_position_detected_total`` and takes NO write action — so real naked
+positions are detected and then ignored (the 2026-07-16 free-for-all).
+
+These tests lock in the mode-behavior contract:
+  - off / dry_run       → NEVER re-arm or flatten (no exchange writes)
+  - arm_only            → re-arms, never flattens
+  - arm_or_flatten      → re-arms, and flattens after grace
+
+They PASS today (they document the intended per-mode contract). The #500 fix is
+a deployment/config change (set the env, surface the mode, alert on off) rather
+than a code-logic change — so these serve as the regression guard ensuring the
+enforcement code paths actually do work once the mode is flipped, and a
+canary/config test (below) documents the prod-safety requirement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tradeengine.naked_position_remediator import NakedPositionRemediator
+
+
+class _Rec:
+    """Minimal async-callable spies for exchange/close/position_manager."""
+
+    def __init__(self) -> None:
+        self.execute_calls: list = []
+        self.close_calls: list = []
+
+    async def execute(self, order: object) -> dict:
+        self.execute_calls.append(order)
+        return {"order_id": "1000000000000001", "status": "NEW"}
+
+    async def close(self, **kwargs: object) -> dict:
+        self.close_calls.append(kwargs)
+        return {"status": "closed"}
+
+    def get_positions(self) -> dict:
+        return {}
+
+
+def _divergence() -> dict:
+    return {
+        "symbol": "ETHUSDT",
+        "side": "LONG",
+        "binance_qty": 0.052,
+        "sl_present": False,
+        "tp_present": False,
+    }
+
+
+def _make(mode: str, clock_vals: list[float]) -> tuple[NakedPositionRemediator, _Rec]:
+    rec = _Rec()
+    it = iter(clock_vals)
+    last = [clock_vals[0]]
+
+    def clock() -> float:
+        try:
+            last[0] = next(it)
+        except StopIteration:
+            pass
+        return last[0]
+
+    rem = NakedPositionRemediator(
+        exchange=rec,  # type: ignore[arg-type]
+        position_manager=rec,  # type: ignore[arg-type]
+        close_position=rec.close,
+        mode=mode,  # type: ignore[arg-type]
+        flatten_grace_sec=60,
+        clock=clock,
+    )
+    return rem, rec
+
+
+class TestOffModeIsNoOp:
+    @pytest.mark.asyncio
+    async def test_off_mode_never_writes(self) -> None:
+        rem, rec = _make("off", [0.0, 0.0])
+        counts = await rem.remediate(
+            [_divergence()], {("ETHUSDT", "LONG"): {"entryPrice": 1876.0}}
+        )
+        assert counts["detected"] == 1
+        assert counts["skipped"] == 1
+        assert counts["armed"] == 0 and counts["flattened"] == 0
+        assert rec.execute_calls == [] and rec.close_calls == []
+
+    @pytest.mark.asyncio
+    async def test_dry_run_never_writes(self) -> None:
+        rem, rec = _make("dry_run", [0.0, 0.0])
+        counts = await rem.remediate(
+            [_divergence()], {("ETHUSDT", "LONG"): {"entryPrice": 1876.0}}
+        )
+        assert counts["detected"] == 1
+        assert counts["skipped"] == 1
+        assert rec.execute_calls == [] and rec.close_calls == []
+
+
+class TestEnforcementModesDoAct:
+    @pytest.mark.asyncio
+    async def test_arm_only_rearms(self) -> None:
+        rem, rec = _make("arm_only", [0.0, 0.0])
+        counts = await rem.remediate(
+            [_divergence()], {("ETHUSDT", "LONG"): {"entryPrice": 1876.0}}
+        )
+        assert counts["armed"] >= 1
+        assert len(rec.execute_calls) >= 1  # SL and/or TP re-armed
+        assert rec.close_calls == []  # arm_only never flattens
+
+    @pytest.mark.asyncio
+    async def test_arm_or_flatten_flattens_after_grace(self) -> None:
+        # first_seen at t=0, then t=120 (> 60s grace) → flatten
+        rem, rec = _make("arm_or_flatten", [0.0, 120.0])
+        # First pass registers first_seen at t=0
+        await rem.remediate(
+            [_divergence()], {("ETHUSDT", "LONG"): {"entryPrice": 1876.0}}
+        )
+        # Second pass at t=120 → grace expired → flatten
+        counts = await rem.remediate(
+            [_divergence()], {("ETHUSDT", "LONG"): {"entryPrice": 1876.0}}
+        )
+        assert counts["flattened"] >= 1
+        assert len(rec.close_calls) >= 1
+
+
+class TestUnknownModeFailsSafe:
+    @pytest.mark.asyncio
+    async def test_unknown_mode_coerces_to_off(self) -> None:
+        rem, rec = _make("garbage_mode", [0.0, 0.0])
+        assert rem.mode == "off"
+        counts = await rem.remediate(
+            [_divergence()], {("ETHUSDT", "LONG"): {"entryPrice": 1876.0}}
+        )
+        assert rec.execute_calls == [] and rec.close_calls == []
+        assert counts["skipped"] == 1
+
+
+class TestProdConfigSafety:
+    """The #500 fix requirement: prod must not silently run 'off'."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#500: default remediation mode is 'off' — a fresh deploy is "
+        "silently non-enforcing. Fix should default to at least 'dry_run'.",
+    )
+    def test_default_mode_is_not_silently_off(self) -> None:
+        from shared.config import Settings
+
+        mode = str(Settings().naked_position_remediation_mode).lower()
+        assert mode != "off", (
+            "Default naked_position_remediation_mode is 'off' — deploys run "
+            "detection-only with no enforcement (#500)"
+        )

--- a/tests/test_adversarial_501_market_fill_price.py
+++ b/tests/test_adversarial_501_market_fill_price.py
@@ -1,0 +1,109 @@
+"""Adversarial tests for tradeengine#501 — MARKET fill_price collapses to 0.
+
+`BinanceFuturesExchange._format_execution_result` (tradeengine/exchange/binance.py
+:1343) computes:
+
+    "fill_price": result.get("price") or result.get("triggerPrice")
+
+For a Binance FUTURES MARKET order the response returns ``price = "0.00000000"``
+and no ``triggerPrice`` — the real average fill lives in ``fills[]`` (or
+``cumQuote``/``executedQty``). The method already computes
+``total_quote_qty = sum(quoteQty)`` and ``total_qty = sum(qty)`` from ``fills``
+but throws them away for ``fill_price``. Result: ``fill_price`` is 0/None, the
+dispatcher falls back to the unvalidated ``signal.current_price`` as the SL/TP
+reference anchor, and every protective order is computed off a possibly-stale
+number.
+
+Correct behavior: for a filled MARKET order, ``fill_price`` must equal the
+volume-weighted average fill = ``total_quote_qty / total_qty``.
+
+xfail(strict) → red now, flips loud when #501 lands.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from contracts.order import OrderStatus, TradeOrder
+
+
+def _market_order() -> TradeOrder:
+    return TradeOrder(
+        symbol="BCHUSDT",
+        side="buy",
+        type="market",
+        amount=0.22,
+        status=OrderStatus.PENDING,
+        position_side="LONG",
+    )
+
+
+def _binance_market_response() -> dict:
+    """Realistic Binance futures MARKET response: price='0', real fill in fills[].
+
+    0.22 filled: 0.1 @ 224.00 + 0.12 @ 224.50 → quote 22.40 + 26.94 = 49.34,
+    qty 0.22 → VWAP = 49.34 / 0.22 = 224.2727...
+    """
+    return {
+        "orderId": 123456789,
+        "symbol": "BCHUSDT",
+        "status": "FILLED",
+        "type": "MARKET",
+        "side": "BUY",
+        "price": "0.00000000",  # <-- the trap
+        "avgPrice": "224.27272727",
+        "executedQty": "0.22",
+        "cumQuote": "49.34",
+        "transactTime": 1784225587901,
+        "fills": [
+            {
+                "price": "224.00",
+                "qty": "0.10",
+                "quoteQty": "22.40",
+                "commission": "0.01",
+            },
+            {
+                "price": "224.50",
+                "qty": "0.12",
+                "quoteQty": "26.94",
+                "commission": "0.01",
+            },
+        ],
+    }
+
+
+def _format(result: dict, order: TradeOrder) -> dict:
+    """Call the private formatter without constructing a live exchange client."""
+    from tradeengine.exchange.binance import BinanceFuturesExchange
+
+    return BinanceFuturesExchange._format_execution_result(
+        BinanceFuturesExchange.__new__(BinanceFuturesExchange), result, order
+    )
+
+
+class TestMarketFillPrice:
+    def test_formatter_extracts_fills(self) -> None:
+        """Sanity: the formatter already aggregates fills into total_value/amount."""
+        out = _format(_binance_market_response(), _market_order())
+        assert out["amount"] == pytest.approx(0.22)
+        assert out["total_value"] == pytest.approx(49.34)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#501: fill_price uses result['price']=0 for MARKET; must use VWAP from fills",
+    )
+    def test_market_fill_price_is_vwap_not_zero(self) -> None:
+        out = _format(_binance_market_response(), _market_order())
+        fp = out["fill_price"]
+        assert fp not in (None, 0, "0", "0.00000000"), (
+            "MARKET fill_price collapsed to 0 — SL/TP will anchor to stale signal price"
+        )
+        assert float(fp) == pytest.approx(49.34 / 0.22, rel=1e-4)  # VWAP ≈ 224.27
+
+    def test_current_behavior_fill_price_is_zeroish(self) -> None:
+        """Documents the bug as-is: fill_price is falsy for MARKET orders."""
+        out = _format(_binance_market_response(), _market_order())
+        fp = out["fill_price"]
+        assert (fp is None) or (float(fp) == 0.0), (
+            "If this fails, #501 may already be fixed — remove the xfail above"
+        )

--- a/tests/test_adversarial_502_mirror_explosion.py
+++ b/tests/test_adversarial_502_mirror_explosion.py
@@ -1,0 +1,124 @@
+"""Adversarial tests for tradeengine#502 — unbounded mirror manufactures ~2x prices.
+
+`correct_protective_price` in tradeengine/risk/sl_tp_direction.py, when a
+wrong-side absolute price arrives WITHOUT a pct hint, mirrors across the
+reference using ``implied_pct = abs(requested - reference)/reference`` and
+``effective_pct = max(implied_pct, min_distance_pct)``. There is **no upper
+bound** on ``effective_pct``. A garbage / far-wrong-side requested price
+therefore yields ``corrected ≈ reference * (1 + effective_pct)`` which can be
+2x, 3x, or arbitrarily large — exactly the BCHUSDT $223.66 → $454.66 (+103%)
+observed on 2026-07-16, which Binance then rejected with -2021.
+
+These tests assert the CORRECT (post-fix) behavior: the mirror must be bounded
+by a sane maximum distance so it never emits a price outside a plausible band.
+They are EXPECTED TO FAIL against current code (red) and pass once #502 lands.
+
+Marked ``xfail(strict=True)`` so CI is green now AND flips loud (XPASS→fail)
+the moment the bug is fixed, forcing the marker to be removed with the fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tradeengine.risk.sl_tp_direction import correct_protective_price
+
+# Maximum plausible protective-order distance. Ties to the widest PERCENT_PRICE
+# band the exchange will accept for a stop; anything beyond this is a broken
+# input, not a legitimate stop. The fix should reject or clamp to <= this.
+MAX_PLAUSIBLE_DISTANCE_PCT = 0.20  # 20% — generous upper bound
+
+
+def _distance_pct(price: float, reference: float) -> float:
+    return abs(price - reference) / reference
+
+
+class TestMirrorMustBeBounded:
+    """A wrong-side price with no pct hint must never mirror to an absurd level."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#502: mirror is unbounded; produces ~2x reference for garbage input",
+    )
+    def test_bchusdt_shortish_garbage_does_not_produce_2x(self) -> None:
+        """The exact 2026-07-16 shape: reference ~223, wrong-side requested near 0
+        implies ~100% distance → current code emits ~2x reference. Must not."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=0.01,  # effectively garbage / far wrong side
+            requested_pct=None,
+            reference_price=223.66,
+            min_distance_pct=0.06,
+        )
+        # Post-fix: corrected price must stay within a plausible band of reference.
+        assert _distance_pct(out.price, 223.66) <= MAX_PLAUSIBLE_DISTANCE_PCT, (
+            f"Corrected SL {out.price} is {_distance_pct(out.price, 223.66) * 100:.1f}% "
+            f"from reference 223.66 — unbounded mirror explosion (#502)"
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#502: mirror unbounded for far wrong-side SHORT SL",
+    )
+    def test_short_sl_far_wrong_side_bounded(self) -> None:
+        # SHORT SL must be ABOVE reference; requested far below (near 0) implies
+        # ~100% → current code mirrors to ~2x. Must be bounded instead.
+        out = correct_protective_price(
+            kind="SL",
+            position_side="SHORT",
+            requested_price=0.5,
+            requested_pct=None,
+            reference_price=100.0,
+            min_distance_pct=0.06,
+        )
+        assert _distance_pct(out.price, 100.0) <= MAX_PLAUSIBLE_DISTANCE_PCT
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#502: TP mirror also unbounded",
+    )
+    def test_long_tp_far_wrong_side_bounded(self) -> None:
+        out = correct_protective_price(
+            kind="TP",
+            position_side="LONG",
+            requested_price=0.01,
+            requested_pct=None,
+            reference_price=50.0,
+            min_distance_pct=0.0,
+        )
+        assert _distance_pct(out.price, 50.0) <= MAX_PLAUSIBLE_DISTANCE_PCT
+
+
+class TestMirrorRegressionTable:
+    """Table of wrong-side inputs → current mirror output, documenting the blast
+    radius. These are NOT xfail: they PASS today and lock in the observed buggy
+    magnitudes so the fix's behavior change is explicit and reviewable in diff.
+    """
+
+    @pytest.mark.parametrize(
+        "reference,requested,expected_multiple",
+        [
+            (223.66, 0.01, 2.0),  # ~2x — the incident
+            (100.0, 1.0, 2.0),  # near-0 → ~2x
+            (50.0, 200.0, 4.0),  # 3x wrong-side above → ~4x reference
+        ],
+    )
+    def test_current_mirror_explodes(
+        self, reference: float, requested: float, expected_multiple: float
+    ) -> None:
+        """LONG SL: wrong-side (above ref) with no pct → mirrors below by implied
+        distance. Documents that huge implied distances pass straight through."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="SHORT",  # SHORT SL must be above ref; below = wrong side
+            requested_price=requested,
+            requested_pct=None,
+            reference_price=reference,
+            min_distance_pct=0.06,
+        )
+        implied = _distance_pct(requested, reference)
+        # Current (buggy) contract: corrected = reference * (1 + implied), no cap.
+        assert out.price == pytest.approx(reference * (1 + implied))
+        # And that magnitude is absurd (> plausible band) — proving the bug.
+        assert _distance_pct(out.price, reference) > MAX_PLAUSIBLE_DISTANCE_PCT

--- a/tests/test_adversarial_503_oco_percent_filter.py
+++ b/tests/test_adversarial_503_oco_percent_filter.py
@@ -1,0 +1,129 @@
+"""Adversarial tests for tradeengine#503 — OCO STOP path skips PERCENT_PRICE clamp.
+
+`BinanceFuturesExchange._execute_stop_order` (STOP_MARKET, the leg used by the
+OCO path) submits ``triggerPrice`` verbatim with NO call to
+``validate_and_adjust_price_for_percent_filter``. The stop-LIMIT sibling
+(``_execute_stop_limit_order``) DOES validate. So an out-of-band SL (e.g.
+XLMUSDT 14.8% away when the filter allows ±5%) ships unmodified and Binance
+rejects it with -2021, contributing to naked positions.
+
+Correct behavior: the STOP_MARKET OCO leg must run its trigger price through
+the PERCENT_PRICE validator/adjuster before submission (and refuse cleanly if
+it cannot be made compliant).
+
+We assert this at two levels:
+  1. Static/structural: the validator is invoked on the STOP_MARKET path.
+  2. Behavioral: an out-of-band trigger price is either adjusted into the band
+     or the order is refused — never shipped as-is.
+
+xfail(strict) → red now, flips loud when #503 lands.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from contracts.order import OrderStatus, TradeOrder
+
+
+def test_stop_limit_path_validates_but_stop_market_does_not_currently() -> None:
+    """Documents the asymmetry: stop-LIMIT validates, stop-MARKET does not.
+
+    This test PASSES today (documents the bug). When #503 is fixed the
+    stop-market source should also reference the validator and this test's
+    second assertion should be updated.
+    """
+    from tradeengine.exchange import binance as _b
+
+    stop_limit_src = inspect.getsource(
+        _b.BinanceFuturesExchange._execute_stop_limit_order
+    )
+    stop_market_src = inspect.getsource(_b.BinanceFuturesExchange._execute_stop_order)
+
+    # stop-limit already guards its price
+    assert (
+        "validate_price_within_percent_filter" in stop_limit_src
+        or "validate_and_adjust_price_for_percent_filter" in stop_limit_src
+    )
+    # stop-market currently does NOT — this is the bug.
+    assert (
+        "validate_and_adjust_price_for_percent_filter" not in stop_market_src
+        and "validate_price_within_percent_filter" not in stop_market_src
+    ), "If this fails, #503 may be fixed — flip the xfail test below to a real assert"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#503: STOP_MARKET (OCO leg) must validate triggerPrice against PERCENT_PRICE",
+)
+def test_stop_market_path_references_percent_filter_validator() -> None:
+    """Post-fix: the STOP_MARKET path must invoke the PERCENT_PRICE validator."""
+    from tradeengine.exchange import binance as _b
+
+    src = inspect.getsource(_b.BinanceFuturesExchange._execute_stop_order)
+    assert "validate_and_adjust_price_for_percent_filter" in src or (
+        "validate_price_within_percent_filter" in src
+    ), "OCO STOP_MARKET leg ships triggerPrice without PERCENT_PRICE validation (#503)"
+
+
+class TestOutOfBandTriggerRefused:
+    """Behavioral: an out-of-band SL trigger must be adjusted or refused."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#503: out-of-band OCO stop trigger is shipped verbatim, not clamped/refused",
+    )
+    async def test_xlm_out_of_band_sl_is_not_shipped_verbatim(self) -> None:
+        """XLMUSDT scenario: market ~0.19, SL 14.8% away, filter ±5%.
+
+        The OCO STOP_MARKET leg must NOT submit the raw out-of-band trigger.
+        Either it adjusts into the band, or it refuses — but the exact raw
+        0.162 must never reach the algo-order API.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tradeengine.exchange.binance import BinanceFuturesExchange
+
+        exch = BinanceFuturesExchange.__new__(BinanceFuturesExchange)
+        exch.client = MagicMock()
+        # market 0.19, filter ±5%
+        exch._get_current_price = AsyncMock(return_value=0.19)  # type: ignore[method-assign]
+        exch.get_percent_price_filter = MagicMock(  # type: ignore[method-assign]
+            return_value={"multiplierUp": "1.05", "multiplierDown": "0.95"}
+        )
+        exch._format_price = MagicMock(side_effect=lambda s, p: f"{p:.5f}")  # type: ignore[method-assign]
+
+        captured: dict = {}
+
+        async def _fake_algo_api(**params: object) -> dict:
+            captured.update(params)
+            return {"algoId": "999", "algoStatus": "NEW"}
+
+        exch._call_algo_order_api = _fake_algo_api  # type: ignore[method-assign]
+
+        async def _retry(fn, **kw):  # type: ignore[no-untyped-def]
+            return await fn(**kw)
+
+        exch._execute_with_retry = _retry  # type: ignore[method-assign]
+
+        order = TradeOrder(
+            symbol="XLMUSDT",
+            side="sell",
+            type="stop",
+            amount=579.0,
+            stop_loss=0.16215,  # 14.8% below market 0.19 — out of ±5% band
+            position_side="LONG",
+            reduce_only=True,
+            status=OrderStatus.PENDING,
+        )
+
+        await exch._execute_stop_order(order)
+
+        # The raw out-of-band trigger must not have been shipped.
+        shipped = str(captured.get("triggerPrice", ""))
+        assert shipped not in ("0.16215", "0.16215000"), (
+            f"OCO STOP shipped out-of-band trigger {shipped} verbatim (#503)"
+        )

--- a/tests/test_adversarial_504_partial_oco_naked.py
+++ b/tests/test_adversarial_504_partial_oco_naked.py
@@ -1,0 +1,115 @@
+"""Adversarial tests for tradeengine#504 — partial OCO failure leaves naked position.
+
+IMPORTANT interaction with #482/#425: those tickets deliberately made OCO
+atomic — on a partial fill the surviving leg MUST be cancelled to avoid an
+orphan reduce-only order (the -4509 loop). We do NOT want to revert that.
+
+The #504 defect is what happens AFTER the surviving leg is cancelled:
+``OCOManager.place_oco_orders`` returns ``{"status": "failed"}`` (dispatcher.py
+:466) and the dispatcher falls back to ``_place_individual_risk_orders``, which
+retries both legs with the SAME uncorrected prices. When those also fail (the
+2026-07-16 -2021 storm), there is NO terminal safety net — the position is left
+fully naked and nothing flattens or escalates it.
+
+Correct behavior (the fix): after OCO partial-failure AND fallback exhaustion,
+the position must not be silently naked — it must be escalated to remediation
+(re-arm with corrected price, or flatten). This test asserts the escalation
+contract at the OCO-result level.
+
+Two guards:
+  1. Keep #482 atomicity: surviving leg IS cancelled on partial failure (green).
+  2. #504: the failed OCO result must carry an escalation/naked signal the
+     caller can act on — not an opaque "failed" that gets silently dropped.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tradeengine.dispatcher import OCOManager
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test-adversarial-504")
+
+
+def _make_exchange(sl_ok: bool, tp_ok: bool) -> AsyncMock:
+    exch = AsyncMock()
+    exch.client = MagicMock()
+    sl_id, tp_id = "1000000091274545", "1000000091274546"
+
+    async def execute(order: Any) -> dict[str, Any]:
+        if str(order.type) in ("OrderType.STOP", "stop"):
+            return {
+                "order_id": sl_id if sl_ok else None,
+                "status": "NEW" if sl_ok else "failed",
+            }
+        return {
+            "order_id": tp_id if tp_ok else None,
+            "status": "NEW" if tp_ok else "failed",
+        }
+
+    exch.execute = execute
+    return exch
+
+
+class TestAtomicityStillHolds:
+    """#482 must not regress: surviving leg is cancelled on partial failure."""
+
+    @pytest.mark.asyncio
+    async def test_surviving_leg_cancelled(self, logger: logging.Logger) -> None:
+        exch = _make_exchange(sl_ok=True, tp_ok=False)
+        oco = OCOManager(exchange=exch, logger=logger)
+        result = await oco.place_oco_orders(
+            position_id="p",
+            symbol="BCHUSDT",
+            position_side="LONG",
+            quantity=0.22,
+            stop_loss_price=200.0,
+            take_profit_price=260.0,
+        )
+        assert result["status"] == "failed"
+        # surviving SL leg cancelled (atomicity preserved)
+        assert exch.client._request_futures_api.call_count == 1
+
+
+class TestNakedEscalationSignal:
+    """#504: partial OCO failure must surface an actionable naked/escalation
+    signal so the position is never silently left unprotected."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#504: failed OCO result is opaque; must flag position naked/needs "
+        "escalation so caller can re-arm or flatten instead of going naked",
+    )
+    async def test_partial_failure_result_flags_naked_for_escalation(
+        self, logger: logging.Logger
+    ) -> None:
+        exch = _make_exchange(sl_ok=True, tp_ok=False)
+        oco = OCOManager(exchange=exch, logger=logger)
+        result = await oco.place_oco_orders(
+            position_id="p",
+            symbol="BCHUSDT",
+            position_side="LONG",
+            quantity=0.22,
+            stop_loss_price=200.0,
+            take_profit_price=260.0,
+        )
+        assert result["status"] == "failed"
+        # Post-fix: the result must let the caller know the position is now
+        # unprotected and requires remediation — not just "failed".
+        assert (
+            result.get("position_naked") is True
+            or result.get("requires_remediation") is True
+            or result.get("escalate") is True
+        ), (
+            "Partial OCO failure returns opaque 'failed' with no naked/escalation "
+            "signal — caller cannot distinguish 'unprotected position' from a "
+            "benign rejection (#504)"
+        )

--- a/tests/test_adversarial_505_short_sign.py
+++ b/tests/test_adversarial_505_short_sign.py
@@ -1,0 +1,125 @@
+"""Adversarial tests for tradeengine#505 — SHORT position sign inconsistency.
+
+Two related hazards surfaced during the 2026-07-16 incident:
+
+1. Storage: ``StrategyPositionManager`` stores ``entry_quantity`` as the raw,
+   UNSIGNED amount (strategy_position_manager.py:153) with ``side`` tracked
+   separately. A SHORT can therefore be recorded as
+   ``side="SHORT", quantity=+9470.2``.
+
+2. Matching / inference: the one-way (``BOTH``) branch of
+   ``_has_matching_exchange_position`` (strategy_position_reconciler.py:99-104)
+   assumes a SIGNED exchange quantity — ``side == "SHORT" and snap.quantity < 0``.
+   Live Binance data in the incident showed a SHORT snapshot carrying a
+   POSITIVE ``positionAmt`` (9470.2). If such a snapshot is ever presented in
+   one-way mode, a REAL short fails to match its strategy row → the reconciler
+   mis-classifies a live, real position as a ghost and could evict it.
+
+These tests assert robust behavior: side matching must be driven by the
+explicit side / consistent sign convention, not by an assumed sign that live
+data violates. xfail(strict) for the hazards that require the fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tradeengine.exchange_truth_store import PositionSnapshot
+from tradeengine.strategy_position_reconciler import _has_matching_exchange_position
+
+
+def _short_strategy_row() -> dict:
+    return {"symbol": "XRPUSDT", "side": "SHORT", "quantity": 9470.2}
+
+
+class TestHedgeModeMatch:
+    """Hedge mode keys directly by (symbol, side) — should always match."""
+
+    def test_short_hedge_key_matches_regardless_of_sign(self) -> None:
+        # Incident-shape: hedge SHORT snapshot with POSITIVE quantity.
+        ex = {
+            ("XRPUSDT", "SHORT"): PositionSnapshot(
+                symbol="XRPUSDT",
+                side="SHORT",
+                quantity=9470.2,  # positive, as live Binance returned
+                entry_price=1.0945,
+                unrealized_pnl=-71.0,
+            )
+        }
+        assert _has_matching_exchange_position(_short_strategy_row(), ex) is True
+
+
+class TestOneWayModeSignHazard:
+    """One-way (BOTH) matching assumes signed qty; live data can violate it."""
+
+    def test_oneway_short_with_negative_qty_matches(self) -> None:
+        """Baseline: properly-signed one-way SHORT matches (documents intent)."""
+        ex = {
+            ("XRPUSDT", "BOTH"): PositionSnapshot(
+                symbol="XRPUSDT",
+                side="BOTH",
+                quantity=-9470.2,  # correctly signed short
+                entry_price=1.0945,
+                unrealized_pnl=-71.0,
+            )
+        }
+        assert _has_matching_exchange_position(_short_strategy_row(), ex) is True
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#505: one-way SHORT with positive qty (as live Binance returned) "
+        "fails to match → real position mis-evicted as ghost",
+    )
+    def test_oneway_short_with_positive_qty_still_matches(self) -> None:
+        """The incident hazard: a real short presented with positive qty in a
+        BOTH snapshot must NOT be treated as absent (ghost)."""
+        ex = {
+            ("XRPUSDT", "BOTH"): PositionSnapshot(
+                symbol="XRPUSDT",
+                side="BOTH",
+                quantity=9470.2,  # POSITIVE — the sign hazard
+                entry_price=1.0945,
+                unrealized_pnl=-71.0,
+            )
+        }
+        # A live position must never be misclassified as a ghost due to sign.
+        assert _has_matching_exchange_position(_short_strategy_row(), ex) is True
+
+
+class TestStorageSignConvention:
+    """The strategy store should carry a consistent, documented sign convention
+    so downstream sign-based inference is safe."""
+
+    def test_storage_currently_stores_unsigned_quantity(self) -> None:
+        """Documents the bug at source: create_strategy_position stores the raw
+        ``execution_result['amount']`` as ``entry_quantity`` with no sign applied,
+        keying the sign convention entirely on the separate ``side`` field. Passes
+        today; if it fails the fix may have introduced a signed convention."""
+        import inspect
+
+        from tradeengine.strategy_position_manager import StrategyPositionManager
+
+        src = inspect.getsource(StrategyPositionManager.create_strategy_position)
+        assert 'entry_quantity = float(execution_result.get("amount"' in src, (
+            "entry_quantity derivation changed — re-verify the sign convention (#505)"
+        )
+        # No negation / sign application on the SHORT branch today.
+        assert "-entry_quantity" not in src and "abs(entry_quantity)" not in src
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#505: entry_quantity stored unsigned; a signed convention (SHORT<0) "
+        "or explicit side-only inference must be applied so BOTH-mode matching is safe",
+    )
+    def test_storage_applies_signed_convention_for_short(self) -> None:
+        """Post-fix: the storage path must encode SHORT with a negative signed
+        quantity (or otherwise guarantee sign-consistent inference)."""
+        import inspect
+
+        from tradeengine.strategy_position_manager import StrategyPositionManager
+
+        src = inspect.getsource(StrategyPositionManager.create_strategy_position)
+        # Expect the fix to introduce an explicit signed quantity for SHORT.
+        assert "-entry_quantity" in src or "signed_quantity" in src, (
+            "No signed-quantity convention applied for SHORT storage (#505)"
+        )


### PR DESCRIPTION
Adds 6 adversarial test files pinning every bug in the 2026-07-16 naked-position cluster. All tests use xfail(strict=True) so CI stays green now and flips loud the moment each bug is fixed.

**Test files:**
| Ticket | File | Bug pinned |
|--------|------|------------|
| #500 | test_adversarial_500_watchdog_mode.py | `off` default means no enforcement ever |
| #501 | test_adversarial_501_market_fill_price.py | MARKET fill_price = 0 → stale/zero anchor |
| #502 | test_adversarial_502_mirror_explosion.py | Mirror formula unbounded → 2x–4x price explosion |
| #503 | test_adversarial_503_oco_percent_filter.py | OCO STOP_MARKET skips PERCENT_PRICE validator |
| #504 | test_adversarial_504_partial_oco_naked.py | Partial OCO failure → opaque "failed" → silent naked |
| #505 | test_adversarial_505_short_sign.py | SHORT unsigned qty → positive-qty match fails |

**#504 scope note (discovered during test authoring):**
Must NOT revert #482 atomicity. Cancelling the surviving leg on partial OCO failure is correct (prevents the -4509 orphan loop). The real #504 defect: after cancel, `OCOManager.place_oco_orders` returns opaque `{status:failed}` (dispatcher.py:466), fallback retries with same bad prices, no terminal flatten → silent naked. Revised fix: keep atomicity, add naked/escalation signal, escalate to re-arm-or-flatten.

**Full suite:** 46 passed + 10 xfailed (0 failures), ruff clean, no conflict with existing #479/#482 suites.