### PR TITLE
fix: derive MARKET fill price from VWAP, re-anchor stale SL/TP reference (#501)

### DIFF
--- a/tests/test_adversarial_501_market_fill_price.py
+++ b/tests/test_adversarial_501_market_fill_price.py
@@ -22,6 +22,8 @@ xfail(strict) → red now, flips loud when #501 lands.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from contracts.order import OrderStatus, TradeOrder
@@ -88,11 +90,8 @@ class TestMarketFillPrice:
         assert out["amount"] == pytest.approx(0.22)
         assert out["total_value"] == pytest.approx(49.34)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#501: fill_price uses result['price']=0 for MARKET; must use VWAP from fills",
-    )
     def test_market_fill_price_is_vwap_not_zero(self) -> None:
+        """#501 (fixed): MARKET fill_price is the VWAP from fills, never 0."""
         out = _format(_binance_market_response(), _market_order())
         fp = out["fill_price"]
         assert fp not in (None, 0, "0", "0.00000000"), (
@@ -100,10 +99,67 @@ class TestMarketFillPrice:
         )
         assert float(fp) == pytest.approx(49.34 / 0.22, rel=1e-4)  # VWAP ≈ 224.27
 
-    def test_current_behavior_fill_price_is_zeroish(self) -> None:
-        """Documents the bug as-is: fill_price is falsy for MARKET orders."""
-        out = _format(_binance_market_response(), _market_order())
-        fp = out["fill_price"]
-        assert (fp is None) or (float(fp) == 0.0), (
-            "If this fails, #501 may already be fixed — remove the xfail above"
-        )
+    def test_market_fill_price_from_cumquote_when_no_fills(self) -> None:
+        """#501: fall back to cumQuote/executedQty when fills[] is absent."""
+        resp = _binance_market_response()
+        resp.pop("fills")
+        out = _format(resp, _market_order())
+        assert float(out["fill_price"]) == pytest.approx(49.34 / 0.22, rel=1e-4)
+
+    def test_limit_fill_price_uses_price_no_regression(self) -> None:
+        """AC4: LIMIT orders with a real price and no fills keep using price."""
+        limit_resp = {
+            "orderId": 987654321,
+            "symbol": "BCHUSDT",
+            "status": "NEW",
+            "type": "LIMIT",
+            "side": "BUY",
+            "price": "220.50",
+            "executedQty": "0",
+            "cumQuote": "0",
+            "fills": [],
+        }
+        out = _format(limit_resp, _market_order())
+        assert float(out["fill_price"]) == pytest.approx(220.50)
+
+
+def _dispatcher_with_price(live_price: float, band_up=1.05, band_down=0.95):
+    """Build a bare Dispatcher whose exchange returns a fixed live price + band."""
+    from tradeengine.dispatcher import Dispatcher
+
+    d = Dispatcher()
+    d.exchange = MagicMock()
+    d.exchange._get_current_price = AsyncMock(return_value=live_price)
+    d.exchange.get_percent_price_filter = MagicMock(
+        return_value={
+            "multiplierUp": str(band_up),
+            "multiplierDown": str(band_down),
+            "avgPriceMins": 5,
+        }
+    )
+    return d
+
+
+class TestReanchorStaleEntryPrice:
+    """#501 AC2/AC3: stale-but-nonzero anchors re-anchor to live market."""
+
+    @pytest.mark.asyncio
+    async def test_stale_anchor_reanchored_to_live(self) -> None:
+        # BCH market ≈ 223.66 but anchor 454 (~2x) is far outside the ±5% band.
+        d = _dispatcher_with_price(223.66)
+        out = await d._reanchor_entry_price_if_stale("BCHUSDT", 454.66)
+        assert out == pytest.approx(223.66)
+
+    @pytest.mark.asyncio
+    async def test_in_band_anchor_preserved(self) -> None:
+        # A legit fill 224.27 vs market 223.66 is inside the band — untouched.
+        d = _dispatcher_with_price(223.66)
+        out = await d._reanchor_entry_price_if_stale("BCHUSDT", 224.27)
+        assert out == pytest.approx(224.27)
+
+    @pytest.mark.asyncio
+    async def test_live_price_failure_preserves_entry(self) -> None:
+        d = _dispatcher_with_price(223.66)
+        d.exchange._get_current_price = AsyncMock(side_effect=RuntimeError("boom"))
+        out = await d._reanchor_entry_price_if_stale("BCHUSDT", 454.66)
+        assert out == pytest.approx(454.66)

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -3491,6 +3491,51 @@ class Dispatcher:
             result["error"] = f"defer_oco_until_filled raised: {defer_err}"
             return result
 
+    async def _reanchor_entry_price_if_stale(
+        self, symbol: str, entry_price: float
+    ) -> float:
+        """Re-anchor a stale entry/reference price to live market (#501 AC2).
+
+        Returns the live market price when ``entry_price`` deviates beyond the
+        symbol's PERCENT_PRICE band; otherwise returns ``entry_price`` unchanged.
+        Any resolution failure is non-fatal — the original ``entry_price`` is
+        preserved so this guard can never make the fill path worse.
+        """
+        if entry_price <= 0 or self.exchange is None:
+            return entry_price
+        try:
+            live_price = float(await self.exchange._get_current_price(symbol))
+        except Exception as ref_err:  # pragma: no cover - defensive
+            self.logger.warning(
+                f"⚠️ #501 re-anchor: could not resolve live price for "
+                f"{symbol}: {ref_err}. Keeping entry_price {entry_price}."
+            )
+            return entry_price
+        if live_price <= 0:
+            return entry_price
+
+        # Resolve the PERCENT_PRICE band; default to ±10% if unavailable.
+        mult_up, mult_down = 1.10, 0.90
+        try:
+            band = self.exchange.get_percent_price_filter(symbol)
+            mult_up = float(band.get("multiplierUp", mult_up))
+            mult_down = float(band.get("multiplierDown", mult_down))
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+        upper = live_price * mult_up
+        lower = live_price * mult_down
+        if entry_price > upper or entry_price < lower:
+            deviation_pct = abs(entry_price - live_price) / live_price * 100.0
+            self.logger.warning(
+                f"⚠️ #501 STALE ANCHOR: entry_price {entry_price} for {symbol} "
+                f"deviates {deviation_pct:.2f}% from live market {live_price} "
+                f"(band {lower:.6f}–{upper:.6f}). Re-anchoring SL/TP reference "
+                f"to live market price."
+            )
+            return live_price
+        return entry_price
+
     async def _place_risk_management_orders(
         self, order: TradeOrder, result: dict[str, Any]
     ) -> None:
@@ -3562,6 +3607,18 @@ class Dispatcher:
                     f"⚠️ Could not cast entry_price '{entry_price_raw}' to float"
                 )
                 entry_price = 0.0
+
+            # #501 AC2: re-anchor a STALE reference price to live market.
+            # The old code only fell back to live market when entry_price <= 0.
+            # A non-zero-but-stale signal price (order.target_price =
+            # signal.current_price) would still be preferred, so all downstream
+            # SL/TP percentages were computed off a suspect anchor. Force the
+            # live-market fallback whenever the resolved entry_price deviates
+            # beyond the symbol's PERCENT_PRICE band from the current market.
+            if entry_price > 0 and self.exchange is not None:
+                entry_price = await self._reanchor_entry_price_if_stale(
+                    order.symbol, entry_price
+                )
 
             # MIN SL DISTANCE FLOOR: enforce a minimum safe distance against
             # premature stop-outs from strategy anomalies or micro-volatility.

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -1352,13 +1352,28 @@ class BinanceFuturesExchange:
         status = result.get("status") or result.get("algoStatus", "NEW")
         order_type = result.get("type") or result.get("orderType")
 
+        # #501: derive the true fill price for MARKET orders.
+        # A Binance FUTURES MARKET response returns price="0.00000000" and carries
+        # the real fill in fills[] (or cumQuote/executedQty). Using result["price"]
+        # here collapses fill_price to 0, so the dispatcher falls back to the
+        # unvalidated signal.current_price as the SL/TP reference anchor and every
+        # protective order is computed off a possibly-stale number.
+        # Precedence (most authoritative first):
+        #   1. VWAP from fills[]              = total_quote_qty / total_qty
+        #   2. cumQuote / executedQty         (same VWAP when fills[] is absent)
+        #   3. avgPrice                       (Binance's own average fill)
+        #   4. price / triggerPrice           (LIMIT / stop legs — unchanged, AC4)
+        fill_price = self._resolve_fill_price(
+            result, total_quote_qty=total_quote_qty, total_qty=total_qty
+        )
+
         return {
             "order_id": str(order_id) if order_id else None,
             "status": status,
             "side": result.get("side"),
             "type": order_type,
             "amount": total_qty or order.amount,
-            "fill_price": result.get("price") or result.get("triggerPrice"),
+            "fill_price": fill_price,
             "total_value": total_quote_qty,
             "fees": self._calculate_fees(fills),
             "timestamp": result.get("transactTime"),
@@ -1366,6 +1381,51 @@ class BinanceFuturesExchange:
             "fills": fills,
             "original_order": order.model_dump(),
         }
+
+    @staticmethod
+    def _resolve_fill_price(
+        result: dict[str, Any],
+        *,
+        total_quote_qty: float,
+        total_qty: float,
+    ) -> float | None:
+        """Resolve the effective fill price for an execution result (#501).
+
+        For MARKET orders Binance returns ``price="0.00000000"`` and reports the
+        real fill in ``fills[]`` / ``cumQuote``+``executedQty``. Prefer the
+        volume-weighted average fill; fall back to Binance's ``avgPrice``; and
+        only then to ``price``/``triggerPrice`` for LIMIT and stop legs whose
+        ``price`` field is legitimately populated (AC4 — no LIMIT regression).
+        """
+
+        def _pos(val: Any) -> float | None:
+            try:
+                f = float(val)
+            except (ValueError, TypeError):
+                return None
+            return f if f > 0 else None
+
+        # 1. VWAP from aggregated fills[].
+        if total_qty > 0 and total_quote_qty > 0:
+            return total_quote_qty / total_qty
+
+        # 2. cumQuote / executedQty (VWAP when fills[] is absent but totals are on
+        #    the top-level response).
+        cum_quote = _pos(result.get("cumQuote"))
+        executed_qty = _pos(result.get("executedQty"))
+        if cum_quote is not None and executed_qty is not None:
+            return cum_quote / executed_qty
+
+        # 3. Binance's own average fill price.
+        avg_price = _pos(result.get("avgPrice"))
+        if avg_price is not None:
+            return avg_price
+
+        # 4. LIMIT / stop legs: price / triggerPrice (legacy behavior, unchanged).
+        price = _pos(result.get("price"))
+        if price is not None:
+            return price
+        return _pos(result.get("triggerPrice"))
 
     def _format_error_result(self, error: str, order: TradeOrder) -> dict[str, Any]:
         """Format error result"""


### PR DESCRIPTION
## Summary

Fixes the root cause of the 2026-07-16 naked-position cluster: **MARKET fill price collapsing to 0**, which caused the dispatcher to anchor SL/TP to the unvalidated `signal.current_price` and ship out-of-band protective orders (rejected `-2021`).

For a Binance FUTURES MARKET order the response returns `price="0.00000000"` and carries the real fill in `fills[]` / `cumQuote`+`executedQty`. The old formatter did `fill_price = result.get("price") or result.get("triggerPrice")` → `0`, and the dispatcher fell through to `order.target_price = signal.current_price`.

## Changes

- **`tradeengine/exchange/binance.py`** — new `_resolve_fill_price()` with precedence: VWAP from `fills[]` → `cumQuote/executedQty` → `avgPrice` → `price`/`triggerPrice`. `_format_execution_result` now uses it. LIMIT/stop legs (real `price`, no fills) are unchanged. **(AC1, AC4)**
- **`tradeengine/dispatcher.py`** — new `_reanchor_entry_price_if_stale()`, called before SL/TP computation. A non-zero-but-stale entry price that deviates beyond the symbol's PERCENT_PRICE band is re-anchored to live market — not only when `entry_price <= 0`. Resolution failures are non-fatal (original price preserved). **(AC2, AC3)**
- **`tests/test_adversarial_501_market_fill_price.py`** — flipped the red-first `xfail` to passing; added `cumQuote` fallback, LIMIT no-regression, and three re-anchor unit tests.

## Acceptance Criteria

- [x] **AC1** — MARKET fill price derived from `cumQuote/executedQty`/`fills[]`; unit test asserts non-zero VWAP for a MARKET response with `price="0"`.
- [x] **AC2** — When entry/reference price deviates beyond the PERCENT_PRICE band, code re-anchors to live market (test covers the out-of-band case, not just `<=0`).
- [x] **AC3** — Re-anchor unit tests cover the BCH ~2x scenario (in-band price preserved, stale price re-anchored).
- [x] **AC4** — No regression for LIMIT entries where `fill_price` is legitimately populated (dedicated test).

## Testing

- `tests/test_adversarial_501_market_fill_price.py` — 7 passed.
- Full suite: **1823 passed, 12 skipped, 9 xfailed** (remaining xfails are the other #500/#502–505 cluster tickets), coverage 80.63%.
- `ruff check`/`format`, pre-commit hooks, and pre-push suite all pass.

## Notes

- The 110 pre-existing `mypy --strict` errors on `main` are untouched by this PR (verified via stash) — all live in files not modified here. This PR introduces **zero** new type errors.

Closes #501

Part of the #500–505 naked-position cluster; this is the documented root-cause ticket that unblocks #502/#503/#504 and the `arm_*` enablement in #500.
