### PR TITLE
fix: clamp/refuse OCO STOP_MARKET trigger against PERCENT_PRICE filter (#503)

### DIFF
--- a/tests/test_adversarial_503_oco_percent_filter.py
+++ b/tests/test_adversarial_503_oco_percent_filter.py
@@ -28,13 +28,8 @@ import pytest
 from contracts.order import OrderStatus, TradeOrder
 
 
-def test_stop_limit_path_validates_but_stop_market_does_not_currently() -> None:
-    """Documents the asymmetry: stop-LIMIT validates, stop-MARKET does not.
-
-    This test PASSES today (documents the bug). When #503 is fixed the
-    stop-market source should also reference the validator and this test's
-    second assertion should be updated.
-    """
+def test_both_stop_paths_validate_percent_filter() -> None:
+    """#503 (fixed): both stop-LIMIT and stop-MARKET guard the price."""
     from tradeengine.exchange import binance as _b
 
     stop_limit_src = inspect.getsource(
@@ -47,17 +42,13 @@ def test_stop_limit_path_validates_but_stop_market_does_not_currently() -> None:
         "validate_price_within_percent_filter" in stop_limit_src
         or "validate_and_adjust_price_for_percent_filter" in stop_limit_src
     )
-    # stop-market currently does NOT — this is the bug.
+    # stop-market now validates too (#503).
     assert (
-        "validate_and_adjust_price_for_percent_filter" not in stop_market_src
-        and "validate_price_within_percent_filter" not in stop_market_src
-    ), "If this fails, #503 may be fixed — flip the xfail test below to a real assert"
+        "validate_and_adjust_price_for_percent_filter" in stop_market_src
+        or "validate_price_within_percent_filter" in stop_market_src
+    ), "OCO STOP_MARKET leg must validate triggerPrice against PERCENT_PRICE (#503)"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#503: STOP_MARKET (OCO leg) must validate triggerPrice against PERCENT_PRICE",
-)
 def test_stop_market_path_references_percent_filter_validator() -> None:
     """Post-fix: the STOP_MARKET path must invoke the PERCENT_PRICE validator."""
     from tradeengine.exchange import binance as _b
@@ -72,10 +63,6 @@ class TestOutOfBandTriggerRefused:
     """Behavioral: an out-of-band SL trigger must be adjusted or refused."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#503: out-of-band OCO stop trigger is shipped verbatim, not clamped/refused",
-    )
     async def test_xlm_out_of_band_sl_is_not_shipped_verbatim(self) -> None:
         """XLMUSDT scenario: market ~0.19, SL 14.8% away, filter ±5%.
 
@@ -120,10 +107,66 @@ class TestOutOfBandTriggerRefused:
             status=OrderStatus.PENDING,
         )
 
-        await exch._execute_stop_order(order)
+        # AC3: a leg that cannot be made filter-compliant is refused (raises),
+        # not shipped. This SL is 14.8% below market with a ±5% filter and a 6%
+        # safety floor — infeasible — so the correct outcome is a clean refuse.
+        # An in-band-adjustable trigger would instead be clamped and shipped.
+        with pytest.raises(ValueError, match="percent_filter_reject|unreachable"):
+            await exch._execute_stop_order(order)
 
-        # The raw out-of-band trigger must not have been shipped.
+        # In either outcome, the raw out-of-band trigger must never be shipped.
         shipped = str(captured.get("triggerPrice", ""))
         assert shipped not in ("0.16215", "0.16215000"), (
             f"OCO STOP shipped out-of-band trigger {shipped} verbatim (#503)"
         )
+
+    @pytest.mark.asyncio
+    async def test_adjustable_out_of_band_sl_is_clamped_then_shipped(self) -> None:
+        """AC1: a slightly out-of-band SL that CAN be made compliant is clamped
+        into the band and shipped — not rejected. Market 100, filter ±10%, SL
+        at 88 (12% below, just outside ±10%): the adjuster pulls it to the
+        filter edge (still beyond the 6% safety floor), so it ships adjusted.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tradeengine.exchange.binance import BinanceFuturesExchange
+
+        exch = BinanceFuturesExchange.__new__(BinanceFuturesExchange)
+        exch.client = MagicMock()
+        exch._get_current_price = AsyncMock(return_value=100.0)  # type: ignore[method-assign]
+        exch.get_percent_price_filter = MagicMock(  # type: ignore[method-assign]
+            return_value={"multiplierUp": "1.10", "multiplierDown": "0.90"}
+        )
+        exch._format_price = MagicMock(side_effect=lambda s, p: f"{p:.4f}")  # type: ignore[method-assign]
+
+        captured: dict = {}
+
+        async def _fake_algo_api(**params: object) -> dict:
+            captured.update(params)
+            return {"algoId": "1000", "algoStatus": "NEW"}
+
+        exch._call_algo_order_api = _fake_algo_api  # type: ignore[method-assign]
+
+        async def _retry(fn, **kw):  # type: ignore[no-untyped-def]
+            return await fn(**kw)
+
+        exch._execute_with_retry = _retry  # type: ignore[method-assign]
+
+        order = TradeOrder(
+            symbol="BTCUSDT",
+            side="sell",
+            type="stop",
+            amount=1.0,
+            stop_loss=88.0,  # 12% below market 100 — just outside ±10% band
+            position_side="LONG",
+            reduce_only=True,
+            status=OrderStatus.PENDING,
+        )
+
+        await exch._execute_stop_order(order)
+
+        shipped = float(captured["triggerPrice"])
+        # Clamped into the ±10% band (with the adjuster's 1% safety margin),
+        # so strictly between the raw 88 and market, and never the raw value.
+        assert shipped != 88.0
+        assert 88.0 < shipped <= 91.0

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -448,6 +448,34 @@ class BinanceFuturesExchange:
 
         if order.stop_loss is None:
             raise ValueError("Stop loss price required for stop orders")
+
+        # #503: the OCO STOP_MARKET leg previously shipped triggerPrice verbatim
+        # with NO PERCENT_PRICE validation (only the stop-LIMIT sibling clamped).
+        # An out-of-band SL (e.g. XLM 14.8% away when the filter allows ±5%) was
+        # rejected by Binance with -2021 and contributed to naked positions. Run
+        # the trigger through the same validate/adjust path used elsewhere: an
+        # adjustable price is clamped into the band; an infeasible one is refused
+        # cleanly (never shipped) so partial-OCO handling can take over.
+        trigger_price = order.stop_loss
+        (
+            is_adjusted,
+            adjusted_price,
+            adjust_msg,
+        ) = await self.validate_and_adjust_price_for_percent_filter(
+            order.symbol, trigger_price, "STOP_MARKET"
+        )
+        if adjusted_price is None:
+            raise ValueError(
+                f"oco_stop_percent_filter_reject: {adjust_msg or 'trigger price out of band'}"
+            )
+        if is_adjusted:
+            logger.warning(
+                f"#503 OCO STOP clamp: {order.symbol} trigger "
+                f"{trigger_price} -> {adjusted_price} to satisfy PERCENT_PRICE. "
+                f"{adjust_msg}"
+            )
+        trigger_price = adjusted_price
+
         # AC-3 (#352): use closePosition=true so Binance auto-sweeps the order when the
         # position closes. quantity + reduceOnly=true do NOT auto-cancel CONDITIONAL algo
         # orders — they accumulate indefinitely as orphans.
@@ -458,7 +486,7 @@ class BinanceFuturesExchange:
             "algoType": "CONDITIONAL",  # Required for Binance Algo Order API
             "closePosition": True,
             "triggerPrice": self._format_price(
-                order.symbol, order.stop_loss
+                order.symbol, trigger_price
             ),  # Note: triggerPrice, not stopPrice
             "workingType": "MARK_PRICE",  # Default to MARK_PRICE for Algo compatibility
             "priceProtect": True,  # Enable price protection for stop orders


### PR DESCRIPTION
## Summary

Fixes the OCO STOP_MARKET leg shipping out-of-band trigger prices, part of the #500–505 naked-position cluster. Chained after #501 (root-cause, merged).

`_execute_stop_order` (the STOP_MARKET leg used by `OCOManager.place_oco_orders`) submitted `triggerPrice` verbatim with **no** PERCENT_PRICE validation — only the stop-LIMIT sibling clamped. An out-of-band SL (XLMUSDT 14.8% away, filter ±5%) shipped unmodified → Binance `-2021` → naked position.

## Change

`_execute_stop_order` now routes the trigger through `validate_and_adjust_price_for_percent_filter`:
- **Adjustable** out-of-band price → clamped into the band and shipped (logged).
- **Infeasible** price (beyond both filter and SL safety floor) → refused cleanly with `oco_stop_percent_filter_reject`, so partial-OCO handling takes over rather than shipping an invalid price. (AC3 hand-off)

## Acceptance Criteria

- [x] AC1 — OCO STOP leg passes through PERCENT_PRICE validation/adjustment before submission; test asserts the XLM 14.8% scenario is not shipped verbatim.
- [x] AC3 — a leg that cannot be clamped is refused (raises), not shipped. Adjustable case is clamped-then-shipped.
- [ ] AC2 — persisting the adjusted price on the strategy position record is handled at the dispatcher/OCOManager layer (the exchange method returns the adjusted price via the shipped order); no strategy-position schema change in this PR. See note.

> **AC2 note:** the exchange leg now emits the clamped price in the submitted order; wiring that adjusted value back onto the strategy-position record is a dispatcher-layer follow-up if the current OCOManager result-plumbing doesn't already capture it. Flagging for reviewer.

## Testing

- `tests/test_adversarial_503_oco_percent_filter.py` — 4 passed (2 static asymmetry checks + refuse + clamp-then-ship).
- Full suite: **1826 passed, 12 skipped, 7 xfailed** (remaining xfails: #500/#502/#504/#505), coverage 80.68%.
- ruff/pre-commit/pre-push all green.

Closes #503

Depends on #501 (merged 893af7f). Unblocks #504 (partial-OCO handling relies on this refuse path).
