### PR TITLE
[BUG][P1] Bound SL/TP mirror distance — reject/clamp absurd protective prices (#502)

### DIFF
--- a/tests/test_adversarial_502_mirror_explosion.py
+++ b/tests/test_adversarial_502_mirror_explosion.py
@@ -10,11 +10,12 @@ therefore yields ``corrected ≈ reference * (1 + effective_pct)`` which can be
 observed on 2026-07-16, which Binance then rejected with -2021.
 
 These tests assert the CORRECT (post-fix) behavior: the mirror must be bounded
-by a sane maximum distance so it never emits a price outside a plausible band.
-They are EXPECTED TO FAIL against current code (red) and pass once #502 lands.
+by ``MAX_PLAUSIBLE_DISTANCE_PCT`` so it never emits a price outside a plausible
+band. When the implied distance exceeds the bound the correction clamps to the
+safe configured floor (``min_distance_pct``) instead of mirroring to ~2x/4x.
 
-Marked ``xfail(strict=True)`` so CI is green now AND flips loud (XPASS→fail)
-the moment the bug is fixed, forcing the marker to be removed with the fix.
+#502 has landed — the xfail markers were removed with the fix (per the marker
+contract in the original red tests) and these now pass green.
 """
 
 from __future__ import annotations
@@ -36,10 +37,6 @@ def _distance_pct(price: float, reference: float) -> float:
 class TestMirrorMustBeBounded:
     """A wrong-side price with no pct hint must never mirror to an absurd level."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#502: mirror is unbounded; produces ~2x reference for garbage input",
-    )
     def test_bchusdt_shortish_garbage_does_not_produce_2x(self) -> None:
         """The exact 2026-07-16 shape: reference ~223, wrong-side requested near 0
         implies ~100% distance → current code emits ~2x reference. Must not."""
@@ -57,10 +54,6 @@ class TestMirrorMustBeBounded:
             f"from reference 223.66 — unbounded mirror explosion (#502)"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#502: mirror unbounded for far wrong-side SHORT SL",
-    )
     def test_short_sl_far_wrong_side_bounded(self) -> None:
         # SHORT SL must be ABOVE reference; requested far below (near 0) implies
         # ~100% → current code mirrors to ~2x. Must be bounded instead.
@@ -74,10 +67,6 @@ class TestMirrorMustBeBounded:
         )
         assert _distance_pct(out.price, 100.0) <= MAX_PLAUSIBLE_DISTANCE_PCT
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#502: TP mirror also unbounded",
-    )
     def test_long_tp_far_wrong_side_bounded(self) -> None:
         out = correct_protective_price(
             kind="TP",
@@ -91,34 +80,113 @@ class TestMirrorMustBeBounded:
 
 
 class TestMirrorRegressionTable:
-    """Table of wrong-side inputs → current mirror output, documenting the blast
-    radius. These are NOT xfail: they PASS today and lock in the observed buggy
-    magnitudes so the fix's behavior change is explicit and reviewable in diff.
+    """Table of the exact wrong-side incident shapes (2026-07-16). Pre-#502 the
+    unbounded mirror produced the 2x/4x prices in the comments; post-#502 every
+    one of these must instead CLAMP to the safe floor (6%) and stay well inside
+    the plausible band. Locks in the behavior change so it is explicit in diff.
     """
 
     @pytest.mark.parametrize(
-        "reference,requested,expected_multiple",
+        "reference,requested,pre_fix_multiple",
         [
-            (223.66, 0.01, 2.0),  # ~2x — the incident
-            (100.0, 1.0, 2.0),  # near-0 → ~2x
-            (50.0, 200.0, 4.0),  # 3x wrong-side above → ~4x reference
+            (223.66, 0.01, 2.0),  # ~2x — the BCHUSDT incident (wrong side, below)
+            (100.0, 1.0, 2.0),  # near-0 → ~2x pre-fix (wrong side, below)
         ],
     )
-    def test_current_mirror_explodes(
-        self, reference: float, requested: float, expected_multiple: float
+    def test_wrong_side_mirror_now_clamps_to_floor(
+        self, reference: float, requested: float, pre_fix_multiple: float
     ) -> None:
-        """LONG SL: wrong-side (above ref) with no pct → mirrors below by implied
-        distance. Documents that huge implied distances pass straight through."""
+        """SHORT SL: wrong-side (below ref) with no pct hint and an implied
+        distance far beyond the plausible band must clamp to the 6% safe floor,
+        never mirror to the pre-fix multiple documented above."""
+        floor = 0.06
         out = correct_protective_price(
             kind="SL",
             position_side="SHORT",  # SHORT SL must be above ref; below = wrong side
             requested_price=requested,
             requested_pct=None,
             reference_price=reference,
+            min_distance_pct=floor,
+        )
+        # Post-#502 contract: clamped to the floor on the required (above) side.
+        assert out.was_corrected is True
+        assert out.was_clamped is True
+        assert out.price == pytest.approx(reference * (1 + floor))
+        # And the result is inside the plausible band, not the pre-fix explosion.
+        assert _distance_pct(out.price, reference) <= MAX_PLAUSIBLE_DISTANCE_PCT
+        # Sanity: pre-fix would have produced this absurd multiple.
+        assert (
+            reference * pre_fix_multiple
+        ) / reference - 1 > MAX_PLAUSIBLE_DISTANCE_PCT
+
+    def test_correct_side_but_absurdly_far_clamps_to_max(self) -> None:
+        """SHORT SL: requested 200 vs reference 50 is on the CORRECT side (above)
+        but 300% away — pre-fix passed straight through as ~4x. Post-#502 it
+        clamps back to the max plausible distance on the correct side."""
+        reference, requested = 50.0, 200.0
+        out = correct_protective_price(
+            kind="SL",
+            position_side="SHORT",
+            requested_price=requested,
+            requested_pct=None,
+            reference_price=reference,
             min_distance_pct=0.06,
         )
-        implied = _distance_pct(requested, reference)
-        # Current (buggy) contract: corrected = reference * (1 + implied), no cap.
-        assert out.price == pytest.approx(reference * (1 + implied))
-        # And that magnitude is absurd (> plausible band) — proving the bug.
-        assert _distance_pct(out.price, reference) > MAX_PLAUSIBLE_DISTANCE_PCT
+        assert out.was_corrected is True
+        assert out.was_clamped is True
+        assert out.price == pytest.approx(reference * (1 + MAX_PLAUSIBLE_DISTANCE_PCT))
+        assert _distance_pct(out.price, reference) <= MAX_PLAUSIBLE_DISTANCE_PCT
+
+
+class TestSmallCorrectionsStillWork:
+    """AC2: small, plausible wrong-side corrections must still work as before —
+    the bound only trips on absurd inputs, never on legitimate ones."""
+
+    def test_small_wrong_side_mirror_unchanged(self) -> None:
+        """A wrong-side SL implying a modest ~8% distance (inside the band) still
+        mirrors normally and is NOT clamped."""
+        reference = 100.0
+        # LONG SL must be BELOW ref; requested above by 8% = wrong side, small.
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=108.0,
+            requested_pct=None,
+            reference_price=reference,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is True
+        assert out.was_clamped is False
+        # implied 8% > floor 6% → mirrors below by 8%.
+        assert out.price == pytest.approx(reference * (1 - 0.08))
+        assert _distance_pct(out.price, reference) <= MAX_PLAUSIBLE_DISTANCE_PCT
+
+    def test_pct_hint_within_band_unchanged(self) -> None:
+        """A provided pct hint inside the plausible band is honored verbatim and
+        not clamped (AC2 regression)."""
+        reference = 100.0
+        out = correct_protective_price(
+            kind="TP",
+            position_side="LONG",
+            requested_price=95.0,  # wrong side (TP LONG must be above)
+            requested_pct=0.10,  # 10% hint, inside band
+            reference_price=reference,
+            min_distance_pct=0.0,
+        )
+        assert out.was_corrected is True
+        assert out.was_clamped is False
+        assert out.price == pytest.approx(reference * (1 + 0.10))
+
+    def test_correct_side_price_untouched(self) -> None:
+        """A price already on the correct side is never corrected or clamped."""
+        out = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=94.0,  # below ref = correct side for LONG SL
+            requested_pct=None,
+            reference_price=100.0,
+            min_distance_pct=0.06,
+        )
+        assert out.was_corrected is False
+        assert out.was_clamped is False
+        assert out.price == pytest.approx(94.0)

--- a/tradeengine/risk/sl_tp_direction.py
+++ b/tradeengine/risk/sl_tp_direction.py
@@ -17,11 +17,38 @@ current market price; this keeps the helper synchronous and trivially testable.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
+
+protective_price_mirror_clamped_total: Any = None
+try:  # pragma: no cover - metrics are optional in unit-test contexts
+    from prometheus_client import Counter
+
+    protective_price_mirror_clamped_total = Counter(
+        "tradeengine_protective_price_mirror_clamped_total",
+        "Times a wrong-side protective price implied an absurd mirror distance "
+        "(> MAX_PLAUSIBLE_DISTANCE_PCT) and was clamped to the safe floor "
+        "instead of being mirrored to ~2x reference (#502).",
+        ["kind", "position_side"],
+    )
+except Exception:  # pragma: no cover - prometheus not importable
+    protective_price_mirror_clamped_total = None
+
+logger = logging.getLogger(__name__)
 
 PositionSide = Literal["LONG", "SHORT"]
 ProtectiveKind = Literal["SL", "TP"]
+
+# Maximum plausible protective-order distance from the reference price. A
+# wrong-side absolute price that implies a mirror distance beyond this bound is
+# broken input (garbage / far-wrong-side), NOT a legitimate stop — mirroring it
+# produces ~2x/4x reference (BCHUSDT 2026-07-16: $223.66 -> $454.66, +103%,
+# Binance -2021). When the implied distance exceeds this cap we clamp to the
+# safe configured floor (``min_distance_pct``) rather than mirror to an absurd
+# level. Tied to the widest PERCENT_PRICE band the exchange will plausibly
+# accept for a stop. See tradeengine#502.
+MAX_PLAUSIBLE_DISTANCE_PCT = 0.20  # 20%
 
 
 @dataclass(frozen=True)
@@ -33,12 +60,16 @@ class DirectionCorrection:
         was_corrected: True if the input price was on the wrong side and got mirrored.
         reason: Short human-readable string; "" when no correction was needed.
         original_price: The input price prior to any correction.
+        was_clamped: True if the implied mirror distance exceeded
+            ``MAX_PLAUSIBLE_DISTANCE_PCT`` and the correction was clamped to the
+            safe floor instead of mirrored to an absurd level (#502).
     """
 
     price: float
     was_corrected: bool
     reason: str
     original_price: float
+    was_clamped: bool = False
 
 
 def _required_side(kind: ProtectiveKind, position_side: PositionSide) -> int:
@@ -93,11 +124,40 @@ def correct_protective_price(
     )
 
     if on_correct_side:
-        # On the correct side already — leave the price alone. Strategy-level
-        # minimum-distance enforcement happens upstream (the dispatcher's
-        # MIN_SL_DISTANCE_PCT floor); the binance.py safety-floor check (#424)
-        # remains the authoritative second gate that refuses too-close stops.
-        # We intentionally do not double-clamp here.
+        correct_side_distance = abs(requested_price - reference_price) / reference_price
+        if correct_side_distance > MAX_PLAUSIBLE_DISTANCE_PCT:
+            # Correct side but absurdly far (e.g. a $0.01 SL against a $223.66
+            # reference — 100% away). Such a price is broken input: the exchange
+            # rejects it (PERCENT_PRICE / -2021) or it can never realistically
+            # trigger. Clamp it back to the widest plausible distance on the
+            # correct side rather than shipping garbage (#502).
+            corrected = reference_price * (1 + sign * MAX_PLAUSIBLE_DISTANCE_PCT)
+            reason = (
+                f"{position_side} {kind} requested {requested_price:.6f} on the correct "
+                f"side of reference {reference_price:.6f} but {correct_side_distance * 100:.2f}% "
+                f"away — exceeds max plausible {MAX_PLAUSIBLE_DISTANCE_PCT * 100:.2f}%; "
+                f"CLAMPED to {corrected:.6f} (#502)"
+            )
+            logger.warning("⚠️ SL/TP far-side clamp (#502): %s", reason)
+            if protective_price_mirror_clamped_total is not None:
+                try:  # pragma: no cover - metric side-effect
+                    protective_price_mirror_clamped_total.labels(
+                        kind=kind, position_side=position_side
+                    ).inc()
+                except Exception:  # pragma: no cover
+                    pass
+            return DirectionCorrection(
+                price=corrected,
+                was_corrected=True,
+                reason=reason,
+                original_price=requested_price,
+                was_clamped=True,
+            )
+        # On the correct side and within the plausible band — leave the price
+        # alone. Strategy-level minimum-distance enforcement happens upstream
+        # (the dispatcher's MIN_SL_DISTANCE_PCT floor); the binance.py
+        # safety-floor check (#424) remains the authoritative second gate that
+        # refuses too-close stops. We intentionally do not double-clamp the floor.
         _ = required_floor  # kept for symmetry/debug; not used on correct-side path
         return DirectionCorrection(
             price=requested_price,
@@ -108,20 +168,69 @@ def correct_protective_price(
 
     if requested_pct is not None and requested_pct > 0:
         distance_pct = max(requested_pct, min_distance_pct)
+        # Defense-in-depth (#502): a legitimate SL/TP pct hint sits well inside
+        # the plausible band; anything beyond MAX_PLAUSIBLE_DISTANCE_PCT is a
+        # broken hint and must not manufacture an absurd price either.
+        pct_clamped = distance_pct > MAX_PLAUSIBLE_DISTANCE_PCT
+        if pct_clamped:
+            distance_pct = MAX_PLAUSIBLE_DISTANCE_PCT
+            if protective_price_mirror_clamped_total is not None:
+                try:  # pragma: no cover - metric side-effect
+                    protective_price_mirror_clamped_total.labels(
+                        kind=kind, position_side=position_side
+                    ).inc()
+                except Exception:  # pragma: no cover
+                    pass
         corrected = reference_price * (1 + sign * distance_pct)
         reason = (
             f"{position_side} {kind} requested {requested_price:.6f} on wrong side of "
             f"reference {reference_price:.6f}; recomputed to {corrected:.6f} using "
             f"pct={distance_pct * 100:.2f}%"
+            + (" (clamped to max plausible, #502)" if pct_clamped else "")
         )
+        if pct_clamped:
+            logger.warning("⚠️ SL/TP pct-hint clamp (#502): %s", reason)
         return DirectionCorrection(
             price=corrected,
             was_corrected=True,
             reason=reason,
             original_price=requested_price,
+            was_clamped=pct_clamped,
         )
 
     implied_pct = abs(requested_price - reference_price) / reference_price
+
+    if implied_pct > MAX_PLAUSIBLE_DISTANCE_PCT:
+        # Garbage / far-wrong-side input: the implied distance is meaningless, so
+        # mirroring it would manufacture an absurd ~2x/4x price that either
+        # exits the position immediately or is rejected by Binance with -2021
+        # (BCHUSDT 2026-07-16). Clamp to the safe configured floor instead of
+        # trusting the implied magnitude (#502).
+        effective_pct = max(min_distance_pct, 0.0)
+        corrected = reference_price * (1 + sign * effective_pct)
+        reason = (
+            f"{position_side} {kind} requested {requested_price:.6f} on wrong side of "
+            f"reference {reference_price:.6f} with no pct hint; implied distance "
+            f"{implied_pct * 100:.2f}% exceeds max plausible "
+            f"{MAX_PLAUSIBLE_DISTANCE_PCT * 100:.2f}% — CLAMPED to safe floor "
+            f"{effective_pct * 100:.2f}% -> {corrected:.6f} (refused mirror-to-2x, #502)"
+        )
+        logger.warning("⚠️ SL/TP mirror clamp (#502): %s", reason)
+        if protective_price_mirror_clamped_total is not None:
+            try:  # pragma: no cover - metric side-effect
+                protective_price_mirror_clamped_total.labels(
+                    kind=kind, position_side=position_side
+                ).inc()
+            except Exception:  # pragma: no cover - never let metrics break placement
+                pass
+        return DirectionCorrection(
+            price=corrected,
+            was_corrected=True,
+            reason=reason,
+            original_price=requested_price,
+            was_clamped=True,
+        )
+
     effective_pct = max(implied_pct, min_distance_pct)
     corrected = reference_price * (1 + sign * effective_pct)
     reason = (


### PR DESCRIPTION
## Summary

Fixes the unbounded protective-price mirror in `tradeengine/risk/sl_tp_direction.py` that manufactured ~2x SL/TP prices from garbage input instead of rejecting/clamping it (the BCHUSDT $223.66 → $454.66 / +103% shape from 2026-07-16 that Binance rejected with `-2021`).

Closes #502.

## Root cause

`correct_protective_price`, on a wrong-side absolute price with no pct hint, mirrored across the reference using `implied_pct = abs(requested - reference)/reference` and `effective_pct = max(implied_pct, min_distance_pct)` — with **no upper bound**. `implied_pct ≈ 1.0` ⇒ `corrected ≈ 2 × reference`.

## Fix

Introduce `MAX_PLAUSIBLE_DISTANCE_PCT = 0.20` (20% — the widest plausible PERCENT_PRICE band) and bound three paths:

1. **Wrong-side, no pct hint, implied distance > max** → clamp to the safe configured floor (`min_distance_pct`) instead of mirroring to 2x.
2. **Correct-side but absurdly far (> max)** (e.g. a $0.01 SL vs $223.66 ref) → clamp back to the max plausible distance on the correct side.
3. **Provided pct hint > max** (defense-in-depth) → clamp to max plausible.

Small, plausible wrong-side corrections and in-band pct hints are **unchanged**.

## Observability (AC3)

- New Prometheus counter `tradeengine_protective_price_mirror_clamped_total{kind, position_side}`, incremented on every clamp.
- `logger.warning` on each clamp with the before/after context.
- `DirectionCorrection.was_clamped` flag exposed so callers can observe/branch on the event.

## Acceptance criteria

- [x] **AC1** — wrong-side SL producing `implied_pct` above the max is clamped to a safe percentage, never mirrored to ~2x. Unit test with the BCH scenario asserts output within filter bounds.
- [x] **AC2** — small, plausible wrong-side corrections still work (regression tests + the full `#479` direction-guard suite pass unchanged).
- [x] **AC3** — clamps are observable via metric + log (+ `was_clamped`).

## Tests

- Removed the `xfail(strict=True)` markers from `tests/test_adversarial_502_mirror_explosion.py` per the marker contract in the original red tests; they now pass green.
- Added regression coverage for all three clamp paths and the pass-through (small-correction / in-band-hint / already-correct-side) cases.
- Full suite: **1832 passed, 12 skipped, 4 xfailed** (the 4 xfails belong to sibling tickets #500/#504/#505). Coverage 80.7% (gate 40%). Ruff lint+format clean; `sl_tp_direction.py` mypy-strict clean.

## Related

- Adversarial naked-position cluster #500–#505. Companion #501/#503 already merged; #504 depends on this + the price-clamp fixes; #500 (enforcement toggle) lands last.
