### PR TITLE
fix: #500 - enable naked-position watchdog enforcement (default dry_run + mode metric/alert)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,26 @@ SIMULATION_DELAY_MS=100
 # Supported Symbols
 SUPPORTED_SYMBOLS=BTCUSDT,ETHUSDT,ADAUSDT
 
+# Naked-position watchdog remediation (#445 / #500)
+# The exchange-authoritative NakedPositionRemediator detects positions with no
+# protective SL/TP and, depending on mode, re-arms or flattens them.
+# Modes:
+#   off            - DETECTION ONLY (increments a counter, no writes). UNSAFE as
+#                    a silent default — this is the 2026-07-16 incident (#500).
+#   dry_run        - logs intended actions, no exchange writes (safe default).
+#   arm_only       - re-arms protective stops, never flattens.
+#   arm_or_flatten - re-arms; flattens as fallback after the grace window.
+# Enablement order (AC4): dry_run -> arm_only -> arm_or_flatten.
+# The effective mode is logged at startup and exported as the metric
+# tradeengine_naked_position_remediation_mode_status{mode="..."}; alert when
+# {mode="off"} == 1.
+TE_NAKED_POSITION_REMEDIATION_MODE=dry_run
+# Grace window (sec) before fallback flatten kicks in (arm_or_flatten only).
+TE_NAKED_POSITION_FLATTEN_GRACE_SEC=60
+# Fallback SL/TP distances (% from entry) when no stored stop price exists.
+TE_NAKED_POSITION_FALLBACK_SL_PCT=2.0
+TE_NAKED_POSITION_FALLBACK_TP_PCT=4.0
+
 # =============================================================================
 # EXCHANGE CONFIGURATION
 # =============================================================================

--- a/docs/runbooks/naked-position-remediation.md
+++ b/docs/runbooks/naked-position-remediation.md
@@ -1,0 +1,108 @@
+# Runbook: Naked-Position Remediation Mode
+
+**Alert:** `tradeengine-naked-remediation-off` (Grafana Cloud)
+**Metric:** `tradeengine_naked_position_remediation_mode_status{mode="off"} > 0`
+**Severity:** `critical`
+**Origin:** [#500](https://github.com/PetroSa2/petrosa-tradeengine/issues/500) (2026-07-16 naked-position incident)
+
+---
+
+## What this alert means
+
+The exchange-authoritative `NakedPositionRemediator` (#445) is running in **`off`**
+mode. In `off` mode the watchdog **detects** naked (unprotected) positions and
+increments `tradeengine_naked_position_detected_total`, but takes **no corrective
+write action** — it never re-arms protective stops and never flattens. This is a
+"watchdog that never enforces."
+
+On 2026-07-16 the remediator silently ran `off` in production because
+`TE_NAKED_POSITION_REMEDIATION_MODE` was unset and the code default was `off`.
+Multiple live positions (XRPUSDT, BTCUSDT, ETHUSDT) sat naked with zero
+protective orders while metrics incremented and no repair happened.
+
+Since #500:
+- The code default is **`dry_run`** (`shared/config.py`), so a fresh deploy is
+  never silently `off`.
+- `k8s/tradeengine/deployment.yaml` sets `TE_NAKED_POSITION_REMEDIATION_MODE`
+  **explicitly**.
+- The effective mode is logged at startup and exported as
+  `tradeengine_naked_position_remediation_mode_status{mode="..."}`.
+
+If this alert fires, the env was mis-set (or coerced to `off` from a garbage
+value) and enforcement is disabled.
+
+---
+
+## Remediation modes
+
+| Mode             | Detects | Re-arms SL/TP | Flattens | Exchange writes |
+|------------------|:-------:|:-------------:|:--------:|:---------------:|
+| `off`            | ✅      | ❌            | ❌       | none            |
+| `dry_run`        | ✅      | ❌ (logs)     | ❌ (logs)| none            |
+| `arm_only`       | ✅      | ✅            | ❌       | re-arm only     |
+| `arm_or_flatten` | ✅      | ✅            | ✅ (after grace) | re-arm + flatten |
+
+---
+
+## Enablement order (AC4)
+
+Promote in this exact order, validating each step on a canary before advancing:
+
+```
+dry_run  →  arm_only  →  arm_or_flatten
+```
+
+1. **`dry_run`** — validate the remediator correctly identifies real naked
+   positions and that its *intended* actions (logged, not executed) look
+   correct against live divergences.
+2. **`arm_only`** — allow it to re-arm protective SL/TP but never flatten.
+   Confirm re-armed orders land at correct prices on Binance.
+3. **`arm_or_flatten`** — full enforcement: re-arm, and flatten as a fallback
+   after the grace window (`TE_NAKED_POSITION_FLATTEN_GRACE_SEC`, default 60s).
+
+> **Gate:** `arm_*` modes reuse the SL/TP reference-price logic. That logic was
+> the subject of the price-computation cluster #501 / #502 / #503, all of which
+> are now **closed/merged** — so promotion to `arm_or_flatten` is unblocked.
+> Re-verify the price fixes are deployed before promoting to any `arm_*` mode.
+
+---
+
+## How to change the mode
+
+Edit `k8s/tradeengine/deployment.yaml` in `petrosa_k8s`:
+
+```yaml
+- name: TE_NAKED_POSITION_REMEDIATION_MODE
+  value: "dry_run"   # or arm_only / arm_or_flatten
+```
+
+Commit via GitOps and let the deploy roll. Confirm the new mode at startup:
+
+```bash
+kubectl -n petrosa-apps logs deploy/petrosa-tradeengine | grep naked_remediation_mode
+```
+
+and via the metric:
+
+```
+tradeengine_naked_position_remediation_mode_status{mode="arm_or_flatten"} == 1
+```
+
+---
+
+## Verification
+
+- Startup log shows `naked_remediation_mode=<mode>` and, if `off`, a loud
+  warning.
+- `tradeengine_naked_position_remediation_mode_status{mode="off"} == 0` (alert
+  clears).
+- Exactly one mode series equals `1`.
+
+---
+
+## Related
+
+- [#445](https://github.com/PetroSa2/petrosa-tradeengine/issues/445) — remediator implementation
+- [#500](https://github.com/PetroSa2/petrosa-tradeengine/issues/500) — this alert / config fix
+- [#501](https://github.com/PetroSa2/petrosa-tradeengine/issues/501) / [#502](https://github.com/PetroSa2/petrosa-tradeengine/issues/502) / [#503](https://github.com/PetroSa2/petrosa-tradeengine/issues/503) — SL/TP price fixes (gate for `arm_*`)
+- [unhedged-positions.md](./unhedged-positions.md) — detection-side runbook

--- a/shared/config.py
+++ b/shared/config.py
@@ -92,12 +92,20 @@ class Settings(BaseSettings):
     te_exchange_truth_store_enabled: str = "off"
 
     # #445: exchange-authoritative naked-position remediation.
-    # Modes: "off" (default — read-only, no writes), "dry_run" (log
-    # intended actions, no writes), "arm_only" (re-arm protective stops
-    # but never flatten), "arm_or_flatten" (full AC2 — re-arm with
-    # fallback flatten after grace window). Ships "off" so deploy is a
-    # no-op; operator flips after canary.
-    naked_position_remediation_mode: str = "off"
+    # Modes: "off" (read-only, no writes — detection-only), "dry_run"
+    # (log intended actions, no writes), "arm_only" (re-arm protective
+    # stops but never flatten), "arm_or_flatten" (full AC2 — re-arm with
+    # fallback flatten after grace window).
+    # #500: default is "dry_run" (NOT "off"). A fresh deploy that
+    # silently ran "off" only incremented the detection counter and took
+    # no corrective write action — a "watchdog that never enforces" (see
+    # the 2026-07-16 naked-position incident). "dry_run" preserves the
+    # no-write safety of "off" for a first boot while making the
+    # remediator's intended actions observable in logs, so a missing
+    # TE_NAKED_POSITION_REMEDIATION_MODE env can never leave the fleet
+    # detection-only-and-blind. Operator promotes dry_run → arm_only →
+    # arm_or_flatten after canary validation.
+    naked_position_remediation_mode: str = "dry_run"
     # Grace window before fallback flatten kicks in (arm_or_flatten only).
     naked_position_flatten_grace_sec: int = 60
     # Fallback SL/TP distances (% from entry) when local strategy record

--- a/tests/test_adversarial_500_watchdog_mode.py
+++ b/tests/test_adversarial_500_watchdog_mode.py
@@ -140,13 +140,14 @@ class TestUnknownModeFailsSafe:
 
 
 class TestProdConfigSafety:
-    """The #500 fix requirement: prod must not silently run 'off'."""
+    """The #500 fix requirement: prod must not silently run 'off'.
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#500: default remediation mode is 'off' — a fresh deploy is "
-        "silently non-enforcing. Fix should default to at least 'dry_run'.",
-    )
+    Previously this was an ``xfail(strict=True)`` red-first guard (PR #506).
+    The #500 fix flips ``shared/config.py`` default from ``off`` → ``dry_run``,
+    so the assertion now passes: a fresh deploy with an unset
+    ``TE_NAKED_POSITION_REMEDIATION_MODE`` is never silently detection-only.
+    """
+
     def test_default_mode_is_not_silently_off(self) -> None:
         from shared.config import Settings
 
@@ -155,3 +156,61 @@ class TestProdConfigSafety:
             "Default naked_position_remediation_mode is 'off' — deploys run "
             "detection-only with no enforcement (#500)"
         )
+
+    def test_default_mode_is_dry_run(self) -> None:
+        """#500 AC: the safe default is exactly 'dry_run' — no writes on a
+        fresh boot, but intended actions are logged/observable (not blind)."""
+        from shared.config import Settings
+
+        assert str(Settings().naked_position_remediation_mode).lower() == "dry_run"
+
+
+class TestRemediationModeMetric:
+    """#500 AC2: effective mode is exported as a metric for alerting."""
+
+    def _series(self) -> dict[str, float]:
+        from tradeengine.metrics import (
+            _NAKED_REMEDIATION_MODES,
+            naked_position_remediation_mode_status,
+        )
+
+        return {
+            m: naked_position_remediation_mode_status.labels(mode=m)._value.get()
+            for m in _NAKED_REMEDIATION_MODES
+        }
+
+    def test_active_mode_is_one_others_zero(self) -> None:
+        from tradeengine.metrics import set_naked_position_remediation_mode
+
+        set_naked_position_remediation_mode("arm_or_flatten")
+        series = self._series()
+        assert series["arm_or_flatten"] == 1
+        assert series["off"] == 0
+        assert series["dry_run"] == 0
+        assert series["arm_only"] == 0
+
+    def test_mode_transition_clears_previous(self) -> None:
+        from tradeengine.metrics import set_naked_position_remediation_mode
+
+        set_naked_position_remediation_mode("arm_only")
+        set_naked_position_remediation_mode("dry_run")
+        series = self._series()
+        assert series["dry_run"] == 1
+        # Previous mode must be cleared — no stale `1`.
+        assert series["arm_only"] == 0
+
+    def test_off_mode_surfaces_for_alerting(self) -> None:
+        from tradeengine.metrics import set_naked_position_remediation_mode
+
+        set_naked_position_remediation_mode("off")
+        # The alert `{mode="off"} == 1` must fire on detection-only.
+        assert self._series()["off"] == 1
+
+    def test_unknown_mode_coerces_to_off(self) -> None:
+        from tradeengine.metrics import set_naked_position_remediation_mode
+
+        set_naked_position_remediation_mode("garbage")
+        series = self._series()
+        # Misconfigured env surfaces as unsafe 'off', never silently absent.
+        assert series["off"] == 1
+        assert sum(series.values()) == 1

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -229,7 +229,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     exchange=binance_exchange,
                     position_manager=dispatcher.position_manager,
                     close_position=dispatcher.close_position_with_cleanup,
-                    mode=_te_settings.naked_position_remediation_mode,
+                    # Settings stores the mode as a free-form str; the
+                    # remediator's _coerce_mode() validates/normalizes it (and
+                    # falls back to "off" on garbage), so passing str is safe.
+                    mode=_te_settings.naked_position_remediation_mode,  # type: ignore[arg-type]
                     flatten_grace_sec=_te_settings.naked_position_flatten_grace_sec,
                     fallback_sl_pct=_te_settings.naked_position_fallback_sl_pct,
                     fallback_tp_pct=_te_settings.naked_position_fallback_tp_pct,
@@ -250,12 +253,38 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             await _reconciler.start()
             app.state.position_reconciler = _reconciler
             app.state.naked_position_remediator = _remediator
+
+            # #500: surface the EFFECTIVE remediation mode prominently and
+            # export it as a metric so operators can alert when the watchdog
+            # is detection-only. Use the remediator's coerced .mode (falls
+            # back to "off" on a garbage env) rather than the raw setting so
+            # the log/metric reflect reality. A fresh deploy with an unset
+            # TE_NAKED_POSITION_REMEDIATION_MODE now defaults to "dry_run".
+            _effective_mode = (
+                _remediator.mode
+                if _remediator is not None
+                else _te_settings.naked_position_remediation_mode
+            )
+            from tradeengine.metrics import set_naked_position_remediation_mode
+
+            set_naked_position_remediation_mode(_effective_mode)
             logger.info(
                 "✅ Position reconciler started (interval=%ss, "
                 "naked_remediation_mode=%s)",
                 _te_settings.position_reconciliation_interval_seconds,
-                _te_settings.naked_position_remediation_mode,
+                _effective_mode,
             )
+            if str(_effective_mode).lower() == "off":
+                # Detection-only: watchdog will count naked positions but never
+                # re-arm or flatten. This should never happen on a default
+                # deploy after #500 — flag it loudly for the operator.
+                logger.warning(
+                    "⚠️ Naked-position remediation mode is 'off' — the watchdog "
+                    "DETECTS naked positions but takes NO corrective action "
+                    "(no re-arm, no flatten). Set "
+                    "TE_NAKED_POSITION_REMEDIATION_MODE to dry_run/arm_only/"
+                    "arm_or_flatten to enable enforcement (#500)."
+                )
         else:
             logger.info(
                 "⚠️ Position reconciler disabled (simulation=%s, enabled=%s)",

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -389,6 +389,44 @@ restricted_mode_status = Gauge(
     "Binary status of RESTRICTED_MODE (1 = Restricted, 0 = Normal)",
 )
 
+# #500 — effective naked-position remediation mode, exported as a labeled gauge
+# so operators can alert when the watchdog is running detection-only ("off").
+# Exactly one series is set to 1 (the active mode); all other mode series are 0.
+# The 2026-07-16 incident showed the remediator silently ran "off" in prod
+# (TE_NAKED_POSITION_REMEDIATION_MODE unset) — detecting naked positions but
+# never re-arming/flattening. This metric makes the effective mode first-class
+# and drives the `tradeengine-naked-remediation-off` alert.
+#   arm_or_flatten enforcement:  ...{mode="arm_or_flatten"} == 1
+#   detection-only (unsafe):     ...{mode="off"} == 1
+naked_position_remediation_mode_status = Gauge(
+    "tradeengine_naked_position_remediation_mode_status",
+    "Effective naked-position remediation mode (1 = active mode; one series per "
+    "mode set to 1, others 0). Alert when {mode='off'} == 1.",
+    ["mode"],
+)
+
+# All recognized modes — used to zero out inactive series so a mode transition
+# does not leave a stale `1` on the previous mode label.
+_NAKED_REMEDIATION_MODES = ("off", "dry_run", "arm_only", "arm_or_flatten")
+
+
+def set_naked_position_remediation_mode(mode: str) -> None:
+    """Set the effective naked-position remediation mode gauge (#500).
+
+    Sets the active mode's series to 1 and every other known mode's series to 0
+    so alerting on ``{mode="off"} == 1`` is unambiguous. Unknown/garbage modes
+    are coerced to ``off`` (matching NakedPositionRemediator._coerce_mode) so a
+    misconfigured env still surfaces as the unsafe detection-only state rather
+    than silently disappearing.
+    """
+    normalized = (mode or "off").lower().strip()
+    if normalized not in _NAKED_REMEDIATION_MODES:
+        normalized = "off"
+    for known in _NAKED_REMEDIATION_MODES:
+        naked_position_remediation_mode_status.labels(mode=known).set(
+            1 if known == normalized else 0
+        )
+
 
 # ============================================================
 # OTel SDK instruments (dual-export — OTLP push to Grafana Alloy)


### PR DESCRIPTION
## Summary

Fixes the **P0 naked-position watchdog** bug (#500): the exchange-authoritative
`NakedPositionRemediator` (#445) ran in **`off`** mode in production because
`TE_NAKED_POSITION_REMEDIATION_MODE` was unset and the code default was `off`.
In `off` mode the watchdog only *detects* naked positions (increments a counter)
and takes **no corrective action** — the 2026-07-16 incident where XRP/BTC/ETH
positions sat naked with zero protective orders.

## Changes (this repo — petrosa-tradeengine)

| AC | Change |
|----|--------|
| AC3 | `shared/config.py`: default `naked_position_remediation_mode` **`off` → `dry_run`** — a fresh deploy is never silently detection-only. |
| AC2 | `tradeengine/api.py`: log the **effective (coerced)** mode at startup, warn loudly when `off`, and export it as a metric. |
| AC2 | `tradeengine/metrics.py`: new labeled gauge `tradeengine_naked_position_remediation_mode_status{mode}` + `set_naked_position_remediation_mode()` helper (active mode → 1, others → 0). Drives the `mode==off` alert. |
| AC1/AC4 | `.env.example`: document `TE_NAKED_POSITION_REMEDIATION_MODE` + enablement order. |
| AC4 | `docs/runbooks/naked-position-remediation.md`: enablement runbook (`dry_run → arm_only → arm_or_flatten`). |
| — | tests: flip the red-first `xfail(strict)` guard (PR #506) to a passing assertion; add `default==dry_run` + mode-metric tests. |

## Companion PR (petrosa_k8s)

Sets `TE_NAKED_POSITION_REMEDIATION_MODE=dry_run` explicitly in
`k8s/tradeengine/deployment.yaml` (AC1) and adds the
`tradeengine-naked-remediation-off` Grafana alert (AC2). Enablement order per
AC4 — the SL/TP price-fix deps (#501/#502/#503) are all closed, so promotion to
`arm_or_flatten` is unblocked.

## Validation

- `ruff check` / `ruff format` — clean
- `mypy --strict` on changed modules — clean (also fixed a pre-existing `arg-type` on the remediator ctor)
- Full suite: **1838 passed, 12 skipped, 3 xfailed**, coverage **80.7%**

Closes #500
