### PR TITLE
[BUG][P0] Partial OCO failure cancels the surviving leg — leaves position fully naked

### DIFF
--- a/tests/test_adversarial_504_partial_oco_naked.py
+++ b/tests/test_adversarial_504_partial_oco_naked.py
@@ -83,11 +83,6 @@ class TestNakedEscalationSignal:
     signal so the position is never silently left unprotected."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#504: failed OCO result is opaque; must flag position naked/needs "
-        "escalation so caller can re-arm or flatten instead of going naked",
-    )
     async def test_partial_failure_result_flags_naked_for_escalation(
         self, logger: logging.Logger
     ) -> None:
@@ -113,3 +108,83 @@ class TestNakedEscalationSignal:
             "signal — caller cannot distinguish 'unprotected position' from a "
             "benign rejection (#504)"
         )
+
+
+class TestAllPartialFailureShapes504:
+    """#504 AC4: regression coverage for all four 2026-07-16 partial-failure
+    shapes. Each ends with the position naked (surviving leg cancelled) and
+    MUST now carry the naked/escalation signal so remediation can act.
+
+    Evidence shapes from the incident:
+      - LINKUSDT LONG  — TP posted, SL failed  → cancel surviving TP → naked
+      - BCHUSDT SHORT  — SL posted, TP failed  → cancel surviving SL → naked
+      - XLMUSDT LONG   — SL posted, TP failed  → cancel surviving SL → naked
+      - BCHUSDT SHORT  — SL posted, TP failed  → cancel surviving SL → naked
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "symbol,side,sl_ok,tp_ok,expected_cancelled_leg",
+        [
+            # TP posted / SL failed → surviving TP cancelled
+            ("LINKUSDT", "LONG", False, True, "TP"),
+            # SL posted / TP failed → surviving SL cancelled
+            ("BCHUSDT", "SHORT", True, False, "SL"),
+            ("XLMUSDT", "LONG", True, False, "SL"),
+            ("BCHUSDT", "SHORT", True, False, "SL"),
+        ],
+    )
+    async def test_every_partial_shape_flags_naked_and_cancels_survivor(
+        self,
+        logger: logging.Logger,
+        symbol: str,
+        side: str,
+        sl_ok: bool,
+        tp_ok: bool,
+        expected_cancelled_leg: str,
+    ) -> None:
+        exch = _make_exchange(sl_ok=sl_ok, tp_ok=tp_ok)
+        oco = OCOManager(exchange=exch, logger=logger)
+        result = await oco.place_oco_orders(
+            position_id="p",
+            symbol=symbol,
+            position_side=side,
+            quantity=0.22,
+            stop_loss_price=200.0 if side == "LONG" else 260.0,
+            take_profit_price=260.0 if side == "LONG" else 200.0,
+        )
+
+        # Atomicity preserved (#482): surviving leg cancelled exactly once.
+        assert exch.client._request_futures_api.call_count == 1
+
+        # #504: naked/escalation signal present and correct.
+        assert result["status"] == "failed"
+        assert result.get("position_naked") is True
+        assert result.get("requires_remediation") is True
+        assert result.get("escalate") is True
+        assert result.get("cancelled_leg") == expected_cancelled_leg
+        assert result.get("symbol") == symbol
+        assert result.get("position_side") == side
+
+    @pytest.mark.asyncio
+    async def test_total_leg_failure_is_not_flagged_naked(
+        self, logger: logging.Logger
+    ) -> None:
+        """Both legs fail (nothing posted) → no surviving leg to cancel and no
+        naked position was created by us. Must NOT emit the #504 naked signal
+        (that would misroute a benign rejection into remediation)."""
+        exch = _make_exchange(sl_ok=False, tp_ok=False)
+        oco = OCOManager(exchange=exch, logger=logger)
+        result = await oco.place_oco_orders(
+            position_id="p",
+            symbol="ETHUSDT",
+            position_side="LONG",
+            quantity=0.22,
+            stop_loss_price=200.0,
+            take_profit_price=260.0,
+        )
+        assert result["status"] == "failed"
+        # No surviving leg → no cancel call, no naked flag.
+        assert exch.client._request_futures_api.call_count == 0
+        assert result.get("position_naked") is None
+        assert result.get("requires_remediation") is None

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -463,6 +463,42 @@ class OCOManager:
                 self.logger.error("❌ FAILED TO PLACE OCO ORDERS")
                 self.logger.error(f"  SL Result: {sl_result}")
                 self.logger.error(f"  TP Result: {tp_result}")
+
+                # #504 (inverse of #482): a PARTIAL OCO failure means one leg
+                # posted and was then atomically cancelled above to avoid the
+                # -4509 orphan loop (#425/#482 — we deliberately keep that
+                # cancel). The consequence is that the position is now FULLY
+                # NAKED: entry filled, both protective legs gone. Previously
+                # this returned an opaque {"status": "failed"} that the caller
+                # (_place_risk_management_orders) treated identically to a
+                # benign rejection, silently falling back to individual-order
+                # placement with the SAME uncorrected prices — and when those
+                # also failed (the 2026-07-16 -2021 storm) the position was
+                # left naked with NO escalation. We now surface an explicit,
+                # actionable naked/escalation signal so the caller hands off to
+                # the exchange-authoritative naked-position remediator (re-arm
+                # with corrected pricing, or flatten after the grace window)
+                # instead of going silently unprotected.
+                if surviving_leg is not None:
+                    leg_label, surviving_id = surviving_leg
+                    self.logger.error(
+                        "🚨 POSITION NAKED after partial OCO failure for "
+                        f"{symbol} {position_side}: {leg_label} leg was posted "
+                        f"then cancelled (algoId={surviving_id}); no protection "
+                        "remains. Flagging for remediation (re-arm/flatten)."
+                    )
+                    return {
+                        "status": "failed",
+                        "position_naked": True,
+                        "requires_remediation": True,
+                        "escalate": True,
+                        "reason": "partial_oco_failure_surviving_leg_cancelled",
+                        "symbol": symbol,
+                        "position_side": position_side,
+                        "cancelled_leg": leg_label,
+                        "cancelled_algo_id": surviving_id,
+                    }
+
                 return {"status": "failed"}
 
         except Exception as e:
@@ -3913,6 +3949,38 @@ class Dispatcher:
                         f"reports no open position — skipping individual SL/TP "
                         f"fallback (AC3 of #445, prevents -4509 churn)"
                     )
+                elif oco_result.get("position_naked") or oco_result.get(
+                    "requires_remediation"
+                ):
+                    # #504 (inverse of #482): partial OCO failure — one leg
+                    # posted then was atomically cancelled, leaving the
+                    # position fully naked. Blindly falling back to
+                    # _place_individual_risk_orders here retries BOTH legs with
+                    # the SAME uncorrected prices (the exact loop that produced
+                    # the 2026-07-16 -2021 storm and ended every time with a
+                    # naked position). Instead we STOP the same-price retry and
+                    # hand off to the exchange-authoritative naked-position
+                    # remediator, whose periodic loop iterates Binance
+                    # positionRisk directly (independent of local state) and
+                    # will re-arm with corrected pricing or flatten after the
+                    # grace window. We do NOT mark the position closed — the
+                    # position is open and unprotected, and stops-health must
+                    # reflect that reality (AC3) rather than a false
+                    # position_closed.
+                    self.logger.error(
+                        "🚨 NAKED POSITION (partial OCO failure) for "
+                        f"{order.symbol} {oco_result.get('position_side')}: "
+                        "skipping same-price individual-order retry; handing "
+                        "off to naked-position remediator for re-arm/flatten "
+                        f"(#504). oco_result={oco_result}"
+                    )
+                    # Intentionally do NOT record risk-order IDs (there are
+                    # none) and do NOT mark the position closed. The position
+                    # is open and unprotected; leaving it without SL/TP order
+                    # IDs is what lets /positions/stops-health report it as
+                    # naked (AC3) instead of a false position_closed. The
+                    # exchange-authoritative remediator's periodic loop takes
+                    # it from here.
                 else:
                     self.logger.error(
                         f"❌ OCO ORDERS FAILED FOR {order.symbol}: {oco_result} - falling back to individual orders"


### PR DESCRIPTION
## Summary

Fixes #504 — on a **partial OCO placement failure** the dispatcher left the position **fully naked** with no escalation.

## Root cause

On partial OCO placement one leg posts and the counterparty fails. Per #425/#482 the surviving leg is **atomically cancelled** to avoid the -4509 orphan reduce-only loop (retained — reverting it reintroduces that bug). The #504 defect (inverse of #482) is what happened *after*: `OCOManager.place_oco_orders` returned an opaque `{"status": "failed"}`, and `_place_risk_management_orders` silently fell back to individual-order placement with the **same uncorrected prices**. When those also failed (2026-07-16 `-2021` storm) the position sat fully naked with no remediation.

## Changes

- `OCOManager.place_oco_orders` now returns an actionable escalation signal on partial failure: `position_naked`/`requires_remediation`/`escalate` plus the cancelled-leg context.
- `_place_risk_management_orders` detects that signal, **skips the same-price retry**, and hands off to the exchange-authoritative naked-position remediator (re-arm/flatten). It does **not** record bogus risk-order IDs or mark the position closed, so `/positions/stops-health` reflects the naked state.
- Regression tests cover all four 2026-07-16 partial-failure shapes and preserve #482 atomicity; the strict `xfail` on the escalation-contract test was removed now that it passes. Full-leg failure (nothing posted) is explicitly NOT misrouted into remediation.

## Acceptance Criteria

- [x] AC1 — Surviving leg behavior preserved atomically (#482 test still green); result now carries naked signal.
- [x] AC2 — On exhaustion, control passes to remediation (re-arm/flatten) instead of naked; no same-price blind retry.
- [x] AC3 — Partial-protection/naked state surfaced accurately (no false `position_closed`).
- [x] AC4 — Regression test covering all four 2026-07-16 partial-failure shapes.

## Verification

- `ruff format --check` + `ruff check`: clean
- `mypy tradeengine/dispatcher.py`: clean
- Full suite: **1844 passed, 12 skipped, 2 xfailed**, coverage **80.75%**

Closes #504
