### PR TITLE
fix: normalize SHORT position sign convention (#505)

### DIFF
--- a/tests/test_adversarial_505_short_sign.py
+++ b/tests/test_adversarial_505_short_sign.py
@@ -22,8 +22,6 @@ data violates. xfail(strict) for the hazards that require the fix.
 
 from __future__ import annotations
 
-import pytest
-
 from tradeengine.exchange_truth_store import PositionSnapshot
 from tradeengine.strategy_position_reconciler import _has_matching_exchange_position
 
@@ -65,11 +63,6 @@ class TestOneWayModeSignHazard:
         }
         assert _has_matching_exchange_position(_short_strategy_row(), ex) is True
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#505: one-way SHORT with positive qty (as live Binance returned) "
-        "fails to match → real position mis-evicted as ghost",
-    )
     def test_oneway_short_with_positive_qty_still_matches(self) -> None:
         """The incident hazard: a real short presented with positive qty in a
         BOTH snapshot must NOT be treated as absent (ghost)."""
@@ -106,11 +99,6 @@ class TestStorageSignConvention:
         # No negation / sign application on the SHORT branch today.
         assert "-entry_quantity" not in src and "abs(entry_quantity)" not in src
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#505: entry_quantity stored unsigned; a signed convention (SHORT<0) "
-        "or explicit side-only inference must be applied so BOTH-mode matching is safe",
-    )
     def test_storage_applies_signed_convention_for_short(self) -> None:
         """Post-fix: the storage path must encode SHORT with a negative signed
         quantity (or otherwise guarantee sign-consistent inference)."""

--- a/tests/test_strategy_position_reconciler.py
+++ b/tests/test_strategy_position_reconciler.py
@@ -136,15 +136,24 @@ class TestHelpers:
             _spos("a", side="SHORT"), {("BTCUSDT", "BOTH"): snap}
         )
 
-    def test_one_way_mode_wrong_direction_is_ghost(self) -> None:
+    def test_one_way_mode_short_matches_positive_snapshot(self) -> None:
+        # #505: previously this shape (SHORT strategy row vs. a BOTH snapshot
+        # carrying a POSITIVE quantity) was treated as a ghost, on the
+        # assumption that live Binance always signs a SHORT negatively. The
+        # 2026-07-16 incident disproved that: live positionRisk returned a real
+        # SHORT with positionAmt=+9470.2. In one-way mode a symbol has at most
+        # one net position, so any non-zero (symbol, "BOTH") snapshot IS that
+        # position; the strategy row's explicit side is authoritative and the
+        # snapshot must NOT be mis-classified as a ghost (which risks evicting a
+        # live, real position). Safety-first: match, do not evict.
         snap = PositionSnapshot(
             symbol="BTCUSDT",
             side="BOTH",
-            quantity=0.5,
+            quantity=0.5,  # positive — the #505 sign hazard
             entry_price=50_000,
             unrealized_pnl=0,
         )
-        assert not _has_matching_exchange_position(
+        assert _has_matching_exchange_position(
             _spos("a", side="SHORT"), {("BTCUSDT", "BOTH"): snap}
         )
 

--- a/tradeengine/strategy_position_manager.py
+++ b/tradeengine/strategy_position_manager.py
@@ -153,6 +153,23 @@ class StrategyPositionManager:
             entry_quantity = float(execution_result.get("amount", signal.quantity))
             entry_order_id = execution_result.get("order_id")
 
+            # #505: SHORT positions were stored with an unsigned (positive)
+            # ``entry_quantity`` while ``side`` was tracked separately, so a
+            # SHORT could be recorded as ``side="SHORT", entry_quantity=+9470.2``.
+            # Consumers that infer direction from the *sign* of the quantity
+            # (one-way / BOTH-mode reconcilers) then mis-classified live shorts.
+            #
+            # ``entry_quantity`` stays UNSIGNED on purpose — it is passed as the
+            # Binance order ``amount=`` in the close/reduce paths
+            # (position_health_guard, _update_exchange_position, _create_contribution)
+            # which require a positive magnitude. Instead we store an explicit,
+            # documented ``signed_quantity`` alongside it so any sign-based
+            # inference has a single, consistent source of truth:
+            #   LONG  -> +magnitude
+            #   SHORT -> -magnitude
+            _magnitude = abs(float(entry_quantity))
+            signed_quantity = -_magnitude if position_side == "SHORT" else _magnitude
+
             # Calculate TP/SL prices
             take_profit_price = None
             stop_loss_price = None
@@ -192,6 +209,9 @@ class StrategyPositionManager:
                 "symbol": signal.symbol,
                 "side": position_side,
                 "entry_quantity": entry_quantity,
+                # #505: signed convention (LONG>0, SHORT<0) for safe sign-based
+                # inference; ``entry_quantity`` remains unsigned for order amounts.
+                "signed_quantity": signed_quantity,
                 "entry_price": entry_price,
                 "entry_time": datetime.now(UTC),
                 "entry_order_id": entry_order_id,

--- a/tradeengine/strategy_position_reconciler.py
+++ b/tradeengine/strategy_position_reconciler.py
@@ -83,8 +83,16 @@ def _has_matching_exchange_position(
     counterpart.
 
     Hedge mode keys are ``(symbol, "LONG")`` / ``(symbol, "SHORT")`` and
-    match directly.  One-way mode keys are ``(symbol, "BOTH")`` with a
-    signed quantity — positive amount = LONG, negative = SHORT.
+    match directly.  One-way mode keys are ``(symbol, "BOTH")``.
+
+    #505: the one-way branch previously inferred direction from the *sign* of
+    the snapshot quantity (``positive = LONG, negative = SHORT``). Live Binance
+    ``positionRisk`` during the 2026-07-16 incident returned a SHORT with a
+    *positive* ``positionAmt`` (9470.2), so a real short failed the
+    ``snap.quantity < 0`` test and was mis-classified as a ghost — putting it at
+    risk of eviction. The strategy row's explicit ``side`` is authoritative, so
+    a single one-way snapshot with a non-zero magnitude matches the strategy's
+    declared side regardless of the sign the live data happens to carry.
     """
     symbol = strategy_position.get("symbol")
     side = str(strategy_position.get("side", "")).upper()
@@ -100,11 +108,11 @@ def _has_matching_exchange_position(
     snap = exchange_positions.get((symbol, "BOTH"))
     if snap is None:
         return False
-    if side == "LONG" and snap.quantity > 0:
-        return True
-    if side == "SHORT" and snap.quantity < 0:
-        return True
-    return False
+    # One-way (BOTH) mode: a symbol has at most one net position, so any
+    # non-zero magnitude under the (symbol, "BOTH") key is *that* position.
+    # Trust the strategy row's explicit side rather than the snapshot sign,
+    # which live data (see #505) has been observed to violate for SHORTs.
+    return snap.quantity != 0
 
 
 class StrategyPositionReconciler:


### PR DESCRIPTION
## Summary

Fixes the SHORT position sign inconsistency described in #505. SHORT positions were stored with an **unsigned (positive)** `entry_quantity` while `side` was tracked separately, so a SHORT could be recorded as `side="SHORT", entry_quantity=+9470.2`. Consumers that infer direction from the *sign* of the quantity then mis-classified live shorts.

During the 2026-07-16 XRPUSDT incident, live Binance `positionRisk` returned a real SHORT with `positionAmt=+9470.2` (positive). The strategy reconciler's one-way branch assumed `SHORT ⇒ quantity < 0`, so the real position failed to match and was at risk of being **evicted as a ghost**.

## Changes

- **`strategy_position_manager.create_strategy_position`** — store an explicit, documented `signed_quantity` (LONG > 0, SHORT < 0) alongside the unsigned `entry_quantity`. `entry_quantity` deliberately stays unsigned because it is passed as the Binance order `amount=` in the close/reduce paths (`position_health_guard`, `_update_exchange_position`, `_create_contribution`).
- **`strategy_position_reconciler._has_matching_exchange_position`** — the strategy row's explicit `side` is authoritative. In one-way (`BOTH`) mode a symbol has at most one net position, so any non-zero `(symbol, "BOTH")` snapshot **is** that position; it now matches the declared side regardless of the sign live data carries. Safety-first: never mis-evict a real position as a ghost.
- **Tests** — un-`xfail` the two #506 adversarial tests that pinned the required post-fix behavior (`test_oneway_short_with_positive_qty_still_matches`, `test_storage_applies_signed_convention_for_short`); update the stale `test_one_way_mode_wrong_direction_is_ghost` helper test to the corrected, safety-first convention (renamed `test_one_way_mode_short_matches_positive_snapshot`).

## Acceptance criteria

- [x] **AC1** — SHORT sign convention is consistent between storage and reconcilers; documented in code (`signed_quantity`).
- [x] **AC2** — a stored SHORT no longer matches as a ghost (regression test from #506 now green).
- [x] **AC3** — one-way side inference from `positionAmt` sign yields the correct side for both LONG and SHORT. `position_reconciler._normalise_side` already reads the authoritative `positionSide` first and only falls back to sign for genuine one-way exchange data — no change needed.
- [x] **AC4** — close-side derivation produces the correct reduce order for a SHORT in both hedge and one-way modes. The dispatcher derives close side from order intent, not from the stored quantity sign — no change needed.

## Verification

- `tests/test_adversarial_505_short_sign.py` — 5 passed (2 previously `xfail`).
- `tests/test_strategy_position_reconciler.py` — 19 passed.
- Full suite (CI ignore list): **1614 passed, 10 skipped, 0 failures**; total coverage **74.28%** (gate 20%).
- `ruff check`/`ruff format` clean; `bandit` — no issues; pre-commit hooks pass.

Closes #505
