### PR TITLE
[INFRA] OCO pair age metric — visibility for stale OCO pairs (#972)

### DIFF
--- a/tests/test_oco_pair_age_metric.py
+++ b/tests/test_oco_pair_age_metric.py
@@ -1,0 +1,137 @@
+"""Tests for the #972 ``oco_pair_age_seconds`` gauge.
+
+AC3 of PetroSa2/petrosa_k8s#972:
+- assert the gauge is updated on each ``_monitor_orders`` cycle
+- assert the (symbol, position_side) series is removed on pair completion
+
+The tests drive exactly one iteration of ``OCOManager._monitor_orders`` by
+using a mocked exchange whose ``get_all_open_orders`` flips
+``monitoring_active`` to ``False`` after the first cycle, so the ``while``
+loop exits deterministically without a real 2s sleep dependency.
+
+Run with: ``uv run pytest tests/test_oco_pair_age_metric.py -v``
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tradeengine.dispatcher import OCOManager
+from tradeengine.metrics import oco_pair_age_seconds
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test-oco-pair-age-972")
+
+
+@pytest.fixture(autouse=True)
+def _clear_gauge() -> Any:
+    """Ensure a clean gauge between tests so cross-test series don't leak."""
+    oco_pair_age_seconds.clear()
+    yield
+    oco_pair_age_seconds.clear()
+
+
+def _read_gauge(symbol: str, position_side: str) -> float | None:
+    """Return the current gauge value for a label set, or None if absent."""
+    from prometheus_client import REGISTRY
+
+    return REGISTRY.get_sample_value(
+        "petrosa_tradeengine_oco_pair_age_seconds",
+        {"symbol": symbol, "position_side": position_side},
+    )
+
+
+def _make_oco_info(
+    *, symbol: str, position_side: str, created_at: float, status: str = "active"
+) -> dict[str, Any]:
+    return {
+        "position_id": f"{symbol}-{position_side}",
+        "strategy_position_id": None,
+        "entry_price": 0.0,
+        "quantity": 1.0,
+        "sl_order_id": "sl-1",
+        "tp_order_id": "tp-1",
+        "symbol": symbol,
+        "position_side": position_side,
+        "status": status,
+        "created_at": created_at,
+    }
+
+
+@pytest.mark.asyncio
+async def test_gauge_updated_on_monitor_cycle(logger: logging.Logger) -> None:
+    """An active pair reports a positive age after one monitor cycle."""
+    exch = AsyncMock()
+    oco = OCOManager(exchange=exch, logger=logger)
+
+    # Seed one active OCO pair created ~30s ago.
+    created_at = time.time() - 30.0
+    oco.active_oco_pairs["BTCUSDT_LONG"] = [
+        _make_oco_info(symbol="BTCUSDT", position_side="LONG", created_at=created_at)
+    ]
+    oco.monitoring_active = True
+
+    async def _get_all_open_orders(symbol: str) -> list[str]:
+        # Both legs still open → pair remains active. Stop after this cycle.
+        oco.monitoring_active = False
+        return ["sl-1", "tp-1"]
+
+    exch.get_all_open_orders = _get_all_open_orders
+
+    await oco._monitor_orders()
+
+    age = _read_gauge("BTCUSDT", "LONG")
+    assert age is not None, "gauge series must exist for the active pair"
+    # Age is time since created_at; at least the ~30s we backdated.
+    assert age >= 30.0
+    # Pair is still active (both legs open), so it stays tracked.
+    assert oco.active_oco_pairs.get("BTCUSDT_LONG")
+
+
+@pytest.mark.asyncio
+async def test_gauge_removed_on_pair_completion(logger: logging.Logger) -> None:
+    """When both legs vanish the pair completes and its series is removed."""
+    exch = AsyncMock()
+    oco = OCOManager(exchange=exch, logger=logger)
+
+    created_at = time.time() - 10.0
+    oco.active_oco_pairs["ETHUSDT_SHORT"] = [
+        _make_oco_info(symbol="ETHUSDT", position_side="SHORT", created_at=created_at)
+    ]
+    oco.monitoring_active = True
+
+    # Pre-seed a stale value so we can prove removal (not just absence).
+    oco_pair_age_seconds.labels(symbol="ETHUSDT", position_side="SHORT").set(999.0)
+
+    async def _get_all_open_orders(symbol: str) -> list[str]:
+        # Neither leg exists → OCO completed this cycle.
+        oco.monitoring_active = False
+        return []
+
+    exch.get_all_open_orders = _get_all_open_orders
+
+    await oco._monitor_orders()
+
+    # Completed pair: key removed from active set...
+    assert "ETHUSDT_SHORT" not in oco.active_oco_pairs
+    # ...and the gauge series removed (get_sample_value returns None).
+    assert _read_gauge("ETHUSDT", "SHORT") is None
+
+
+def test_remove_helper_is_idempotent(logger: logging.Logger) -> None:
+    """_remove_oco_pair_age_series swallows KeyError for unknown series."""
+    oco = OCOManager(exchange=AsyncMock(), logger=logger)
+    # Never observed → remove must not raise.
+    oco._remove_oco_pair_age_series("NOSUCH", "LONG")
+    # Observe then remove twice → second remove must not raise.
+    oco_pair_age_seconds.labels(symbol="ADAUSDT", position_side="LONG").set(1.0)
+    oco._remove_oco_pair_age_series("ADAUSDT", "LONG")
+    oco._remove_oco_pair_age_series("ADAUSDT", "LONG")
+    assert _read_gauge("ADAUSDT", "LONG") is None

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -20,10 +20,12 @@ from tradeengine.leverage_bound_guard import LeverageBoundGuard
 from tradeengine.metrics import (
     atomic_rollback_failed_total,
     dispatcher_thrash_circuit_open_total,
+    oco_pair_age_seconds,
     order_execution_latency_seconds,
     order_failures_total,
     order_placement_skipped_total,
     orders_executed_by_type,
+    otel_oco_pair_age_seconds,
     risk_checks_total,
     risk_rejections_total,
     strategy_close_blocked_no_exchange_position_total,
@@ -1186,6 +1188,40 @@ class OCOManager:
                         outcome="failed_other", symbol=symbol
                     ).inc()
 
+    @staticmethod
+    def _coerce_created_at(value: Any, fallback: float) -> float:
+        """#972: return an epoch-seconds float for an OCO pair's created_at.
+
+        Production code stores ``time.time()`` (a float), but tests and any
+        future serialization path may present an int or an ISO-8601 string.
+        Anything unparseable falls back to ``fallback`` (yielding age ~0)
+        rather than raising and aborting the monitor cycle.
+        """
+        if isinstance(value, int | float):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                # Accept trailing 'Z' as UTC.
+                dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+                return dt.timestamp()
+            except ValueError:
+                return fallback
+        return fallback
+
+    def _remove_oco_pair_age_series(self, symbol: str, position_side: str) -> None:
+        """#972: drop the oco_pair_age_seconds series for a completed pair.
+
+        prometheus_client raises KeyError if the (symbol, position_side) label
+        set was never observed; that is benign here (the series may have already
+        been removed on a prior cycle) so we swallow it. The OTel synchronous
+        gauge has no per-series removal API — it simply stops receiving points
+        for a label set, which the SDK ages out — so nothing to do there.
+        """
+        try:
+            oco_pair_age_seconds.remove(symbol, position_side)
+        except KeyError:
+            pass
+
     async def _monitor_orders(self) -> None:
         """
         Monitor active orders for fills and trigger OCO logic
@@ -1220,6 +1256,37 @@ class OCOManager:
                     symbol = oco_list[0]["symbol"] if oco_list else None
                     if not symbol:
                         continue
+
+                    # #972: publish OCO pair age (seconds since the pair entered
+                    # active_oco_pairs). Set every cycle for each active pair so a
+                    # stuck/stale pair (>300s) is visible in Grafana. Dual-export
+                    # (prometheus + OTel) per the #415/#497 pattern. Guarded so a
+                    # malformed created_at can never abort the monitor cycle.
+                    _now = time.time()
+                    for _oco in oco_list:
+                        if _oco.get("status") != "active":
+                            continue
+                        try:
+                            _created = self._coerce_created_at(
+                                _oco.get("created_at"), _now
+                            )
+                            _age = _now - _created
+                            oco_pair_age_seconds.labels(
+                                symbol=_oco["symbol"],
+                                position_side=_oco["position_side"],
+                            ).set(_age)
+                            otel_oco_pair_age_seconds.set(
+                                _age,
+                                {
+                                    "symbol": _oco["symbol"],
+                                    "position_side": _oco["position_side"],
+                                },
+                            )
+                        except Exception as _age_err:  # pragma: no cover - defensive
+                            self.logger.debug(
+                                "oco_pair_age_seconds update skipped for "
+                                f"{_oco.get('symbol')} {_oco.get('position_side')}: {_age_err}"
+                            )
 
                     # Query all open orders for this symbol once
                     # Use the robust combined list (Standard + Algo) to avoid ghost orders
@@ -1340,12 +1407,24 @@ class OCOManager:
 
                 # Clean up completed OCO pairs
                 for exchange_position_key in list(self.active_oco_pairs.keys()):
-                    # Filter out completed pairs
+                    # #972: drop the age gauge series for pairs leaving the active
+                    # set (completed/cancelled/externally-closed) so they don't
+                    # report a frozen age forever. Remove the (symbol,
+                    # position_side) series when no active pair remains for it.
                     active_pairs = [
                         oco
                         for oco in self.active_oco_pairs[exchange_position_key]
                         if oco["status"] == "active"
                     ]
+                    _active_label_pairs = {
+                        (oco["symbol"], oco["position_side"]) for oco in active_pairs
+                    }
+                    for _oco in self.active_oco_pairs[exchange_position_key]:
+                        _label_pair = (_oco["symbol"], _oco["position_side"])
+                        if _oco["status"] != "active" and (
+                            _label_pair not in _active_label_pairs
+                        ):
+                            self._remove_oco_pair_age_series(*_label_pair)
 
                     if active_pairs:
                         self.active_oco_pairs[exchange_position_key] = active_pairs

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -236,6 +236,19 @@ oco_orphan_count = Gauge(
     "Current number of OCO orphans: positions on Binance that lack their full stop/target pair",
 )
 
+# #972 — OCO pair age: seconds since an OCO pair entered ``active_oco_pairs``.
+# An OCO pair that stays active for a long time (>300s) signals a stuck monitor
+# loop, a silently-failed cancellation, or a race. The gauge is set every
+# ``_monitor_orders`` cycle (2s cadence) and the (symbol, position_side) series
+# is removed when the pair completes/cancels so a stale pair never reports a
+# frozen-but-climbing age. Dual-exported (see ``otel_oco_pair_age_seconds``
+# below, per #415/#497) so the Grafana Cloud OTLP datasource sees it too.
+oco_pair_age_seconds = Gauge(
+    "petrosa_tradeengine_oco_pair_age_seconds",
+    "Age in seconds of each active OCO pair (time since it entered active_oco_pairs)",
+    ["symbol", "position_side"],
+)
+
 # #484 — stops-health violation alarms. The 2026-06-18 testnet diagnosis showed
 # violation_count=12 with alarms_emitted=0: alarms only fired on the force-close
 # branch, so a "successful" (or lying) remediation silenced the operator-facing
@@ -522,4 +535,13 @@ otel_oco_orphan_leg = meter.create_counter(
 otel_oco_orphan_count = meter.create_up_down_counter(
     "petrosa_tradeengine_oco_orphan_count",
     description="Current number of OCO orphans: positions lacking their full stop/target pair (OTLP dual-export)",
+)
+
+# #972 — OCO pair age (OTLP dual-export). Synchronous gauge; .set() is called
+# alongside the prometheus_client Gauge each _monitor_orders cycle. Mirrors the
+# prometheus metric name for cross-system correlation in Grafana.
+otel_oco_pair_age_seconds = meter.create_gauge(
+    "petrosa_tradeengine_oco_pair_age_seconds",
+    description="Age in seconds of each active OCO pair (time since it entered active_oco_pairs) (OTLP dual-export)",
+    unit="s",
 )


### PR DESCRIPTION
## Summary

Implements the tradeengine portion of PetroSa2/petrosa_k8s#972 — visibility for stale OCO pairs.

Adds a new `oco_pair_age_seconds` gauge that reports, per active OCO pair, the seconds since it entered `active_oco_pairs`. An OCO pair that stays active for >300s signals a stuck monitor loop, a silently-failed cancellation, or a race — previously invisible.

## Changes

- **`tradeengine/metrics.py`**: new `oco_pair_age_seconds` prometheus Gauge (labels `symbol`, `position_side`) + dual-export OTel synchronous gauge `otel_oco_pair_age_seconds`, following the #415/#497 dual-export pattern so the metric reaches the Grafana Cloud OTLP datasource (not just the Prometheus pull path).
- **`tradeengine/dispatcher.py`**:
  - `_monitor_orders` sets the gauge for each active pair every cycle (2s cadence), using the `created_at` epoch already stamped at placement.
  - On pair completion/cancellation the `(symbol, position_side)` series is removed (`_remove_oco_pair_age_series`) so a stale pair never reports a frozen-but-climbing age.
  - `_coerce_created_at` defensively parses `created_at` (float/int/ISO string) so a malformed value can never abort the monitor loop.
- **`tests/test_oco_pair_age_metric.py`**: gauge updated on a monitor cycle; series removed on completion; idempotent remove helper.

## Acceptance Criteria

- [x] **AC1** — `oco_pair_age_seconds` gauge, labels `symbol`/`position_side`, updated every `_monitor_orders` cycle, removed on completion/cancellation.
- [x] **AC3** — unit tests (update-on-cycle, remove-on-completion). Run: `uv run pytest tests/test_oco_pair_age_metric.py -v`
- [ ] **AC2** — dashboard panel ships in **petrosa_k8s** (`oco-tracking-dashboard.json`) via a separate PR (cross-repo infra ticket).

## Validation

- `ruff format` / `ruff check` — clean
- `mypy --strict` — no issues
- `bandit -ll` — no issues
- Full suite: **1866 passed, 12 skipped**, coverage **80.82%** (floor 40%)
- pre-commit hooks — pass

Closes PetroSa2/petrosa_k8s#972
