### PR TITLE
fix: #522 - bandit-wrapper.sh: add python -m fallback when binary not on PATH

### DIFF
--- a/scripts/bandit-wrapper.sh
+++ b/scripts/bandit-wrapper.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
 # Wrapper script for bandit to handle argument parsing correctly
 # Ignore all arguments passed by pre-commit (they are file paths)
-bandit -ll -r . -c .bandit
+#
+# Fallback logic (per #522):
+#   1. Prefer bare `bandit` binary on PATH
+#   2. Fall back to the project venv's `python -m bandit`
+#   3. Fail with a clear install message if neither works
+
+if command -v bandit >/dev/null 2>&1; then
+    bandit -ll -r . -c .bandit
+else
+    # Detect project venv python (relative to this script's repo root)
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+    VENV_PYTHON="$REPO_ROOT/.venv/bin/python"
+
+    if [ -x "$VENV_PYTHON" ] && "$VENV_PYTHON" -m bandit --version >/dev/null 2>&1; then
+        "$VENV_PYTHON" -m bandit -ll -r . -c .bandit
+    else
+        echo "ERROR: bandit is not installed. Run: uv pip install -r requirements-dev.txt" >&2
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Summary

Closes #522.

Updates `scripts/bandit-wrapper.sh` to gracefully fall back to the project venv's `python -m bandit` when the bare `bandit` binary is not available on PATH.

## Changes

- Added detection of project `.venv/bin/python` when `bandit` command is missing
- Falls back to `python -m bandit` via the venv interpreter
- Prints a clear install message if neither works
- Preserves existing flags (`-ll -r . -c .bandit`)

## Testing

- [x] `pre-commit run bandit --all-files` passes
- [x] Wrapper works when only `.venv/bin` bandit is present (no PATH bandit)
- [x] Pre-push hook passes all checks