### PR TITLE
fix: #527 second-wave OCO orphan — resolve SL safety floor deadlock

### DIFF
--- a/.github/deployments/flip-remediation-mode.sh
+++ b/.github/deployments/flip-remediation-mode.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# C3: Flip naked-position remediation mode from dry_run → arm_or_flatten.
+#
+# Run AFTER the new image (with C1/C2) is deployed. The mode flip must be
+# atomic with the image — do NOT flip before the deploy or the remediator
+# will attempt re-arms with the old 2% fallback (un-armable against the
+# 6% safety floor) and degrade to flatten-everything.
+#
+# Usage:
+#   bash .github/deployments/flip-remediation-mode.sh [--dry-run]
+#
+# Requires: kubectl with petrosa kubeconfig, TE_NAKED_POSITION_REMEDIATION_MODE
+#           must currently be "dry_run".
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+DEPLOY="petrosa-tradeengine"
+NAMESPACE="petrosa-apps"
+KUBECTL="kubectl --kubeconfig=petrosa_k8s/k8s/kubeconfig.yaml --insecure-skip-tls-verify=true"
+
+CURRENT=$($KUBECTL get deploy "$DEPLOY" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="TE_NAKED_POSITION_REMEDIATION_MODE")].value}')
+
+echo "Current TE_NAKED_POSITION_REMEDIATION_MODE: $CURRENT"
+
+if [[ "$CURRENT" != "dry_run" ]]; then
+  echo "ERROR: expected 'dry_run', got '$CURRENT'. Aborting to avoid double-flip."
+  exit 1
+fi
+
+if $DRY_RUN; then
+  echo "[dry-run] Would patch TE_NAKED_POSITION_REMEDIATION_MODE → arm_or_flatten"
+  exit 0
+fi
+
+$KUBECTL set env deploy/"$DEPLOY" -n "$NAMESPACE" \
+  TE_NAKED_POSITION_REMEDIATION_MODE=arm_or_flatten
+
+echo "✅ TE_NAKED_POSITION_REMEDIATION_MODE set to arm_or_flatten"
+echo "   Verify: kubectl -n $NAMESPACE logs deploy/$DEPLOY --since=5m | grep NakedPositionRemediator"
+echo "   Watch:  tradeengine_naked_position_rearmed_total{outcome='armed'} should increment"

--- a/shared/config.py
+++ b/shared/config.py
@@ -110,7 +110,18 @@ class Settings(BaseSettings):
     naked_position_flatten_grace_sec: int = 60
     # Fallback SL/TP distances (% from entry) when local strategy record
     # has no stored stop_loss_price/take_profit_price for a naked position.
-    naked_position_fallback_sl_pct: float = 2.0
+    #
+    # CRITICAL (2026-07-20 second-wave OCO-orphan incident): the SL fallback
+    # MUST clear te_min_sl_distance_pct (the safety floor, default 6.0%).
+    # A fallback below the floor is un-armable — the price-adjuster in
+    # BinanceFuturesExchange.execute() returns (False, None, reason) for any
+    # STOP inside the floor, the re-arm raises, and arm_or_flatten degrades to
+    # "flatten everything after the grace window". The old 2.0% value was
+    # hardwired to lose that fight. Keep this >= te_min_sl_distance_pct with a
+    # small margin so the re-armed stop lands just outside the floor.
+    # TP is not floor-constrained (TPs may sit near market), so its fallback
+    # is unchanged.
+    naked_position_fallback_sl_pct: float = 6.5
     naked_position_fallback_tp_pct: float = 4.0
 
     model_config = {

--- a/tests/unit/test_naked_position_remediator.py
+++ b/tests/unit/test_naked_position_remediator.py
@@ -70,6 +70,9 @@ def _make_remediator(
     exchange_execute_raises: bool = False,
     close_return: dict | None = None,
     close_raises: bool = False,
+    fallback_sl_pct: float = 2.0,
+    fallback_tp_pct: float = 4.0,
+    min_sl_distance_pct: float = 0.0,
 ) -> tuple[NakedPositionRemediator, MagicMock, MagicMock, AsyncMock, _FakeClock]:
     exchange = MagicMock()
     if exchange_execute_raises:
@@ -94,6 +97,9 @@ def _make_remediator(
         close_position=close_cb,
         mode=mode,  # type: ignore[arg-type]
         flatten_grace_sec=grace_sec,
+        fallback_sl_pct=fallback_sl_pct,
+        fallback_tp_pct=fallback_tp_pct,
+        min_sl_distance_pct=min_sl_distance_pct,
         clock=clock,
     )
     return remediator, exchange, pm, close_cb, clock
@@ -336,6 +342,80 @@ def test_derive_returns_none_for_missing_entry_price() -> None:
         "BTCUSDT", "LONG", {("BTCUSDT", "LONG"): {"entryPrice": 0}}
     )
     assert sl is None and tp is None
+
+
+# ---------------------------------------------------------------------------
+# Second-wave OCO-orphan fix: SL clamped to safety floor (C1 + C2)
+# ---------------------------------------------------------------------------
+
+
+def test_derive_widens_too_tight_stored_long_sl_to_floor() -> None:
+    """C2: a stored LONG SL tighter than the floor is widened out.
+
+    entry=100, floor=6% → LONG SL must be <= 94.0. A stored 97.6 (2.4%)
+    is un-armable, so it is widened down to 94.0.
+    """
+    r, _, _, _, _ = _make_remediator(mode="arm_only", min_sl_distance_pct=6.0)
+    positions = _binance_positions("BTCUSDT", "LONG", 100.0)
+    positions[("BTCUSDT", "LONG")]["stop_loss_price"] = 97.6
+    r._position_manager.get_positions = MagicMock(
+        return_value={("BTCUSDT", "LONG"): {"stop_loss_price": 97.6}}
+    )
+    sl, _ = r._derive_protective_prices("BTCUSDT", "LONG", positions)
+    assert sl == pytest.approx(94.0)  # widened to floor, not left at 97.6
+
+
+def test_derive_widens_too_tight_stored_short_sl_to_floor() -> None:
+    """C2: a stored SHORT SL tighter than the floor is widened up.
+
+    entry=100, floor=6% → SHORT SL must be >= 106.0. A stored 102.4 (2.4%)
+    is un-armable, so it is widened up to 106.0.
+    """
+    r, _, _, _, _ = _make_remediator(mode="arm_only", min_sl_distance_pct=6.0)
+    positions = _binance_positions("BTCUSDT", "SHORT", 100.0)
+    r._position_manager.get_positions = MagicMock(
+        return_value={("BTCUSDT", "SHORT"): {"stop_loss_price": 102.4}}
+    )
+    sl, _ = r._derive_protective_prices("BTCUSDT", "SHORT", positions)
+    assert sl == pytest.approx(106.0)
+
+
+def test_derive_leaves_compliant_stored_sl_untouched() -> None:
+    """A stored SL already outside the floor is preserved (strategy intent)."""
+    r, _, _, _, _ = _make_remediator(mode="arm_only", min_sl_distance_pct=6.0)
+    positions = _binance_positions("BTCUSDT", "LONG", 100.0)
+    r._position_manager.get_positions = MagicMock(
+        return_value={("BTCUSDT", "LONG"): {"stop_loss_price": 90.0}}  # 10% away
+    )
+    sl, _ = r._derive_protective_prices("BTCUSDT", "LONG", positions)
+    assert sl == pytest.approx(90.0)
+
+
+def test_derive_fallback_sl_clears_floor_when_configured() -> None:
+    """C1: a fallback SL below the floor is widened out to the floor.
+
+    With the old 2% fallback and a 6% floor, the fallback SL (98.0 LONG)
+    is un-armable; the clamp widens it to 94.0.
+    """
+    r, _, _, _, _ = _make_remediator(
+        mode="arm_only", fallback_sl_pct=2.0, min_sl_distance_pct=6.0
+    )
+    sl, _ = r._derive_protective_prices(
+        "BTCUSDT", "LONG", _binance_positions("BTCUSDT", "LONG", 100.0)
+    )
+    assert sl == pytest.approx(94.0)
+
+
+def test_derive_no_clamp_when_floor_disabled() -> None:
+    """min_sl_distance_pct=0 disables the clamp (legacy behaviour)."""
+    r, _, _, _, _ = _make_remediator(mode="arm_only", min_sl_distance_pct=0.0)
+    r._position_manager.get_positions = MagicMock(
+        return_value={("BTCUSDT", "LONG"): {"stop_loss_price": 99.0}}
+    )
+    sl, _ = r._derive_protective_prices(
+        "BTCUSDT", "LONG", _binance_positions("BTCUSDT", "LONG", 100.0)
+    )
+    assert sl == pytest.approx(99.0)  # left tight, not widened
 
 
 # ---------------------------------------------------------------------------

--- a/tradeengine/api.py
+++ b/tradeengine/api.py
@@ -236,6 +236,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     flatten_grace_sec=_te_settings.naked_position_flatten_grace_sec,
                     fallback_sl_pct=_te_settings.naked_position_fallback_sl_pct,
                     fallback_tp_pct=_te_settings.naked_position_fallback_tp_pct,
+                    # Pass the safety floor so the remediator widens any
+                    # too-tight stored SL out to a placeable distance instead
+                    # of re-arming with a guaranteed-to-fail price (#second-wave
+                    # OCO-orphan: 2.4% strategy SL vs 6% floor deadlock).
+                    min_sl_distance_pct=_te_settings.te_min_sl_distance_pct,
                 )
             except Exception:
                 logger.exception(

--- a/tradeengine/naked_position_remediator.py
+++ b/tradeengine/naked_position_remediator.py
@@ -97,6 +97,7 @@ class NakedPositionRemediator:
         flatten_grace_sec: int = 60,
         fallback_sl_pct: float = 2.0,
         fallback_tp_pct: float = 4.0,
+        min_sl_distance_pct: float = 6.0,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._exchange = exchange
@@ -106,6 +107,12 @@ class NakedPositionRemediator:
         self._flatten_grace_sec = max(int(flatten_grace_sec), 0)
         self._fallback_sl_pct = float(fallback_sl_pct)
         self._fallback_tp_pct = float(fallback_tp_pct)
+        # The exchange safety floor (te_min_sl_distance_pct). A stored
+        # strategy SL tighter than this is un-armable — the price-adjuster
+        # rejects it — so _derive_protective_prices widens it out to the
+        # floor rather than handing the re-arm a guaranteed-to-fail price
+        # (2026-07-20 second-wave OCO-orphan incident).
+        self._min_sl_distance_pct = float(min_sl_distance_pct)
         self._clock = clock
         # (symbol, side) -> first-seen monotonic timestamp
         self._first_seen: dict[tuple[str, str], float] = {}
@@ -398,6 +405,13 @@ class NakedPositionRemediator:
         intent. Fallback exists because the whole point of #445 is that
         local state may be stale or missing — the exchange position is
         the ground truth.
+
+        Second-wave OCO-orphan fix (2026-07-20): a stored strategy SL that
+        is tighter than the exchange safety floor (te_min_sl_distance_pct)
+        is un-armable — the price-adjuster rejects it and the re-arm fails,
+        degrading arm_or_flatten to flatten-everything. When we know the
+        entry price, any SL inside the floor band is WIDENED out to the
+        floor so the re-arm can actually place. TP is not floor-constrained.
         """
         sl_price: float | None = None
         tp_price: float | None = None
@@ -421,9 +435,8 @@ class NakedPositionRemediator:
             except (TypeError, ValueError):
                 pass
 
-        if sl_price is not None and tp_price is not None:
-            return sl_price, tp_price
-
+        # Resolve entry price unconditionally — needed both for the fallback
+        # legs AND to clamp a too-tight stored SL out to the safety floor.
         entry_price: float | None = None
         if binance_positions:
             bp = binance_positions.get((symbol, side))
@@ -433,9 +446,12 @@ class NakedPositionRemediator:
                 except (TypeError, ValueError):
                     entry_price = None
 
+        # Without an entry price we cannot compute the floor band or the
+        # fallback — return whatever local values we have (legacy behaviour).
         if entry_price is None or entry_price <= 0:
             return sl_price, tp_price
 
+        # Fill missing legs from the entry-anchored fallback.
         if sl_price is None:
             if side == "LONG":
                 sl_price = entry_price * (1.0 - self._fallback_sl_pct / 100.0)
@@ -446,6 +462,41 @@ class NakedPositionRemediator:
                 tp_price = entry_price * (1.0 + self._fallback_tp_pct / 100.0)
             else:
                 tp_price = entry_price * (1.0 - self._fallback_tp_pct / 100.0)
+
+        # Clamp a too-tight SL (stored OR fallback) out to the safety floor.
+        # LONG SL is below entry: it must be <= entry * (1 - floor).
+        # SHORT SL is above entry: it must be >= entry * (1 + floor).
+        if sl_price is not None and self._min_sl_distance_pct > 0:
+            floor = self._min_sl_distance_pct / 100.0
+            if side == "LONG":
+                floor_price = entry_price * (1.0 - floor)
+                if sl_price > floor_price:
+                    logger.warning(
+                        "NakedPositionRemediator: widening too-tight LONG SL "
+                        "%s/%s from %s to floor %s (entry=%s, floor=%.2f%%)",
+                        symbol,
+                        side,
+                        sl_price,
+                        floor_price,
+                        entry_price,
+                        self._min_sl_distance_pct,
+                    )
+                    sl_price = floor_price
+            else:
+                floor_price = entry_price * (1.0 + floor)
+                if sl_price < floor_price:
+                    logger.warning(
+                        "NakedPositionRemediator: widening too-tight SHORT SL "
+                        "%s/%s from %s to floor %s (entry=%s, floor=%.2f%%)",
+                        symbol,
+                        side,
+                        sl_price,
+                        floor_price,
+                        entry_price,
+                        self._min_sl_distance_pct,
+                    )
+                    sl_price = floor_price
+
         return sl_price, tp_price
 
     def _resolve_position_id(self, symbol: str, side: str) -> str:


### PR DESCRIPTION
## Problem
Strategy signals emit 2.4% SLs but the engine enforces a 6% safety floor. The SL leg is physically un-armable → every OCO fails → TP cancels → naked position. Remediation was `dry_run` AND its 2.0% fallback also failed the floor.

## Fix
- **C1**: `naked_position_fallback_sl_pct` 2.0 → 6.5 (clears the floor)
- **C2**: `_derive_protective_prices()` widens too-tight stored SL to the floor
- **C3**: `.github/deployments/flip-remediation-mode.sh` (apply AFTER deploy)

## Deploy Order
1. Merge this PR → deploys new image
2. `bash .github/deployments/flip-remediation-mode.sh`
3. Verify `tradeengine_naked_position_rearmed_total{outcome="armed"}` increments

Closes #527