### PR TITLE
feat: #529 emit fill audit fields on execution events

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -24,3 +24,26 @@ A valid organic trade signal must include the following mandatory fields at a mi
 *   `strategy` (str): Human-readable name of the strategy.
 
 Failure to provide all required fields will result in a Pydantic validation error, and the signal will be discarded.
+
+## Execution Event Contract (`execution.events`)
+
+The engine publishes order-lifecycle events to NATS (`execution.events.*`); `petrosa-data-manager`
+persists them to the `execution_events` collection, which is the system's trade audit trail.
+
+Every event carries `decision_id`, `strategy_id`, `order_id`, `event_type`
+(`placed` / `filled` / `partial_fill` / `rejected`), `timestamp`, `symbol`, `side` and `qty`.
+
+Fill events (`filled`, `partial_fill`) additionally carry the audit fields below, emitted from
+`Dispatcher._emit_execution_event_from_order`:
+
+| Field | Source | Notes |
+| --- | --- | --- |
+| `fill_price` | exchange `fill_price` / `average_price` | mirrored to `price` — data-manager's PnL calculator reads that key |
+| `fill_quantity` | exchange `amount` / `filled` | mirrored to `fill_qty` for backwards compatibility |
+| `fill_time` | exchange `fill_time` / `timestamp` | normalised to a UTC ISO-8601 string; Binance ms-epoch `transactTime` is converted |
+| `fee` | exchange `fees` | absolute fee amount |
+| `fee_asset` | exchange `fee_asset`, else first `fills[].commissionAsset` | e.g. `BNB`, `USDT` |
+| `pnl` | exchange `pnl` | emitted as explicit `null` on fills when the exchange does not report it, so consumers can distinguish "unknown" from "omitted" |
+
+Fields are omitted (rather than sent as `null`) when the exchange does not report them, except
+`pnl` on fill events as noted above. Consumers must treat every audit field as optional.

--- a/tests/test_dispatcher_execution_events.py
+++ b/tests/test_dispatcher_execution_events.py
@@ -102,7 +102,16 @@ async def test_emit_from_order_covers_all_lifecycle_events(
     dispatcher, event_type, reason
 ):
     order = _build_order(strategy_id="momentum_v2", decision_id="dec-MOM")
-    result = {"order_id": "binance-7777", "status": event_type, "amount": 0.005}
+    result = {
+        "order_id": "binance-7777",
+        "status": event_type,
+        "amount": 0.005,
+        "fill_price": 50123.45,
+        "fees": 0.0123,
+        "fee_asset": "USDT",
+        "timestamp": 1716163200123,
+        "fills": [{"commission": "0.0123", "commissionAsset": "USDT"}],
+    }
 
     with patch("tradeengine.dispatcher.execution_event_publisher") as pub:
         pub.publish = AsyncMock(return_value=True)
@@ -124,6 +133,15 @@ async def test_emit_from_order_covers_all_lifecycle_events(
     assert kw["extra"]["symbol"] == "BTCUSDT"
     assert kw["extra"]["side"] == "buy"
     assert kw["extra"]["qty"] == 0.01
+    assert kw["extra"]["fill_qty"] == 0.005
+    assert kw["extra"]["fill_quantity"] == 0.005
+    assert kw["extra"]["fill_price"] == 50123.45
+    assert kw["extra"]["price"] == 50123.45
+    assert kw["extra"]["fee"] == 0.0123
+    assert kw["extra"]["fee_asset"] == "USDT"
+    assert kw["extra"]["fill_time"] == "2024-05-20T00:00:00.123000+00:00"
+    if event_type in ("filled", "partial_fill"):
+        assert "pnl" in kw["extra"]
 
 
 @pytest.mark.asyncio
@@ -163,3 +181,34 @@ async def test_emit_strips_unknown_fields_from_signal_decision_id(dispatcher):
             signal, event_type="rejected", reason="restricted_mode"
         )
     assert pub.publish.await_args.kwargs["decision_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_emit_from_order_includes_fill_audit_fields(dispatcher):
+    """#529: filled extras must carry price/qty/time/fee for the trade audit trail."""
+    order = _build_order()
+    result = {
+        "order_id": "binance-9999",
+        "status": "filled",
+        "amount": 0.02,
+        "fill_price": 61000.5,
+        "fees": 0.05,
+        "fee_asset": "BNB",
+        "timestamp": "2026-05-18T12:00:01+00:00",
+        "pnl": 12.5,
+    }
+    with patch("tradeengine.dispatcher.execution_event_publisher") as pub:
+        pub.publish = AsyncMock(return_value=True)
+        await dispatcher._emit_execution_event_from_order(
+            order, result, event_type="filled", reason="binance_filled"
+        )
+    extra = pub.publish.await_args.kwargs["extra"]
+    assert extra["fill_price"] == 61000.5
+    assert extra["fill_quantity"] == 0.02
+    assert extra["fill_qty"] == 0.02
+    assert extra["fill_time"] == "2026-05-18T12:00:01+00:00"
+    assert extra["fee"] == 0.05
+    assert extra["fee_asset"] == "BNB"
+    assert extra["pnl"] == 12.5
+    assert extra["symbol"] == "BTCUSDT"
+    assert extra["side"] == "buy"

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -2934,9 +2934,42 @@ class Dispatcher:
         order_id = str(exchange_order_id or order.order_id or "")
 
         fill_qty = None
+        fill_price = None
+        fee = None
+        fee_asset = None
+        fill_time: str | None = None
+        pnl = None
         if isinstance(result, dict):
             # Binance fills carry total filled qty; partial_fill needs this to be meaningful.
             fill_qty = result.get("amount") or result.get("filled") or None
+            fill_price = result.get("fill_price") or result.get("average_price")
+            fee = result.get("fees")
+            fee_asset = result.get("fee_asset")
+            if fee_asset is None:
+                fills = result.get("fills") or []
+                if isinstance(fills, list):
+                    for fill in fills:
+                        if isinstance(fill, dict) and fill.get("commissionAsset"):
+                            fee_asset = fill.get("commissionAsset")
+                            break
+            raw_fill_time = result.get("fill_time") or result.get("timestamp")
+            if raw_fill_time is not None:
+                if isinstance(raw_fill_time, datetime):
+                    ts = (
+                        raw_fill_time
+                        if raw_fill_time.tzinfo
+                        else raw_fill_time.replace(tzinfo=UTC)
+                    )
+                    fill_time = ts.astimezone(UTC).isoformat()
+                elif isinstance(raw_fill_time, int | float):
+                    # Binance transactTime is ms epoch; simulator may emit ISO already.
+                    epoch = float(raw_fill_time)
+                    if epoch > 1e12:
+                        epoch /= 1000.0
+                    fill_time = datetime.fromtimestamp(epoch, tz=UTC).isoformat()
+                else:
+                    fill_time = str(raw_fill_time)
+            pnl = result.get("pnl")
 
         extra: dict[str, Any] = {
             "symbol": order.symbol,
@@ -2945,6 +2978,22 @@ class Dispatcher:
         }
         if fill_qty is not None:
             extra["fill_qty"] = fill_qty
+            extra["fill_quantity"] = fill_qty
+        if fill_price is not None:
+            extra["fill_price"] = fill_price
+            # PnL calculator in data-manager reads `price`; keep both keys in sync.
+            extra["price"] = fill_price
+        if fill_time is not None:
+            extra["fill_time"] = fill_time
+        if fee is not None:
+            extra["fee"] = fee
+        if fee_asset is not None:
+            extra["fee_asset"] = fee_asset
+        if pnl is not None:
+            extra["pnl"] = pnl
+        elif event_type in ("filled", "partial_fill"):
+            # Explicit null so audit consumers can distinguish "unknown" from omitted.
+            extra["pnl"] = None
         if order.rejection_source is not None:
             extra["rejection_source"] = order.rejection_source
             extra["rejection_reason"] = order.rejection_reason

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -1404,6 +1404,7 @@ class BinanceFuturesExchange:
             "fill_price": fill_price,
             "total_value": total_quote_qty,
             "fees": self._calculate_fees(fills),
+            "fee_asset": self._resolve_fee_asset(fills),
             "timestamp": result.get("transactTime"),
             "simulated": False,
             "fills": fills,
@@ -1473,6 +1474,15 @@ class BinanceFuturesExchange:
             if "commission" in fill:
                 total_fees += float(fill["commission"])
         return total_fees
+
+    @staticmethod
+    def _resolve_fee_asset(fills: list[dict[str, Any]]) -> str | None:
+        """Return the commission asset from the first fill that reports one."""
+        for fill in fills:
+            asset = fill.get("commissionAsset")
+            if asset:
+                return str(asset)
+        return None
 
     async def get_account_info(self) -> dict[str, Any]:
         """Get account information"""

--- a/tradeengine/exchange/simulator.py
+++ b/tradeengine/exchange/simulator.py
@@ -143,6 +143,7 @@ class TradeSimulator:
             "average_price": round(fill_price, 2),
             "total_value": round(order.amount * fill_price, 2),
             "fees": round(order.amount * fill_price * 0.001, 4),  # 0.1% fees
+            "fee_asset": "USDT",
             "timestamp": datetime.now(UTC).isoformat(),
             "simulated": True,
             "fills": self._generate_fills(order, fill_price),


### PR DESCRIPTION
## What

Emit the full trade-audit payload on `execution.events` fill events.

Before: fill events carried only `symbol`, `side`, `qty`, `fill_qty` — not enough to reconstruct a trade, its cost, or its PnL.

After, `filled` / `partial_fill` events also carry:

| Field | Source |
| --- | --- |
| `fill_price` (mirrored to `price`) | exchange `fill_price` / `average_price` |
| `fill_quantity` (mirrored to `fill_qty`) | exchange `amount` / `filled` |
| `fill_time` | exchange `fill_time` / `timestamp`, normalised to UTC ISO-8601 |
| `fee` | exchange `fees` |
| `fee_asset` | exchange `fee_asset`, else first `fills[].commissionAsset` |
| `pnl` | exchange `pnl`, explicit `null` on fills when unreported |

`fill_time` normalisation handles all three shapes the exchanges produce: `datetime` (tz-naive treated as UTC), Binance ms-epoch `transactTime`, and ISO strings.

`pnl` is emitted as an explicit `null` on fill events so audit consumers can distinguish "exchange did not report it" from "publisher omitted the key".

## Changes

- `tradeengine/dispatcher.py` — extract price/fee/time/pnl in `_emit_execution_event_from_order`
- `tradeengine/exchange/binance.py` — `_resolve_fee_asset` surfaces `commissionAsset`
- `tradeengine/exchange/simulator.py` — simulated fills report `fee_asset` so sim matches live
- `docs/CONTRACTS.md` — execution-event contract documented (field table + optionality rules)
- `tests/test_dispatcher_execution_events.py` — coverage for all new fields across every lifecycle event

## Consumer side

`PetroSa2/petrosa-data-manager` PR persists these fields to `execution_events` and exposes `GET /api/v1/trades` + `/api/v1/trades/summary`. That PR should merge after this one, though the two are independent (the model tolerates missing fields).

## Verification

- `pytest` — 1876 passed, 12 skipped, coverage 80.88% (gate 40%)
- `ruff check` / `ruff format --check` clean
- `mypy tradeengine/dispatcher.py tradeengine/exchange/binance.py` clean

## Acceptance criteria (#529)

- [x] Fill events include fill_price, fill_quantity, fill_time, fee, fee_asset, pnl, side, symbol
- [x] Tests cover new fields
- [x] Documentation updated
- [ ] Query / summary API — data-manager PR
- [ ] Grafana dashboard — deferred, see issue comment (no JSON/Infinity datasource exists in the cluster)

Refs #529
