### PR TITLE
[FIX] Bounded retry for cancel_other_order() — OCO surviving-leg cancellation resilience (H4 of #977)

### DIFF
--- a/shared/constants.py
+++ b/shared/constants.py
@@ -248,6 +248,19 @@ BINANCE_WS_URL = os.getenv(
 )
 BINANCE_TIMEOUT = int(os.getenv("BINANCE_TIMEOUT", "10"))
 BINANCE_RETRY_ATTEMPTS = int(os.getenv("BINANCE_RETRY_ATTEMPTS", "3"))
+
+# #532 (H4 of #977): bounded retry for the OCO surviving-leg cancellation in
+# cancel_other_order(). Retries only transient/retryable errors; terminal states
+# (-2011 already closed / -2013 does not exist) are never retried. Setting
+# OCO_CANCEL_RETRY_ATTEMPTS=1 restores the pre-#532 single-attempt behaviour
+# (documented rollback lever). Backoff is capped exponential:
+# min(base * multiplier**attempt, cap).
+OCO_CANCEL_RETRY_ATTEMPTS = int(os.getenv("OCO_CANCEL_RETRY_ATTEMPTS", "3"))
+OCO_CANCEL_RETRY_BASE_DELAY = float(os.getenv("OCO_CANCEL_RETRY_BASE_DELAY", "0.5"))
+OCO_CANCEL_RETRY_BACKOFF_MULTIPLIER = float(
+    os.getenv("OCO_CANCEL_RETRY_BACKOFF_MULTIPLIER", "2.0")
+)
+OCO_CANCEL_RETRY_MAX_DELAY = float(os.getenv("OCO_CANCEL_RETRY_MAX_DELAY", "4.0"))
 PROMETHEUS_ENABLED = os.getenv("PROMETHEUS_ENABLED", "true").lower() == "true"
 PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", "9090"))
 PROMETHEUS_PATH = os.getenv("PROMETHEUS_PATH", "/metrics")

--- a/tests/test_oco_cancel_retry_532.py
+++ b/tests/test_oco_cancel_retry_532.py
@@ -1,0 +1,315 @@
+"""Unit tests for bounded-retry surviving-leg cancellation (#532, H4 of #977).
+
+``OCOManager.cancel_other_order`` used to issue a *single* cancel call. A
+transient network blip or a momentary Binance ``-1xxx`` left the surviving leg
+live and dropped the OCO pair tracking — re-creating the orphan-leg incident
+class this program exists to prevent.
+
+Per tradeengine#532 the cancel is now wrapped in a **bounded retry with capped
+exponential backoff**:
+
+- Transient failures (network errors, empty responses, momentary ``-1xxx``) are
+  retried within the ``OCO_CANCEL_RETRY_ATTEMPTS`` budget.
+- Terminal states (``-2011`` already closed / ``-2013`` order does not exist)
+  are an idempotent no-op success and are **never** retried.
+- On budget exhaustion the pair remains tracked (never silently dropped), the
+  ``oco_cancel_retry_exhausted_total`` counter increments, and a
+  ``alerts.tradeengine.oco_cancel_retry_exhausted.<symbol>`` alert fires.
+
+Guardrails asserted (must not reintroduce):
+
+- #504 — no same-price cancel spin: a terminal/gone leg is not looped over.
+- #490 (``-1102``) — algo cancels are not routed through ``/order``; this path
+  uses ``futures_cancel_order`` for the standard SL/TP legs only.
+- Idempotency — a retry after the leg actually cancelled is a no-op, not an
+  error.
+
+Related:
+    - Issue: https://github.com/PetroSa2/petrosa-tradeengine/issues/532
+    - Depends on (regression net): tradeengine#515 cancel-failure test.
+    - Parent epic: https://github.com/PetroSa2/petrosa_k8s/issues/977
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from tradeengine.dispatcher import OCOManager
+
+
+class RetryFakeExchange:
+    """Fake exchange whose ``futures_cancel_order`` behaviour is swappable per-test.
+
+    Modelled on ``tests/test_oco_race_conditions.py::RaceFakeExchange`` (#515).
+    """
+
+    def __init__(self) -> None:
+        self.client = Mock()
+        self.cancel_calls: list[tuple[str, str]] = []
+        self.client.futures_cancel_order = self._default_cancel
+
+    def _default_cancel(self, symbol: str, orderId: str) -> dict[str, Any]:
+        self.cancel_calls.append((symbol, orderId))
+        return {"orderId": orderId, "status": "CANCELED"}
+
+
+def _make_oco_info(
+    *,
+    sl_order_id: str,
+    tp_order_id: str,
+    symbol: str = "BTCUSDT",
+    position_side: str = "LONG",
+    status: str = "active",
+) -> dict[str, Any]:
+    return {
+        "position_id": "pos-1",
+        "strategy_position_id": None,
+        "entry_price": 50000.0,
+        "quantity": 0.001,
+        "sl_order_id": sl_order_id,
+        "tp_order_id": tp_order_id,
+        "symbol": symbol,
+        "position_side": position_side,
+        "status": status,
+        "created_at": "2026-08-09T00:00:00+00:00",
+    }
+
+
+@pytest.fixture
+def exchange() -> RetryFakeExchange:
+    return RetryFakeExchange()
+
+
+@pytest.fixture
+def oco_manager(exchange: RetryFakeExchange) -> OCOManager:
+    logger = logging.getLogger("test_oco_cancel_retry_532")
+    return OCOManager(exchange=exchange, logger=logger)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_backoff() -> Any:
+    """Patch the backoff sleep so retries do not wait real wall-clock time."""
+    with patch(
+        "tradeengine.dispatcher.asyncio.sleep", new=AsyncMock(return_value=None)
+    ) as sleep_mock:
+        yield sleep_mock
+
+
+# ---------------------------------------------------------------------------
+# AC1: transient failure is retried then succeeds within budget.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_transient_error_retried_then_succeeds(
+    oco_manager: OCOManager, exchange: RetryFakeExchange, _no_real_backoff: AsyncMock
+) -> None:
+    key = "BTCUSDT_LONG"
+    oco_info = _make_oco_info(sl_order_id="SL1", tp_order_id="TP1")
+    oco_manager.active_oco_pairs[key] = [oco_info]
+
+    calls = {"n": 0}
+
+    def _flaky_then_ok(symbol: str, orderId: str) -> dict[str, Any]:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("network down")
+        return {"orderId": orderId, "status": "CANCELED"}
+
+    exchange.client.futures_cancel_order = _flaky_then_ok
+
+    # SL filled -> cancel TP.
+    success, reason = await oco_manager.cancel_other_order(
+        position_id="pos-1",
+        filled_order_id="SL1",
+        symbol="BTCUSDT",
+        position_side="LONG",
+    )
+
+    assert success is True
+    assert reason == "stop_loss"
+    assert calls["n"] == 3  # two transient failures + one success
+    # Backoff slept between the failed attempts (n-1 sleeps).
+    assert _no_real_backoff.await_count == 2
+    # Pair marked completed on success.
+    assert oco_manager.active_oco_pairs[key][0]["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# AC2: terminal errors are NOT retried (idempotent no-op success).
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "err_text",
+    [
+        "APIError(code=-2011): Unknown order sent.",
+        "APIError(code=-2013): Order does not exist.",
+    ],
+)
+async def test_terminal_error_not_retried(
+    oco_manager: OCOManager,
+    exchange: RetryFakeExchange,
+    _no_real_backoff: AsyncMock,
+    err_text: str,
+) -> None:
+    key = "BTCUSDT_LONG"
+    oco_manager.active_oco_pairs[key] = [
+        _make_oco_info(sl_order_id="SL1", tp_order_id="TP1")
+    ]
+
+    calls = {"n": 0}
+
+    def _terminal(symbol: str, orderId: str) -> dict[str, Any]:
+        calls["n"] += 1
+        raise Exception(err_text)
+
+    exchange.client.futures_cancel_order = _terminal
+
+    success, reason = await oco_manager.cancel_other_order(
+        position_id="pos-1",
+        filled_order_id="SL1",
+        symbol="BTCUSDT",
+        position_side="LONG",
+    )
+
+    # Idempotent no-op success; #504: no same-price spin on a gone leg.
+    assert success is True
+    assert reason == "stop_loss"
+    assert calls["n"] == 1  # NOT retried
+    assert _no_real_backoff.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# AC3: retry exhaustion keeps the pair tracked + fires metric + alert.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_exhaustion_keeps_pair_tracked_and_alerts(
+    oco_manager: OCOManager, exchange: RetryFakeExchange, _no_real_backoff: AsyncMock
+) -> None:
+    key = "BTCUSDT_LONG"
+    oco_info = _make_oco_info(sl_order_id="SL1", tp_order_id="TP1")
+    oco_manager.active_oco_pairs[key] = [oco_info]
+
+    calls = {"n": 0}
+
+    def _always_boom(symbol: str, orderId: str) -> dict[str, Any]:
+        calls["n"] += 1
+        raise ConnectionError("network down")
+
+    exchange.client.futures_cancel_order = _always_boom
+
+    with (
+        patch("tradeengine.dispatcher.oco_cancel_retry_exhausted_total") as metric_mock,
+        patch(
+            "tradeengine.dispatcher.alert_publisher.publish",
+            new=AsyncMock(return_value=True),
+        ) as alert_mock,
+        patch("tradeengine.dispatcher.OCO_CANCEL_RETRY_ATTEMPTS", 3),
+    ):
+        success, reason = await oco_manager.cancel_other_order(
+            position_id="pos-1",
+            filled_order_id="SL1",
+            symbol="BTCUSDT",
+            position_side="LONG",
+        )
+
+    assert success is False
+    assert reason == "stop_loss"
+    # All attempts exhausted.
+    assert calls["n"] == 3
+    # Pair NOT dropped — remains tracked and still active for the next poll.
+    assert key in oco_manager.active_oco_pairs
+    assert oco_manager.active_oco_pairs[key][0] is oco_info
+    assert oco_manager.active_oco_pairs[key][0]["status"] == "active"
+    # Failure metric incremented once with the last error class.
+    metric_mock.labels.assert_called_once_with(
+        symbol="BTCUSDT", reason="ConnectionError"
+    )
+    metric_mock.labels.return_value.inc.assert_called_once()
+    # Critical alert fired on the oco_cancel_retry_exhausted.<symbol> subject.
+    alert_mock.assert_awaited_once()
+    kwargs = alert_mock.await_args.kwargs
+    assert kwargs["alert_name"] == "oco_cancel_retry_exhausted.BTCUSDT"
+    assert kwargs["severity"] == "critical"
+    assert kwargs["payload"]["attempts"] == 3
+    assert kwargs["payload"]["last_error"] == "ConnectionError"
+
+
+# ---------------------------------------------------------------------------
+# AC4 (#490 regression): algo cancels are NOT routed through /order.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancel_uses_futures_cancel_order_not_algo_order_path(
+    oco_manager: OCOManager, exchange: RetryFakeExchange, _no_real_backoff: AsyncMock
+) -> None:
+    """#490 (-1102): the surviving-leg cancel must go through
+    ``futures_cancel_order`` (standard order path), never the raw ``/order``
+    algo route. Also asserts #504: exactly one cancel per successful attempt
+    (no same-price spin)."""
+    key = "BTCUSDT_LONG"
+    oco_manager.active_oco_pairs[key] = [
+        _make_oco_info(sl_order_id="SL1", tp_order_id="TP1")
+    ]
+
+    # _request_futures_api is the raw algo-order route; it must NOT be called.
+    exchange.client._request_futures_api = Mock(
+        side_effect=AssertionError("algo /order route used for cancel (#490)")
+    )
+
+    success, _ = await oco_manager.cancel_other_order(
+        position_id="pos-1",
+        filled_order_id="SL1",
+        symbol="BTCUSDT",
+        position_side="LONG",
+    )
+
+    assert success is True
+    # Exactly one cancel via the standard path (#504: no spin).
+    assert exchange.cancel_calls == [("BTCUSDT", "TP1")]
+    exchange.client._request_futures_api.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC5 (rollback lever): OCO_CANCEL_RETRY_ATTEMPTS=1 == single-attempt behaviour.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_single_attempt_when_retry_disabled(
+    oco_manager: OCOManager, exchange: RetryFakeExchange, _no_real_backoff: AsyncMock
+) -> None:
+    key = "BTCUSDT_LONG"
+    oco_manager.active_oco_pairs[key] = [
+        _make_oco_info(sl_order_id="SL1", tp_order_id="TP1")
+    ]
+
+    calls = {"n": 0}
+
+    def _boom(symbol: str, orderId: str) -> dict[str, Any]:
+        calls["n"] += 1
+        raise ConnectionError("network down")
+
+    exchange.client.futures_cancel_order = _boom
+
+    with (
+        patch("tradeengine.dispatcher.OCO_CANCEL_RETRY_ATTEMPTS", 1),
+        patch(
+            "tradeengine.dispatcher.alert_publisher.publish",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        success, _ = await oco_manager.cancel_other_order(
+            position_id="pos-1",
+            filled_order_id="SL1",
+            symbol="BTCUSDT",
+            position_side="LONG",
+        )
+
+    assert success is False
+    assert calls["n"] == 1  # single attempt, no backoff sleeps
+    assert _no_real_backoff.await_count == 0

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -12,7 +12,13 @@ from contracts.order import OrderSide, OrderStatus, OrderType, TradeOrder
 from contracts.signal import Signal, TimeInForce
 from shared.audit import audit_logger
 from shared.config import Settings
-from shared.constants import UTC
+from shared.constants import (
+    OCO_CANCEL_RETRY_ATTEMPTS,
+    OCO_CANCEL_RETRY_BACKOFF_MULTIPLIER,
+    OCO_CANCEL_RETRY_BASE_DELAY,
+    OCO_CANCEL_RETRY_MAX_DELAY,
+    UTC,
+)
 from shared.distributed_lock import distributed_lock_manager
 from shared.logger import get_logger
 from tradeengine.exchange_truth_store import ExchangeTruthStore, UserDataStreamConsumer
@@ -20,6 +26,7 @@ from tradeengine.leverage_bound_guard import LeverageBoundGuard
 from tradeengine.metrics import (
     atomic_rollback_failed_total,
     dispatcher_thrash_circuit_open_total,
+    oco_cancel_retry_exhausted_total,
     oco_pair_age_seconds,
     order_execution_latency_seconds,
     order_failures_total,
@@ -733,37 +740,36 @@ class OCOManager:
             )
             return True, close_reason
 
-        try:
-            # Cancel the other order
-            cancel_result = self.exchange.client.futures_cancel_order(
-                symbol=oco_info["symbol"], orderId=order_to_cancel
-            )
-
-            if cancel_result:
-                self.logger.info(
-                    f"Order cancelled successfully: order_type={cancel_type}, "
-                    f"order_id={order_to_cancel}"
+        # #532 (H4 of #977): bounded retry with capped exponential backoff around
+        # the surviving-leg cancellation. A single transient network blip or a
+        # momentary Binance -1xxx used to leave the surviving leg live and the
+        # OCO pair tracking dropped — re-creating the orphan-leg incident class.
+        # Retry ONLY transient failures; terminal states (-2011 already
+        # closed / -2013 does not exist) are treated as an idempotent no-op
+        # success and never retried (respects #504 no same-price spin: we do not
+        # loop on a leg that is genuinely gone). Setting OCO_CANCEL_RETRY_ATTEMPTS=1
+        # restores the pre-#532 single-attempt behaviour (rollback lever).
+        max_attempts = max(1, OCO_CANCEL_RETRY_ATTEMPTS)
+        last_error_label = "unknown"
+        for attempt in range(1, max_attempts + 1):
+            try:
+                # Cancel the other order. NOTE: futures_cancel_order is the
+                # standard-order path used for SL/TP legs here; algo-order
+                # cancels go through the algoOrder endpoint elsewhere (#490 /
+                # -1102 — do NOT route algo cancels through /order).
+                cancel_result = self.exchange.client.futures_cancel_order(
+                    symbol=oco_info["symbol"], orderId=order_to_cancel
                 )
-                # Update status in the correct location
-                if found_key and found_key in self.active_oco_pairs:
-                    # Find and update the matching OCO pair in the list
-                    for oco in self.active_oco_pairs[found_key]:
-                        if (
-                            oco.get("sl_order_id") == sl_order_id
-                            or oco.get("tp_order_id") == tp_order_id
-                        ):
-                            oco["status"] = "completed"
-                            oco["close_reason"] = close_reason
-                            break
-                elif position_id in self.active_oco_pairs:
-                    # Backward compatibility
-                    if isinstance(self.active_oco_pairs[position_id], dict):
-                        self.active_oco_pairs[position_id]["status"] = "completed"
-                        self.active_oco_pairs[position_id]["close_reason"] = (
-                            close_reason
-                        )
-                    elif isinstance(self.active_oco_pairs[position_id], list):
-                        for oco in self.active_oco_pairs[position_id]:
+
+                if cancel_result:
+                    self.logger.info(
+                        f"Order cancelled successfully: order_type={cancel_type}, "
+                        f"order_id={order_to_cancel} (attempt {attempt}/{max_attempts})"
+                    )
+                    # Update status in the correct location
+                    if found_key and found_key in self.active_oco_pairs:
+                        # Find and update the matching OCO pair in the list
+                        for oco in self.active_oco_pairs[found_key]:
                             if (
                                 oco.get("sl_order_id") == sl_order_id
                                 or oco.get("tp_order_id") == tp_order_id
@@ -771,35 +777,112 @@ class OCOManager:
                                 oco["status"] = "completed"
                                 oco["close_reason"] = close_reason
                                 break
-                return True, close_reason
-            else:
-                self.logger.error(f"❌ FAILED TO CANCEL {cancel_type} ORDER")
-                return False, close_reason
+                    elif position_id in self.active_oco_pairs:
+                        # Backward compatibility
+                        if isinstance(self.active_oco_pairs[position_id], dict):
+                            self.active_oco_pairs[position_id]["status"] = "completed"
+                            self.active_oco_pairs[position_id]["close_reason"] = (
+                                close_reason
+                            )
+                        elif isinstance(self.active_oco_pairs[position_id], list):
+                            for oco in self.active_oco_pairs[position_id]:
+                                if (
+                                    oco.get("sl_order_id") == sl_order_id
+                                    or oco.get("tp_order_id") == tp_order_id
+                                ):
+                                    oco["status"] = "completed"
+                                    oco["close_reason"] = close_reason
+                                    break
+                    return True, close_reason
 
-        except Exception as e:
-            # Handle cases where order is already cancelled or filled (common in OCO races)
-            if "code=-2011" in str(e) or "Unknown order sent" in str(e):
-                self.logger.warning(
-                    f"⚠️ {cancel_type} order already closed or unknown (likely filled/cancelled): {e}"
+                # Falsy result from the client — transient (empty response /
+                # ambiguous). Retry within budget.
+                last_error_label = "empty_response"
+                self.logger.error(
+                    f"❌ FAILED TO CANCEL {cancel_type} ORDER "
+                    f"(attempt {attempt}/{max_attempts}, empty response)"
                 )
-                self._mark_oco_completed(
-                    found_key, position_id, sl_order_id, tp_order_id, close_reason
-                )
-                return True, close_reason
 
-            # Handle ghost order: order was filled/cancelled externally (e.g. after pod restart)
-            if "code=-2013" in str(e) or "Order does not exist" in str(e):
-                self.logger.info(
-                    f"INFO: Order externally closed, cleaning up local state: "
-                    f"position={position_id}, cancel_type={cancel_type}, error={e}"
-                )
-                self._mark_oco_completed(
-                    found_key, position_id, sl_order_id, tp_order_id, close_reason
-                )
-                return True, close_reason
+            except Exception as e:
+                # Terminal: order already cancelled/filled or unknown. Idempotent
+                # no-op — a retry after the leg actually cancelled must NOT error.
+                if "code=-2011" in str(e) or "Unknown order sent" in str(e):
+                    self.logger.warning(
+                        f"⚠️ {cancel_type} order already closed or unknown "
+                        f"(likely filled/cancelled): {e}"
+                    )
+                    self._mark_oco_completed(
+                        found_key, position_id, sl_order_id, tp_order_id, close_reason
+                    )
+                    return True, close_reason
 
-            self.logger.error(f"❌ ERROR CANCELLING {cancel_type} ORDER: {e}")
-            return False, close_reason
+                # Terminal: ghost order filled/cancelled externally (e.g. after
+                # pod restart). Also idempotent no-op success.
+                if "code=-2013" in str(e) or "Order does not exist" in str(e):
+                    self.logger.info(
+                        f"INFO: Order externally closed, cleaning up local state: "
+                        f"position={position_id}, cancel_type={cancel_type}, error={e}"
+                    )
+                    self._mark_oco_completed(
+                        found_key, position_id, sl_order_id, tp_order_id, close_reason
+                    )
+                    return True, close_reason
+
+                # Transient (network blip, momentary -1xxx, timeout). Retry.
+                last_error_label = type(e).__name__
+                self.logger.error(
+                    f"❌ ERROR CANCELLING {cancel_type} ORDER "
+                    f"(attempt {attempt}/{max_attempts}): {e}"
+                )
+
+            # Backoff before the next attempt (skip the sleep after the final try).
+            if attempt < max_attempts:
+                delay = min(
+                    OCO_CANCEL_RETRY_BASE_DELAY
+                    * (OCO_CANCEL_RETRY_BACKOFF_MULTIPLIER ** (attempt - 1)),
+                    OCO_CANCEL_RETRY_MAX_DELAY,
+                )
+                await asyncio.sleep(delay)
+
+        # Retry budget exhausted. Do NOT drop the pair — keep it tracked so the
+        # next monitor poll retries and the orphan is observable. Increment the
+        # failure metric and fire a NATS alert (both best-effort; the alert path
+        # must never break the caller).
+        self.logger.error(
+            f"❌ OCO surviving-leg cancel EXHAUSTED after {max_attempts} attempts: "
+            f"order_type={cancel_type}, order_id={order_to_cancel}, "
+            f"symbol={oco_info['symbol']}, last_error={last_error_label}. "
+            f"Pair remains tracked for the next poll."
+        )
+        try:
+            oco_cancel_retry_exhausted_total.labels(
+                symbol=oco_info["symbol"],
+                reason=last_error_label,
+            ).inc()
+        except Exception:
+            self.logger.debug(
+                "oco_cancel_retry_exhausted metric inc failed", exc_info=True
+            )
+        try:
+            await alert_publisher.publish(
+                alert_name=f"oco_cancel_retry_exhausted.{oco_info['symbol']}",
+                severity="critical",
+                payload={
+                    "symbol": oco_info["symbol"],
+                    "position_side": position_side,
+                    "position_id": position_id,
+                    "cancel_type": cancel_type,
+                    "order_to_cancel": order_to_cancel,
+                    "attempts": max_attempts,
+                    "last_error": last_error_label,
+                    "close_reason": close_reason,
+                },
+            )
+        except Exception:
+            self.logger.debug(
+                "oco_cancel_retry_exhausted alert publish failed", exc_info=True
+            )
+        return False, close_reason
 
     def _mark_oco_completed(
         self,

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -155,6 +155,20 @@ oco_orphan_leg_total = Counter(
     ["symbol", "side", "leg", "cancel_outcome"],
 )
 
+# #532 (H4 of #977): surviving-leg cancellation retried past its bounded budget.
+# cancel_other_order() now retries transient failures with capped exponential
+# backoff; when the budget is exhausted the OCO pair is kept tracked (never
+# silently dropped) and this counter increments once per exhaustion. Paired with
+# the alerts.tradeengine.oco_cancel_retry_exhausted.<symbol> NATS alert so ops
+# can act on the still-orphaned surviving leg. The reason label carries the last
+# error class encountered (e.g. "ConnectionError", "timeout").
+oco_cancel_retry_exhausted_total = Counter(
+    "petrosa_tradeengine_oco_cancel_retry_exhausted_total",
+    "Surviving-leg cancellations that exhausted the bounded retry budget "
+    "(pair remains tracked; leg may still be live on Binance)",
+    ["symbol", "reason"],
+)
+
 # #426 (RC#2 of #424): the atomic-rollback path itself failed — the
 # OCO-failure cleanup could not close the position on Binance, so the
 # position remains unhedged. Paired with the


### PR DESCRIPTION
## Summary

`cancel_other_order()` issued a **single** cancel call with error-classification only — no retry.
A transient network blip or a momentary Binance `-1xxx` meant the surviving leg was never cancelled and
the OCO pair tracking could be dropped, re-creating the orphan-leg incident class (H4 of #977).

This PR wraps the surviving-leg cancellation in a **bounded retry with capped exponential backoff**.

## Changes

- `tradeengine/dispatcher.py` — `OCOManager.cancel_other_order`: bounded retry loop.
  - Retry **only** transient failures (network errors, empty responses, momentary `-1xxx`).
  - Terminal states (`-2011` already closed / `-2013` does not exist) → idempotent no-op success, **never retried**.
  - On exhaustion: pair stays **tracked** (never silently dropped), failure metric increments, critical NATS alert fires.
- `shared/constants.py` — `OCO_CANCEL_RETRY_ATTEMPTS` (default 3), base delay, multiplier, max delay. `=1` restores single-attempt (rollback lever).
- `tradeengine/metrics.py` — `oco_cancel_retry_exhausted_total{symbol,reason}` counter.
- `tests/test_oco_cancel_retry_532.py` — new unit suite.

## Guardrails respected

- **#504** — no same-price cancel spin (terminal/gone leg is not looped).
- **#490 (`-1102`)** — cancels stay on `futures_cancel_order`, never the algo `/order` route.
- **Idempotency** — a retry after the leg actually cancelled is a no-op, not an error.

## Acceptance Criteria

- [x] Retries transient failures with bounded backoff; terminal errors not retried.
- [x] On exhaustion the pair remains tracked and a failure metric + alert fire (asserted in test).
- [x] Regression test proves no same-price spin (#504) and no algo cancel via `/order` (#490).
- [x] New unit test guards the failure path; existing OCO tests still pass (1882 passed).
- [x] Depends on cancel-failure test H2/#515 — CLOSED, unblocked.

## Verification

- `ruff check .` + `ruff format --check .` — clean.
- `mypy` (strict) over changed files — no issues; introduces **zero** new mypy errors vs main baseline.
- Full suite: **1882 passed, 0 failed, 12 skipped**; coverage gate (≥40%) passed.

## Rollback

Pure code change behind the existing call path. Revert the commit, or set `OCO_CANCEL_RETRY_ATTEMPTS=1`
to restore the pre-#532 single-attempt behaviour without a deploy.

Closes #532
