### PR TITLE
[FIX] Persist HeartbeatMonitor restricted_mode across restart — fail-safe on unverifiable state (H5 of #977)

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -91,6 +91,13 @@ class Settings(BaseSettings):
     # off = legacy paths unchanged; shadow = log divergence only; on = risk reads from exchange
     te_exchange_truth_store_enabled: str = "off"
 
+    # tradeengine#533 (H5 of #977): persist HeartbeatMonitor.restricted_mode
+    # across process restarts. "off" keeps the legacy in-memory-only behavior;
+    # "on" durably records restricted-mode transitions to MongoDB and restores
+    # them at boot (unverifiable state fails closed -> restricted). Default
+    # "off" preserves existing behavior until the operator promotes it.
+    te_heartbeat_persist_enabled: str = "off"
+
     # #445: exchange-authoritative naked-position remediation.
     # Modes: "off" (read-only, no writes — detection-only), "dry_run"
     # (log intended actions, no writes), "arm_only" (re-arm protective

--- a/tests/test_watchdog_gaps.py
+++ b/tests/test_watchdog_gaps.py
@@ -113,66 +113,180 @@ class TestAC1HeartbeatRestrictedOnNatsDown:
 # ---------------------------------------------------------------------------
 
 
-class TestAC2HeartbeatStateLostOnRestart:
-    """AC2 — restricted-mode state is in-memory only. A fresh instance
-    (simulating a pod restart) starts in NORMAL mode, forgetting that the
-    previous instance had tripped into RESTRICTED_MODE.
+class _FakeCollection:
+    """Minimal async stand-in for a motor collection backed by a dict.
 
-    This is a **known weakness**: a crash-looping pod could repeatedly reset
-    itself back to normal and resume trading despite a persistent heartbeat
-    outage.
+    Supports the two operations HeartbeatMonitor uses: ``update_one`` (with
+    ``$set`` + ``upsert``) and ``find_one`` by ``_id``. Optionally raises to
+    simulate an unreadable / unreachable store (fail-safe path).
+    """
 
-    # TODO(#970): restricted-mode should be persisted (or re-derived from a
-    #  durable heartbeat timestamp) so a restart cannot silently drop the
-    #  fail-safe. Until then this test locks in the current behavior.
+    def __init__(self, store: dict, *, raise_on_read: bool = False) -> None:
+        self._store = store
+        self._raise_on_read = raise_on_read
+
+    async def update_one(self, filt, update, upsert=False):  # noqa: ANN001
+        doc = self._store.setdefault(filt["_id"], {"_id": filt["_id"]})
+        doc.update(update["$set"])
+
+    async def find_one(self, filt):  # noqa: ANN001
+        if self._raise_on_read:
+            raise RuntimeError("simulated MongoDB read failure")
+        return self._store.get(filt["_id"])
+
+
+class _FakeDB:
+    """Async db handle returning a shared _FakeCollection per name."""
+
+    def __init__(self, *, raise_on_read: bool = False) -> None:
+        self._store: dict = {}
+        self._raise_on_read = raise_on_read
+        self._cols: dict = {}
+
+    def __getitem__(self, name):  # noqa: ANN001
+        if name not in self._cols:
+            self._cols[name] = _FakeCollection(
+                self._store, raise_on_read=self._raise_on_read
+            )
+        return self._cols[name]
+
+
+class TestAC2HeartbeatStateRestoredOnRestart:
+    """AC2 (tradeengine#533 / H5 of #977) — restricted-mode state is now
+    **persisted** to a durable store and **restored on restart**.
+
+    Previously this class documented the in-memory-only weakness (state lost on
+    restart). H5 hardens it: when persistence is enabled a fresh instance
+    (simulating a pod restart) restores the last-known restricted state instead
+    of resetting to NORMAL, and an unverifiable state fails **closed**.
     """
 
     @pytest.mark.asyncio
-    async def test_fresh_instance_starts_in_normal_mode(self) -> None:
+    async def test_restart_restores_restricted_state(self) -> None:
+        db = _FakeDB()
         with patch("nats.connect", new_callable=AsyncMock):
             first = HeartbeatMonitor(
-                nats_url="nats://localhost:4222", subject="cio.heartbeat"
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=True,
+                state_db=db,
             )
             await first._enter_restricted_mode()
             assert first.is_restricted() is True
             await first.stop()
 
-            # Simulate a restart: a brand-new instance with no shared state.
+            # Simulate a restart: a brand-new instance sharing the durable store.
             fresh = HeartbeatMonitor(
-                nats_url="nats://localhost:4222", subject="cio.heartbeat"
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=True,
+                state_db=db,
             )
-            # The fresh instance forgot the prior restricted state.
+            await fresh.start()
+            # The fresh instance RESTORED the prior restricted state.
+            assert fresh.restricted_mode is True
+            assert fresh.is_restricted() is True
+            # AC: gauge reflects restored state immediately on boot.
+            assert _gauge_value(restricted_mode_status) == 1
+            await fresh.stop()
+
+    @pytest.mark.asyncio
+    async def test_boot_fails_closed_when_state_unverifiable(self) -> None:
+        # Store raises on read -> state cannot be verified -> fail closed.
+        db = _FakeDB(raise_on_read=True)
+        with patch("nats.connect", new_callable=AsyncMock):
+            monitor = HeartbeatMonitor(
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=True,
+                state_db=db,
+            )
+            await monitor.start()
+            assert monitor.restricted_mode is True
+            assert monitor.is_restricted() is True
+            assert _gauge_value(restricted_mode_status) == 1
+            await monitor.stop()
+
+    @pytest.mark.asyncio
+    async def test_boot_fails_closed_when_no_state_handle(self) -> None:
+        # No handle resolvable -> unverifiable -> fail closed.
+        with patch("nats.connect", new_callable=AsyncMock):
+            monitor = HeartbeatMonitor(
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=True,
+                state_db=None,
+            )
+            with patch.object(
+                monitor, "_resolve_state_db", new_callable=AsyncMock, return_value=None
+            ):
+                await monitor.start()
+            assert monitor.restricted_mode is True
+            assert _gauge_value(restricted_mode_status) == 1
+            await monitor.stop()
+
+    @pytest.mark.asyncio
+    async def test_fresh_boot_no_prior_state_starts_normal(self) -> None:
+        # Empty store, readable -> genuine first boot -> NORMAL.
+        db = _FakeDB()
+        with patch("nats.connect", new_callable=AsyncMock):
+            monitor = HeartbeatMonitor(
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=True,
+                state_db=db,
+            )
+            await monitor.start()
+            assert monitor.restricted_mode is False
+            assert _gauge_value(restricted_mode_status) == 0
+            await monitor.stop()
+
+    @pytest.mark.asyncio
+    async def test_persistence_disabled_keeps_legacy_in_memory_behavior(self) -> None:
+        # Flag off -> legacy behavior: a fresh instance forgets prior state.
+        with patch("nats.connect", new_callable=AsyncMock):
+            first = HeartbeatMonitor(
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=False,
+            )
+            await first._enter_restricted_mode()
+            assert first.is_restricted() is True
+            await first.stop()
+
+            fresh = HeartbeatMonitor(
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=False,
+            )
             assert fresh.restricted_mode is False
             assert fresh.is_restricted() is False
             assert fresh.consecutive_heartbeats == 0
             await fresh.stop()
 
     @pytest.mark.asyncio
-    async def test_fresh_instance_resets_restricted_metric_to_zero(self) -> None:
+    async def test_recovery_persists_normal_state(self) -> None:
+        # Exiting restricted mode persists NORMAL so a later restart stays NORMAL.
+        db = _FakeDB()
         with patch("nats.connect", new_callable=AsyncMock):
             first = HeartbeatMonitor(
-                nats_url="nats://localhost:4222", subject="cio.heartbeat"
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=True,
+                state_db=db,
             )
             await first._enter_restricted_mode()
-            assert _gauge_value(restricted_mode_status) == 1
+            await first._exit_restricted_mode()
             await first.stop()
 
-            # A fresh instance leaving restricted mode publishes 0.
-            # NB: restricted_mode_status is a process-global singleton gauge, so
-            # a fresh instance does not *automatically* reset it — the loop /
-            # exit path does. We exercise the exit path a fresh instance would
-            # take when it observes healthy heartbeats.
-            # TODO(#970): the global gauge is shared across instances; on a real
-            #  restart the metric reflects whatever the *last* instance set until
-            #  the new loop runs. Persisted state would make this deterministic.
             fresh = HeartbeatMonitor(
-                nats_url="nats://localhost:4222", subject="cio.heartbeat"
+                nats_url="nats://localhost:4222",
+                subject="cio.heartbeat",
+                persist_enabled=True,
+                state_db=db,
             )
+            await fresh.start()
             assert fresh.restricted_mode is False
-            await fresh._exit_restricted_mode()  # no-op on state, but publishes 0
-            # Force the normal-mode publish path a fresh healthy instance takes.
-            fresh.restricted_mode = False
-            restricted_mode_status.set(0)
             assert _gauge_value(restricted_mode_status) == 0
             await fresh.stop()
 

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -1770,8 +1770,16 @@ class Dispatcher:
         if self.settings.nats_enabled:
             from shared.constants import NATS_URL
 
+            # tradeengine#533: enable restricted-mode persistence when the
+            # feature flag is on. The MongoDB handle is resolved lazily from the
+            # already-booted distributed_lock_manager at start() time.
+            persist_enabled = str(
+                getattr(self.settings, "te_heartbeat_persist_enabled", "off")
+            ).strip().lower() not in ("", "off", "false", "0")
             self.heartbeat_monitor = HeartbeatMonitor(
-                nats_url=NATS_URL, subject=self.settings.nats_topic_heartbeat
+                nats_url=NATS_URL,
+                subject=self.settings.nats_topic_heartbeat,
+                persist_enabled=persist_enabled,
             )
 
     async def initialize(self) -> None:

--- a/tradeengine/services/heartbeat_monitor.py
+++ b/tradeengine/services/heartbeat_monitor.py
@@ -37,6 +37,32 @@ class HeartbeatMessage(BaseModel):
         return self.json()
 
 
+#: MongoDB collection + document id used to persist restricted-mode state
+#: across process restarts (tradeengine#533 / H5 of petrosa_k8s#977).
+HEARTBEAT_STATE_COLLECTION = "heartbeat_state"
+HEARTBEAT_STATE_DOC_ID = "tradeengine"
+
+
+def _resolve_persist_enabled() -> bool:
+    """Resolve whether restricted-mode persistence is enabled.
+
+    Feature flag ``te_heartbeat_persist_enabled`` (string tri-state, mirroring
+    ``te_exchange_truth_store_enabled``): ``"off"`` keeps the legacy in-memory
+    behavior; any other value (``"on"``) enables durable persistence + restore.
+    Reads from the pydantic ``settings`` singleton, falling back to the env var
+    directly so the monitor still resolves the flag if settings import fails.
+    """
+    try:
+        from shared.config import settings
+
+        value = str(getattr(settings, "te_heartbeat_persist_enabled", "off"))
+    except Exception:
+        import os
+
+        value = os.getenv("TE_HEARTBEAT_PERSIST_ENABLED", "off")
+    return value.strip().lower() not in ("", "off", "false", "0")
+
+
 class HeartbeatMonitor:
     """Monitors ecosystem heartbeats and manages fail-safe modes."""
 
@@ -46,6 +72,8 @@ class HeartbeatMonitor:
         subject: str = "cio.heartbeat",
         timeout: float | None = None,
         recovery_threshold: int | None = None,
+        persist_enabled: bool | None = None,
+        state_db: Any = None,
     ):
         self.nats_url = nats_url
         self.subject = subject
@@ -61,8 +89,24 @@ class HeartbeatMonitor:
         self.is_running: bool = False
         self._monitor_task: asyncio.Task[Any] | None = None
 
+        # tradeengine#533 (H5 of #977): persist restricted_mode across restart.
+        # When persistence is enabled, restart restores the last-known state and
+        # an unverifiable state fails *closed* (restricted). When disabled the
+        # monitor keeps the legacy in-memory-only behavior for backwards compat.
+        if persist_enabled is None:
+            persist_enabled = _resolve_persist_enabled()
+        self.persist_enabled: bool = persist_enabled
+        #: Optional motor AsyncIOMotorDatabase handle. Injected by the dispatcher
+        #: (reusing the already-booted distributed-lock MongoDB connection) or in
+        #: tests. Resolved lazily at start() when not provided.
+        self._state_db: Any = state_db
+
     async def start(self) -> None:
         """Start the monitor and subscribe to heartbeats."""
+        # tradeengine#533: restore persisted restricted_mode BEFORE connecting so
+        # the fail-safe is correct from the first instant of boot, and the
+        # restricted_mode_status gauge reflects the restored state immediately.
+        await self._restore_state()
         try:
             # AC: Use robust NATS connection parameters for parity with consumer
             self.nats_client = await nats.connect(
@@ -145,6 +189,9 @@ class HeartbeatMonitor:
             self.consecutive_heartbeats = 0
             restricted_mode_status.set(1)
             logger.critical("🚨 ENTERING RESTRICTED_MODE: CIO heartbeat lost!")
+            # tradeengine#533: durably record the transition so a restart while
+            # restricted boots restricted (fail-safe), not permissive.
+            await self._persist_state(True)
 
     async def _exit_restricted_mode(self) -> None:
         """Exit RESTRICTED_MODE and return to NORMAL_MODE."""
@@ -153,6 +200,106 @@ class HeartbeatMonitor:
             self.consecutive_heartbeats = 0
             restricted_mode_status.set(0)
             logger.info("✅ EXITING RESTRICTED_MODE: CIO heartbeat recovered.")
+            # tradeengine#533: persist the recovery so a subsequent restart does
+            # not resurrect a stale restricted state.
+            await self._persist_state(False)
+
+    async def _resolve_state_db(self) -> Any:
+        """Return the MongoDB handle for persistence, or ``None`` if unavailable.
+
+        Prefers an injected handle; otherwise reuses the already-booted
+        distributed-lock MongoDB connection (dispatcher initializes it before
+        starting the heartbeat monitor). Never raises.
+        """
+        if self._state_db is not None:
+            return self._state_db
+        try:
+            from shared.distributed_lock import distributed_lock_manager
+
+            await distributed_lock_manager._ensure_mongodb_connected()
+            self._state_db = distributed_lock_manager.mongodb_db
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"HeartbeatMonitor could not resolve state DB: {e}")
+            self._state_db = None
+        return self._state_db
+
+    async def _persist_state(self, restricted: bool) -> None:
+        """Persist the current restricted-mode flag to durable storage.
+
+        No-op when persistence is disabled. Best-effort: a persistence failure
+        is logged but never propagates — losing a write must not crash the
+        monitor. The next transition (or the timeout loop) will retry.
+        """
+        if not self.persist_enabled:
+            return
+        try:
+            db = await self._resolve_state_db()
+            if db is None:
+                logger.warning(
+                    "HeartbeatMonitor: no MongoDB handle; restricted_mode "
+                    f"transition to {restricted} not persisted."
+                )
+                return
+            await db[HEARTBEAT_STATE_COLLECTION].update_one(
+                {"_id": HEARTBEAT_STATE_DOC_ID},
+                {"$set": {"restricted_mode": restricted, "updated_at": time.time()}},
+                upsert=True,
+            )
+        except Exception as e:
+            logger.error(f"HeartbeatMonitor failed to persist restricted_mode: {e}")
+
+    async def _restore_state(self) -> None:
+        """Restore restricted_mode from durable storage at boot.
+
+        Fail-safe semantics (tradeengine#533):
+          * persistence disabled -> legacy in-memory init (stay NORMAL).
+          * persisted doc found  -> restore its ``restricted_mode`` verbatim.
+          * no persisted doc     -> NORMAL (first-ever boot; nothing to restore).
+          * state UNVERIFIABLE   -> RESTRICTED (fail-closed): the store is
+            unreachable/erroring, so we cannot prove it is safe to trade.
+
+        Always publishes the resulting state to the ``restricted_mode_status``
+        gauge so monitoring reflects the restored value immediately on boot.
+        """
+        if not self.persist_enabled:
+            return
+        try:
+            db = await self._resolve_state_db()
+            if db is None:
+                # Cannot verify last-known state -> fail closed.
+                self.restricted_mode = True
+                logger.critical(
+                    "🚨 HeartbeatMonitor: restricted_mode state UNVERIFIABLE at "
+                    "boot (no MongoDB handle) — defaulting to RESTRICTED (fail-safe)."
+                )
+            else:
+                doc = await db[HEARTBEAT_STATE_COLLECTION].find_one(
+                    {"_id": HEARTBEAT_STATE_DOC_ID}
+                )
+                if doc is None:
+                    # No prior state persisted — genuine first boot, stay NORMAL.
+                    self.restricted_mode = False
+                    logger.info(
+                        "HeartbeatMonitor: no persisted restricted_mode state; "
+                        "starting in NORMAL mode."
+                    )
+                else:
+                    self.restricted_mode = bool(doc.get("restricted_mode", True))
+                    logger.info(
+                        "HeartbeatMonitor: restored restricted_mode="
+                        f"{self.restricted_mode} from durable store."
+                    )
+        except Exception as e:
+            # Any read error means we cannot verify the state -> fail closed.
+            self.restricted_mode = True
+            logger.critical(
+                "🚨 HeartbeatMonitor: restricted_mode state UNVERIFIABLE at boot "
+                f"({e}) — defaulting to RESTRICTED (fail-safe)."
+            )
+        finally:
+            self.consecutive_heartbeats = 0
+            # AC: gauge reflects restored state immediately on boot.
+            restricted_mode_status.set(1 if self.restricted_mode else 0)
 
     def is_restricted(self) -> bool:
         """Check if TradeEngine is in RESTRICTED_MODE."""


### PR DESCRIPTION
## Summary

Implements #533 (H5 of PetroSa2/petrosa_k8s#977). Persists `HeartbeatMonitor.restricted_mode` across process restart and makes the boot default **fail-safe**.

Previously `restricted_mode` was in-memory only (init `False`). A pod restart while restricted booted back into **permissive** mode until the next heartbeat evaluation — a fail-**open** window on a safety control, recurring on every deploy / OOM / node churn.

## Changes

- **Persistence**: restricted-mode transitions are durably recorded in MongoDB (`heartbeat_state` collection, doc `_id="tradeengine"`), reusing the already-booted `distributed_lock_manager` connection — the cheapest already-wired durable store, no new infra.
- **Restore on boot**: `start()` restores last-known state *before* subscribing; the `restricted_mode_status` gauge reflects the restored value immediately.
- **Fail-closed on unverifiable state**: if the store is unreachable/erroring at boot, default to **RESTRICTED**, never permissive.
- **Hysteresis preserved**: recovery-threshold exit conditions unchanged.
- **Feature-flagged**: `te_heartbeat_persist_enabled` (default `"off"` → legacy in-memory behavior; `"on"` → persist + restore). Mirrors existing `te_exchange_truth_store_enabled` tri-state flag.

## Acceptance Criteria

- [x] After a simulated restart while restricted, the monitor boots **restricted** (`test_restart_restores_restricted_state`).
- [x] When persisted state is unreadable at boot, monitor defaults to restricted (`test_boot_fails_closed_when_state_unverifiable`, `test_boot_fails_closed_when_no_state_handle`).
- [x] `restricted_mode_status` gauge reflects restored state immediately on boot (asserted in restore tests).
- [x] Updated tradeengine#516 AC2 from "state lost on restart" to "state restored on restart".
- [x] Existing heartbeat tests still pass; hysteresis unchanged.
- [x] Builds on the restart-state-loss "before" test (H3 / #516).

## Testing

- `tests/test_watchdog_gaps.py` — rewrote `TestAC2` (now `TestAC2HeartbeatStateRestoredOnRestart`): restore, fail-closed (read error + no handle), fresh-boot-normal, disabled-legacy, recovery-persistence.
- Full suite: 1886 passed, 12 skipped; coverage ≥40% gate green; ruff clean; mypy `--strict` clean on changed files.

## Rollback

Revert the commit; persistence is additive. Feature flag `te_heartbeat_persist_enabled=off` forces the legacy in-memory init.

Closes #533
