### PR TITLE
feat: #529 source fee/fee_asset/pnl for filled Binance Futures fills

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -98,6 +98,18 @@ class Settings(BaseSettings):
     # "off" preserves existing behavior until the operator promotes it.
     te_heartbeat_persist_enabled: str = "off"
 
+    # tradeengine#529: backfill exchange-sourced fill audit fields (commission,
+    # commissionAsset, realizedPnl) for FILLED Binance USDⓈ-M Futures orders.
+    # The synchronous futures_create_order response omits the per-trade fills[]
+    # array (unlike Spot), so fee/fee_asset/pnl are unavailable when the
+    # execution.events fill event is emitted. When enabled, the exchange makes a
+    # best-effort GET /fapi/v1/userTrades (futures_account_trades) call for the
+    # filled order and folds the real values into the emitted audit event. The
+    # call is best-effort — any failure is swallowed and the order path is never
+    # affected. Set TE_FILL_AUDIT_ENRICHMENT_ENABLED=false to disable the extra
+    # per-fill REST call per deploy.
+    te_fill_audit_enrichment_enabled: bool = True
+
     # #445: exchange-authoritative naked-position remediation.
     # Modes: "off" (read-only, no writes — detection-only), "dry_run"
     # (log intended actions, no writes), "arm_only" (re-arm protective

--- a/tests/test_binance_fill_audit_enrichment.py
+++ b/tests/test_binance_fill_audit_enrichment.py
@@ -1,0 +1,253 @@
+"""
+#529: exchange-sourced fill audit enrichment.
+
+Binance USDⓈ-M Futures ``futures_create_order`` responses omit the per-trade
+``fills[]`` array, so ``fee`` / ``fee_asset`` / ``pnl`` are unavailable when the
+``execution.events`` fill event is emitted. ``_enrich_fill_audit`` backfills them
+best-effort from ``GET /fapi/v1/userTrades`` (``futures_account_trades``).
+
+These tests exercise the enrichment helper in isolation plus the
+``_format_execution_result`` passthrough that surfaces ``pnl`` to the dispatcher.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+# Mock the binance SDK before importing the exchange module (mirrors the setup in
+# test_binance_exchange_comprehensive.py so this file is import-order independent).
+_mock_binance = MagicMock()
+_mock_binance.exceptions = MagicMock()
+sys.modules.setdefault("binance", _mock_binance)
+sys.modules.setdefault("binance.exceptions", _mock_binance.exceptions)
+_mock_binance.enums = MagicMock()
+sys.modules.setdefault("binance.enums", _mock_binance.enums)
+
+
+class _MockBinanceAPIException(Exception):
+    def __init__(self, response=None, message=""):
+        self.response = response
+        self.message = message
+        self.code = -1000
+
+
+_mock_binance.exceptions.BinanceAPIException = _MockBinanceAPIException
+
+from contracts.order import OrderSide, OrderType, TradeOrder  # noqa: E402
+from tradeengine.exchange.binance import BinanceFuturesExchange  # noqa: E402
+
+
+def _build_order(amount: float = 0.02) -> TradeOrder:
+    return TradeOrder(
+        symbol="BTCUSDT",
+        side=OrderSide.BUY,
+        type=OrderType.MARKET,
+        amount=amount,
+        target_price=61000.0,
+    )
+
+
+def _exchange_with_trades(trades) -> BinanceFuturesExchange:
+    exchange = BinanceFuturesExchange()
+    client = Mock()
+    client.futures_account_trades = Mock(return_value=trades)
+    exchange.client = client
+    exchange.initialized = True
+    return exchange
+
+
+_TWO_TRADES = [
+    {
+        "id": 1,
+        "orderId": 9999,
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "price": "61000.0",
+        "qty": "0.01",
+        "quoteQty": "610.0",
+        "commission": "0.244",
+        "commissionAsset": "USDT",
+        "realizedPnl": "0.0",
+        "time": 1716163200123,
+    },
+    {
+        "id": 2,
+        "orderId": 9999,
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "price": "61010.0",
+        "qty": "0.01",
+        "quoteQty": "610.1",
+        "commission": "0.244",
+        "commissionAsset": "USDT",
+        "realizedPnl": "5.5",
+        "time": 1716163200200,
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_enrich_populates_fills_and_pnl_from_user_trades():
+    """A FILLED futures order with no fills[] is backfilled from userTrades."""
+    exchange = _exchange_with_trades(_TWO_TRADES)
+    order = _build_order()
+    result = {"orderId": 9999, "symbol": "BTCUSDT", "status": "FILLED", "side": "BUY"}
+
+    await exchange._enrich_fill_audit(result, order)
+
+    exchange.client.futures_account_trades.assert_called_once_with(
+        symbol="BTCUSDT", orderId=9999
+    )
+    assert len(result["fills"]) == 2
+    assert result["pnl"] == pytest.approx(5.5)
+
+    # And the formatter surfaces real fee/fee_asset/pnl/fill_price to the dispatcher.
+    formatted = exchange._format_execution_result(result, order)
+    assert formatted["fees"] == pytest.approx(0.488)
+    assert formatted["fee_asset"] == "USDT"
+    assert formatted["pnl"] == pytest.approx(5.5)
+    # VWAP over the two trades: (610.0 + 610.1) / 0.02
+    assert formatted["fill_price"] == pytest.approx(61005.0)
+    assert formatted["amount"] == pytest.approx(0.02)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["NEW", "PENDING", "CANCELED", ""])
+async def test_enrich_skips_when_not_filled(status):
+    """Non-fill statuses have no trades to fetch — no REST call, result untouched."""
+    exchange = _exchange_with_trades(_TWO_TRADES)
+    result = {"orderId": 9999, "symbol": "BTCUSDT", "status": status}
+
+    await exchange._enrich_fill_audit(result, _build_order())
+
+    exchange.client.futures_account_trades.assert_not_called()
+    assert "fills" not in result
+    assert "pnl" not in result
+
+
+@pytest.mark.asyncio
+async def test_enrich_skips_when_fills_already_present():
+    """If the response already carried per-trade detail, don't re-fetch."""
+    exchange = _exchange_with_trades(_TWO_TRADES)
+    result = {
+        "orderId": 9999,
+        "symbol": "BTCUSDT",
+        "status": "FILLED",
+        "fills": [{"price": "1", "qty": "1", "quoteQty": "1", "commission": "0"}],
+    }
+
+    await exchange._enrich_fill_audit(result, _build_order())
+
+    exchange.client.futures_account_trades.assert_not_called()
+    assert len(result["fills"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_enrich_is_best_effort_and_swallows_client_errors():
+    """A userTrades failure must not raise into the (already-executed) order path."""
+    exchange = BinanceFuturesExchange()
+    client = Mock()
+    client.futures_account_trades = Mock(side_effect=RuntimeError("api down"))
+    exchange.client = client
+    result = {"orderId": 9999, "symbol": "BTCUSDT", "status": "FILLED"}
+
+    # Must not raise.
+    await exchange._enrich_fill_audit(result, _build_order())
+
+    assert "fills" not in result
+    assert "pnl" not in result
+
+
+@pytest.mark.asyncio
+async def test_enrich_skips_non_numeric_order_id():
+    """Algo order ids (non-numeric) aren't queryable via userTrades."""
+    exchange = _exchange_with_trades(_TWO_TRADES)
+    result = {"algoId": "abc-not-int", "symbol": "BTCUSDT", "status": "FILLED"}
+
+    await exchange._enrich_fill_audit(result, _build_order())
+
+    exchange.client.futures_account_trades.assert_not_called()
+    assert "fills" not in result
+
+
+@pytest.mark.asyncio
+async def test_enrich_skips_when_client_is_none():
+    """No client (uninitialized) -> no-op, no crash."""
+    exchange = BinanceFuturesExchange()
+    exchange.client = None
+    result = {"orderId": 9999, "symbol": "BTCUSDT", "status": "FILLED"}
+
+    await exchange._enrich_fill_audit(result, _build_order())
+
+    assert "fills" not in result
+
+
+@pytest.mark.asyncio
+async def test_enrich_missing_commission_does_not_break_fee_summation():
+    """A trade without a commission field must not raise in _calculate_fees."""
+    trades = [
+        {
+            "id": 7,
+            "orderId": 9999,
+            "symbol": "BTCUSDT",
+            "price": "61000.0",
+            "qty": "0.02",
+            "quoteQty": "1220.0",
+            # no commission / commissionAsset
+            "realizedPnl": "3.0",
+        }
+    ]
+    exchange = _exchange_with_trades(trades)
+    order = _build_order()
+    result = {"orderId": 9999, "symbol": "BTCUSDT", "status": "FILLED"}
+
+    await exchange._enrich_fill_audit(result, order)
+    formatted = exchange._format_execution_result(result, order)
+
+    assert formatted["fees"] == pytest.approx(0.0)
+    assert formatted["fee_asset"] is None
+    assert formatted["pnl"] == pytest.approx(3.0)
+
+
+@pytest.mark.asyncio
+async def test_enrich_partially_filled_is_also_enriched():
+    """PARTIALLY_FILLED orders carry trades too and must be enriched."""
+    exchange = _exchange_with_trades(_TWO_TRADES[:1])
+    result = {"orderId": 9999, "symbol": "BTCUSDT", "status": "PARTIALLY_FILLED"}
+
+    await exchange._enrich_fill_audit(result, _build_order())
+
+    exchange.client.futures_account_trades.assert_called_once()
+    assert len(result["fills"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_enrich_empty_user_trades_leaves_result_untouched():
+    """An empty userTrades response is a no-op (no synthetic fills, no pnl)."""
+    exchange = _exchange_with_trades([])
+    result = {"orderId": 9999, "symbol": "BTCUSDT", "status": "FILLED"}
+
+    await exchange._enrich_fill_audit(result, _build_order())
+
+    assert "fills" not in result
+    assert "pnl" not in result
+
+
+def test_format_execution_result_exposes_pnl_key():
+    """_format_execution_result must surface pnl (None when unknown)."""
+    exchange = BinanceFuturesExchange()
+    order = _build_order()
+
+    without_pnl = exchange._format_execution_result(
+        {"orderId": 1, "status": "FILLED", "fills": []}, order
+    )
+    assert "pnl" in without_pnl
+    assert without_pnl["pnl"] is None
+
+    with_pnl = exchange._format_execution_result(
+        {"orderId": 1, "status": "FILLED", "fills": [], "pnl": 9.75}, order
+    )
+    assert with_pnl["pnl"] == pytest.approx(9.75)

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -251,6 +251,13 @@ class BinanceFuturesExchange:
             else:
                 raise ValueError(f"Unsupported order type: {order.type}")
 
+            # #529: backfill exchange-sourced fill audit (fee/fee_asset/pnl) for
+            # FILLED Futures orders whose create_order response omits fills[].
+            from shared.config import settings
+
+            if settings.te_fill_audit_enrichment_enabled:
+                await self._enrich_fill_audit(result, order)
+
             # Format and return result
             return self._format_execution_result(result, order)
 
@@ -1405,6 +1412,10 @@ class BinanceFuturesExchange:
             "total_value": total_quote_qty,
             "fees": self._calculate_fees(fills),
             "fee_asset": self._resolve_fee_asset(fills),
+            # #529: realized PnL sourced from userTrades (see _enrich_fill_audit);
+            # None when unavailable so the audit consumer can distinguish
+            # "unknown" from a genuine zero.
+            "pnl": result.get("pnl"),
             "timestamp": result.get("transactTime"),
             "simulated": False,
             "fills": fills,
@@ -1483,6 +1494,122 @@ class BinanceFuturesExchange:
             if asset:
                 return str(asset)
         return None
+
+    async def _enrich_fill_audit(
+        self, result: dict[str, Any], order: TradeOrder
+    ) -> None:
+        """#529: Backfill exchange-sourced fill audit fields on a FILLED order.
+
+        Binance USDⓈ-M Futures ``futures_create_order`` responses do NOT carry
+        the per-trade ``fills[]`` array that Spot returns, so ``commission``,
+        ``commissionAsset`` and ``realizedPnl`` are unavailable at the moment the
+        ``execution.events`` fill event is emitted. Without them every live
+        futures fill records ``fee=0`` / no ``fee_asset`` / ``pnl=null`` in the
+        trade audit trail.
+
+        This helper fetches the order's trades from ``GET /fapi/v1/userTrades``
+        (``futures_account_trades``), folds them into ``result['fills']`` so the
+        existing fee / fill-price helpers resolve real values, and sets
+        ``result['pnl']`` from the summed ``realizedPnl``.
+
+        Best-effort by contract: the order has already executed on the exchange,
+        so any failure here is swallowed (logged at warning) and leaves
+        ``result`` untouched — audit enrichment must never raise into the trade
+        path (``execute`` would otherwise convert a genuine fill into an error
+        result).
+        """
+        if not isinstance(result, dict):
+            return
+
+        # Only FILLED / PARTIALLY_FILLED orders have trades to fetch. Protective
+        # legs (status NEW) and rejections have nothing to enrich.
+        status = str(result.get("status") or result.get("algoStatus") or "").upper()
+        if status not in ("FILLED", "PARTIALLY_FILLED"):
+            return
+
+        # Respect any per-trade detail the response already carried (spot-shaped
+        # testnet payloads, the simulator, or a future API change).
+        existing_fills = result.get("fills")
+        if isinstance(existing_fills, list) and existing_fills:
+            return
+
+        order_id = result.get("orderId") or result.get("algoId")
+        symbol = result.get("symbol") or order.symbol
+        if not order_id or not symbol or self.client is None:
+            return
+
+        try:
+            order_id_int = int(order_id)
+        except (TypeError, ValueError):
+            # Non-numeric ids (algo orders) aren't queryable via userTrades.
+            return
+
+        try:
+            loop = asyncio.get_event_loop()
+            trades = await loop.run_in_executor(
+                None,
+                lambda: self.client.futures_account_trades(  # type: ignore[union-attr]
+                    symbol=symbol, orderId=order_id_int
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "fill-audit: userTrades fetch failed for %s order %s; emitting "
+                "fill event without exchange-sourced fee/pnl",
+                symbol,
+                order_id,
+                exc_info=True,
+            )
+            return
+
+        if not isinstance(trades, list) or not trades:
+            return
+
+        synthetic_fills: list[dict[str, Any]] = []
+        realized_pnl = 0.0
+        saw_pnl = False
+        for trade in trades:
+            if not isinstance(trade, dict):
+                continue
+            price = trade.get("price")
+            qty = trade.get("qty")
+            if price is None or qty is None:
+                continue
+            quote_qty = trade.get("quoteQty")
+            if quote_qty is None:
+                try:
+                    quote_qty = str(float(price) * float(qty))
+                except (TypeError, ValueError):
+                    continue
+            # Keep the shape compatible with _format_execution_result /
+            # _calculate_fees / _resolve_fee_asset. Commission keys are only
+            # included when present so the fee summation never sees ``None``.
+            fill_entry: dict[str, Any] = {
+                "price": price,
+                "qty": qty,
+                "quoteQty": quote_qty,
+                "tradeId": trade.get("id"),
+            }
+            commission = trade.get("commission")
+            if commission is not None:
+                fill_entry["commission"] = commission
+            commission_asset = trade.get("commissionAsset")
+            if commission_asset is not None:
+                fill_entry["commissionAsset"] = commission_asset
+            synthetic_fills.append(fill_entry)
+
+            realized = trade.get("realizedPnl")
+            if realized is not None:
+                try:
+                    realized_pnl += float(realized)
+                    saw_pnl = True
+                except (TypeError, ValueError):
+                    pass
+
+        if synthetic_fills:
+            result["fills"] = synthetic_fills
+        if saw_pnl:
+            result["pnl"] = realized_pnl
 
     async def get_account_info(self) -> dict[str, Any]:
         """Get account information"""


### PR DESCRIPTION
## Summary

Implements the **tradeengine portion** of #529 (system trade logging / execution-event fill audit).

Binance USDⓈ-M Futures `futures_create_order` responses do **not** include the per-trade `fills[]` array that Spot returns. PR #530 added the emit *schema* for `fill_price / fill_quantity / fill_time / fee / fee_asset / pnl / side / symbol`, but on the live futures path the values for `fee`, `fee_asset` and `pnl` were never sourced — every live fill was recorded with `fee=0`, no `fee_asset`, and `pnl=null` in the `execution_events` audit trail.

This PR backfills those fields from the authoritative source.

## What changed

- **`_enrich_fill_audit`** (`tradeengine/exchange/binance.py`): after a `FILLED` / `PARTIALLY_FILLED` order whose response lacks `fills[]`, best-effort fetch the order's trades via `GET /fapi/v1/userTrades` (`futures_account_trades`), fold them into `result["fills"]` (so the existing fee / VWAP helpers resolve real values), and set `result["pnl"]` from summed `realizedPnl`.
- **`_format_execution_result`** now surfaces `pnl` (None when unknown) so the dispatcher emits it on `execution.events`.
- **Feature flag** `TE_FILL_AUDIT_ENRICHMENT_ENABLED` (default `true`) gates the extra per-fill REST call for per-deploy control.

## Safety

- **Best-effort by contract**: enrichment runs after the order has already executed. Any failure (API error, empty trades, non-numeric algo id, missing client) is swallowed and leaves `result` untouched — it can never raise into the trade path (which would otherwise turn a genuine fill into an error result).
- Commission keys are omitted from synthetic fills when absent, so fee summation never sees `None`.
- No change to order placement behavior; protective legs (status `NEW`) and rejections are skipped.

## Testing

- `tests/test_binance_fill_audit_enrichment.py` — enrichment happy path, skip paths (non-fill status, existing `fills[]`, non-numeric id, no client, empty trades), best-effort error swallowing, partial-fill, missing-commission, and the `pnl` passthrough.
- Full suite: **1899 passed, 12 skipped**, coverage **80.98%** (gate 40%). `ruff` clean; `mypy` adds no new errors in touched files.

## Scope / follow-ups

This completes **AC1 (data sourcing)** in tradeengine. The remaining #529 acceptance criteria are cross-service and belong in **petrosa-data-manager** (separate tickets):

- [ ] data-manager: persist the new fields to `execution_events`
- [ ] data-manager: `GET /api/v1/trades` + `/trades/summary` query API
- [ ] Grafana: trade-history dashboard

Refs #529
