### PR TITLE
feat: WS-driven OCO completion nudge (Closes #534, H6 of #977)

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -51,6 +51,15 @@ class Settings(BaseSettings):
     # headroom; can be tightened/relaxed per-deploy via env var.
     te_min_sl_distance_pct: float = 6.0
 
+    # #534 (H6 of #977): WS-driven OCO completion nudge. When enabled, a
+    # FILLED ORDER_TRADE_UPDATE on an SL/TP leg that belongs to a tracked OCO
+    # pair wakes the _monitor_orders poll immediately instead of waiting for
+    # the next 2s cycle. The poll remains the authoritative decision-maker and
+    # backstop — WS only shortens detection latency, it never cancels/closes
+    # directly, so there is no double-cancel risk. Default off until validated
+    # on testnet. Rollback: unset TE_OCO_WS_WAKE_ENABLED (or set false).
+    te_oco_ws_wake_enabled: bool = False
+
     # Redis Configuration (for caching)
     redis_url: str | None = None
     redis_password: str | None = None

--- a/tests/test_oco_ws_wake_534.py
+++ b/tests/test_oco_ws_wake_534.py
@@ -1,0 +1,196 @@
+"""Unit tests for WS-driven OCO completion nudge (#534, H6 of #977).
+
+The 2-second poll in ``OCOManager._monitor_orders`` owns every OCO
+cancel/close decision. #534 lets a FILLED ``ORDER_TRADE_UPDATE`` on an SL/TP
+leg observed on the user-data stream WAKE that poll early (bounded by the same
+2s ceiling as a backstop) instead of waiting the full interval. The poll stays
+authoritative, so the WS path only shortens latency and can never double-cancel.
+
+These tests exercise the wake mechanism directly:
+
+    AC1: A WS fill on a tracked OCO leg sets the wake event (early re-poll).
+    AC2: The 2s poll remains the backstop; the flag defaults off (no behaviour
+         change when disabled — the event is never consulted).
+    AC4: Idempotency — a fill for an unrelated order does not wake the monitor,
+         and repeated sets are a harmless no-op (poll still decides).
+
+Related:
+    - Issue: https://github.com/PetroSa2/petrosa-tradeengine/issues/534
+    - Parent: https://github.com/PetroSa2/petrosa_k8s/issues/977
+"""
+
+import asyncio
+import logging
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from tradeengine.dispatcher import Dispatcher, OCOManager
+
+
+def _make_manager() -> OCOManager:
+    return OCOManager(exchange=Mock(), logger=logging.getLogger("test-534"))
+
+
+def _track_pair(
+    mgr: OCOManager,
+    *,
+    key: str = "BTCUSDT_LONG",
+    symbol: str = "BTCUSDT",
+    sl: str = "111",
+    tp: str = "222",
+) -> None:
+    mgr.active_oco_pairs[key] = [
+        {
+            "symbol": symbol,
+            "position_side": "LONG",
+            "status": "active",
+            "sl_order_id": sl,
+            "tp_order_id": tp,
+        }
+    ]
+
+
+def test_ac1_ws_fill_on_tracked_sl_leg_sets_wake_event() -> None:
+    """A FILLED WS event on a tracked SL leg wakes the monitor."""
+    mgr = _make_manager()
+    _track_pair(mgr, sl="111", tp="222")
+    assert not mgr._oco_wake_event.is_set()
+
+    mgr.notify_oco_leg_fill("BTCUSDT", "111")
+
+    assert mgr._oco_wake_event.is_set()
+
+
+def test_ac1_ws_fill_on_tracked_tp_leg_sets_wake_event() -> None:
+    """A FILLED WS event on a tracked TP leg wakes the monitor."""
+    mgr = _make_manager()
+    _track_pair(mgr, sl="111", tp="222")
+
+    mgr.notify_oco_leg_fill("BTCUSDT", "222")
+
+    assert mgr._oco_wake_event.is_set()
+
+
+def test_ac4_unrelated_order_does_not_wake() -> None:
+    """A fill for an order that is not part of any tracked pair is ignored."""
+    mgr = _make_manager()
+    _track_pair(mgr, sl="111", tp="222")
+
+    mgr.notify_oco_leg_fill("BTCUSDT", "999")  # unknown order id
+    assert not mgr._oco_wake_event.is_set()
+
+    mgr.notify_oco_leg_fill("ETHUSDT", "111")  # right id, wrong symbol
+    assert not mgr._oco_wake_event.is_set()
+
+
+def test_ac4_idempotent_repeated_sets_are_noop() -> None:
+    """Calling notify repeatedly is safe — the event stays set, poll decides."""
+    mgr = _make_manager()
+    _track_pair(mgr, sl="111", tp="222")
+
+    mgr.notify_oco_leg_fill("BTCUSDT", "111")
+    mgr.notify_oco_leg_fill("BTCUSDT", "111")
+    mgr.notify_oco_leg_fill("BTCUSDT", "222")
+
+    assert mgr._oco_wake_event.is_set()
+
+
+def test_no_tracked_pairs_is_safe() -> None:
+    """No active pairs -> notify is a harmless no-op."""
+    mgr = _make_manager()
+    mgr.notify_oco_leg_fill("BTCUSDT", "111")
+    assert not mgr._oco_wake_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_ac1_wake_event_interrupts_wait_early() -> None:
+    """When set, the wake event releases an awaiter well under the 2s ceiling.
+
+    Mirrors the interruptible-sleep the monitor performs when the flag is on:
+    ``await asyncio.wait_for(self._oco_wake_event.wait(), timeout=2)``.
+    """
+    mgr = _make_manager()
+    _track_pair(mgr, sl="111", tp="222")
+
+    async def waiter() -> float:
+        loop = asyncio.get_event_loop()
+        start = loop.time()
+        try:
+            await asyncio.wait_for(mgr._oco_wake_event.wait(), timeout=2)
+        except TimeoutError:
+            pass
+        return loop.time() - start
+
+    task = asyncio.ensure_future(waiter())
+    await asyncio.sleep(0.05)
+    mgr.notify_oco_leg_fill("BTCUSDT", "111")  # WS fill arrives
+    elapsed = await task
+
+    assert elapsed < 1.0  # woke early, nowhere near the 2s backstop ceiling
+
+
+@pytest.mark.asyncio
+async def test_ac2_backstop_timeout_when_no_wake() -> None:
+    """With no fill signal, the awaiter falls through on the 2s backstop."""
+    mgr = _make_manager()
+    _track_pair(mgr, sl="111", tp="222")
+
+    timed_out = False
+    try:
+        await asyncio.wait_for(mgr._oco_wake_event.wait(), timeout=0.1)
+    except TimeoutError:
+        timed_out = True
+
+    assert timed_out  # poll still fires on its interval — backstop intact
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher._on_user_data_fill — callback → wake integration (flag-gated).
+# ---------------------------------------------------------------------------
+
+
+def _bare_dispatcher_with_pair() -> Dispatcher:
+    d = Dispatcher.__new__(Dispatcher)
+    d.logger = MagicMock()
+    d.oco_manager = _make_manager()
+    _track_pair(d.oco_manager, sl="111", tp="222")
+    return d
+
+
+@pytest.mark.asyncio
+async def test_ac1_callback_wakes_monitor_when_flag_on() -> None:
+    """A FILLED reduce-only SL leg wakes the monitor when the flag is on."""
+    d = _bare_dispatcher_with_pair()
+    order_obj = {
+        "s": "BTCUSDT",
+        "i": 111,  # matches the tracked SL leg
+        "X": "FILLED",
+        "S": "SELL",
+        "o": "STOP_MARKET",
+        "R": True,
+    }
+    with patch("tradeengine.dispatcher.settings") as st:
+        st.te_oco_ws_wake_enabled = True
+        await d._on_user_data_fill(order_obj)
+
+    assert d.oco_manager._oco_wake_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_ac2_callback_does_not_wake_when_flag_off() -> None:
+    """With the flag off, the callback never touches the wake event."""
+    d = _bare_dispatcher_with_pair()
+    order_obj = {
+        "s": "BTCUSDT",
+        "i": 111,
+        "X": "FILLED",
+        "S": "SELL",
+        "o": "STOP_MARKET",
+        "R": True,
+    }
+    with patch("tradeengine.dispatcher.settings") as st:
+        st.te_oco_ws_wake_enabled = False
+        await d._on_user_data_fill(order_obj)
+
+    assert not d.oco_manager._oco_wake_event.is_set()

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -11,7 +11,7 @@ from prometheus_client import Counter, Histogram
 from contracts.order import OrderSide, OrderStatus, OrderType, TradeOrder
 from contracts.signal import Signal, TimeInForce
 from shared.audit import audit_logger
-from shared.config import Settings
+from shared.config import Settings, settings
 from shared.constants import (
     OCO_CANCEL_RETRY_ATTEMPTS,
     OCO_CANCEL_RETRY_BACKOFF_MULTIPLIER,
@@ -110,6 +110,39 @@ class OCOManager:
         self.pending_entries: dict[str, dict[str, Any]] = {}
         self.monitoring_task: asyncio.Task[Any] | None = None
         self.monitoring_active = False
+        # #534 (H6 of #977): WS-driven OCO completion nudge. Set by the
+        # user-data-stream fill callback when a FILLED SL/TP leg belongs to a
+        # tracked OCO pair, so _monitor_orders wakes early instead of waiting
+        # the full 2s poll interval. The poll still performs all cancel/close
+        # decisions — this event only shortens latency (poll is the backstop).
+        self._oco_wake_event: asyncio.Event = asyncio.Event()
+
+    def notify_oco_leg_fill(self, symbol: str, order_id: str) -> None:
+        """#534 (H6 of #977): wake _monitor_orders when a FILLED SL/TP leg
+        observed on the user-data stream belongs to a tracked OCO pair.
+
+        Only sets the wake event when ``order_id`` matches an SL or TP order of
+        an active pair for ``symbol`` — a fill for an unrelated order does not
+        shorten the poll interval. Setting an already-set event is a no-op, and
+        the poll remains the authoritative decision-maker, so this is safe to
+        call for every leg fill (idempotent, never cancels/closes directly).
+        """
+        for oco_list in self.active_oco_pairs.values():
+            for oco in oco_list:
+                if oco.get("symbol") != symbol:
+                    continue
+                if order_id in (
+                    str(oco.get("sl_order_id", "")),
+                    str(oco.get("tp_order_id", "")),
+                ):
+                    self._oco_wake_event.set()
+                    self.logger.info(
+                        "#534: WS ORDER_TRADE_UPDATE fill on OCO leg %s (%s) "
+                        "— nudging monitor to re-poll immediately",
+                        order_id,
+                        symbol,
+                    )
+                    return
 
     async def place_oco_orders(
         self,
@@ -1515,8 +1548,20 @@ class OCOManager:
                         # No active pairs left, remove the key
                         del self.active_oco_pairs[exchange_position_key]
 
-                # Wait before next check
-                await asyncio.sleep(2)  # Check every 2 seconds
+                # Wait before next check. #534: when the WS-wake flag is on,
+                # sleep is interruptible — a FILLED SL/TP leg observed on the
+                # user-data stream sets _oco_wake_event and we re-poll at once
+                # (bounded by the same 2s ceiling as a backstop). When off,
+                # behaviour is identical to the original fixed 2s poll.
+                if settings.te_oco_ws_wake_enabled:
+                    try:
+                        await asyncio.wait_for(self._oco_wake_event.wait(), timeout=2)
+                    except TimeoutError:
+                        pass
+                    finally:
+                        self._oco_wake_event.clear()
+                else:
+                    await asyncio.sleep(2)  # Check every 2 seconds
 
             except Exception as e:
                 self.logger.error(f"❌ ERROR IN ORDER MONITORING: {e}")
@@ -3672,6 +3717,20 @@ class Dispatcher:
                 "STOP",
                 "TAKE_PROFIT",
             ):
+                # #534 (H6 of #977): a FILLED SL/TP leg is the exact signal the
+                # 2s poll waits for. When the WS-wake flag is on, nudge the
+                # OCO monitor so it re-polls immediately instead of waiting up
+                # to 2s. The poll still owns the cancel/close decision, so this
+                # only shortens latency and cannot double-cancel. Best-effort.
+                if settings.te_oco_ws_wake_enabled:
+                    try:
+                        self.oco_manager.notify_oco_leg_fill(symbol, order_id)
+                    except Exception as wake_err:
+                        self.logger.debug(
+                            "#534: OCO wake nudge failed for %s: %s",
+                            order_id,
+                            wake_err,
+                        )
                 self.logger.debug(
                     "#531: skipping user-data fill for reduce-only/SL-TP order "
                     "%s (%s) — OCO path owns its filled event",
@@ -4166,7 +4225,6 @@ class Dispatcher:
                     reference_price = 0.0
 
             if reference_price > 0:
-                from shared.config import Settings
                 from tradeengine.risk.sl_tp_direction import (
                     correct_protective_price,
                 )


### PR DESCRIPTION
## Summary

Drives OCO leg-completion detection from the existing user-data stream (`ORDER_TRADE_UPDATE`) instead of waiting the full 2-second REST poll interval. Implements **H6 of #977** — the last outstanding task from the Orphan/OCO/Watchdog hardening epic.

**Approach: WS nudges the poll** (chosen for lowest risk). A FILLED SL/TP leg observed on the WS wakes `_monitor_orders` immediately; the poll still performs every cancel/close decision, so the WS path only shortens detection latency and **cannot double-cancel**. The 2s poll remains the authoritative backstop.

## Changes

- **`shared/config.py`** — `te_oco_ws_wake_enabled` flag (`TE_OCO_WS_WAKE_ENABLED`, default **off**, testnet-gated).
- **`tradeengine/dispatcher.py`**
  - `OCOManager._oco_wake_event` (`asyncio.Event`).
  - `_monitor_orders` sleep is interruptible when the flag is on: `await asyncio.wait_for(self._oco_wake_event.wait(), timeout=2)` — same 2s ceiling as a backstop; identical behaviour when off.
  - `OCOManager.notify_oco_leg_fill(symbol, order_id)` — sets the wake event **only** when `order_id` matches an SL/TP leg of a tracked active pair (idempotent, never cancels/closes directly).
  - `Dispatcher._on_user_data_fill()` — nudges the monitor on reduce-only/SL-TP fills, before the existing #531 skip-return.

## Acceptance Criteria

- [x] **AC1** — OCO completion can be triggered by a WS `ORDER_TRADE_UPDATE` fill without waiting for the next poll. *(unit + callback integration tests)*
- [x] **AC2** — REST poll remains active as backstop; no behaviour change when the flag is off. *(flag-off test + interruptible-timeout test)*
- [ ] **AC3** — Testnet validation showing reduced detection latency vs poll-only. *(requires live testnet; deferred to rollout — flag defaults off)*
- [x] **AC4** — No double-cancel when both WS and poll observe the same fill (idempotency asserted). *(poll owns all cancel/close; WS only wakes — idempotency tests)*

## Testing

- 9 new tests in `tests/test_oco_ws_wake_534.py` (all green).
- Full OCO/watchdog regression suite: **79 passed, 4 skipped, 0 failed**.
- `ruff` clean; `py_compile` clean.

## Rollback

Single env var: unset/`false` `TE_OCO_WS_WAKE_ENABLED` restores pure poll-based behaviour.

## Notes

- Parent epic #977 and grandparent #970 are closed; this delivers their one remaining optional/stretch task.
- AC3 (testnet latency proof) is intentionally left for the staged rollout since the flag ships **off** by default.

Closes #534
