### PR TITLE
fix(oco): clamp SL to max placeable when safety floor exceeds PERCENT_PRICE cap (Closes #541)

### DIFF
--- a/tests/test_adversarial_503_oco_percent_filter.py
+++ b/tests/test_adversarial_503_oco_percent_filter.py
@@ -107,17 +107,25 @@ class TestOutOfBandTriggerRefused:
             status=OrderStatus.PENDING,
         )
 
-        # AC3: a leg that cannot be made filter-compliant is refused (raises),
-        # not shipped. This SL is 14.8% below market with a ±5% filter and a 6%
-        # safety floor — infeasible — so the correct outcome is a clean refuse.
-        # An in-band-adjustable trigger would instead be clamped and shipped.
-        with pytest.raises(ValueError, match="percent_filter_reject|unreachable"):
-            await exch._execute_stop_order(order)
+        # #541: this SL is 14.8% below market with a ±5% filter and a 6% safety
+        # floor — the floor is FARTHER than the filter allows, so no price
+        # satisfies both. Previously this refused (raised) and left the position
+        # NAKED. It now CLAMPS to the furthest placeable price (just inside the
+        # ±5% filter) and ships that — a slightly-tight stop beats no stop.
+        await exch._execute_stop_order(order)
 
-        # In either outcome, the raw out-of-band trigger must never be shipped.
+        # The raw out-of-band trigger must NEVER be shipped verbatim (#503 intent
+        # preserved) — and what IS shipped must sit inside the ±5% filter (#541).
         shipped = str(captured.get("triggerPrice", ""))
         assert shipped not in ("0.16215", "0.16215000"), (
             f"OCO STOP shipped out-of-band trigger {shipped} verbatim (#503)"
+        )
+        shipped_val = float(captured.get("triggerPrice"))
+        market = 0.19
+        dev_pct = abs(shipped_val - market) / market * 100
+        assert dev_pct < 5.0, (
+            f"#541: shipped SL {shipped_val} ({dev_pct:.2f}%) must be clamped "
+            f"inside the ±5% PERCENT_PRICE filter"
         )
 
     @pytest.mark.asyncio

--- a/tests/test_min_sl_distance.py
+++ b/tests/test_min_sl_distance.py
@@ -52,13 +52,18 @@ def _stub_filter(
 
 
 @pytest.mark.asyncio
-async def test_h4_refuses_sl_inside_safety_floor_when_filter_is_tight(exchange):
-    """AC4: when PERCENT_PRICE filter is ±5% and safety floor is 6%, the
-    adjusted SL would be guaranteed to trigger — the adjuster MUST refuse
-    instead of clipping to the boundary. Mirrors the BCHUSDT case from
-    the 2026-05-30 incident (market $303.10, adjusted SL $315.07 = +3.95%)."""
+async def test_541_clamps_sl_to_max_placeable_when_floor_exceeds_filter(exchange):
+    """#541: when the PERCENT_PRICE filter cap (±5%) is TIGHTER than the safety
+    floor (6%), no price satisfies both. Previously the adjuster refused and
+    left the position NAKED (returned (False, None, reason)). It now CLAMPS the
+    SL to the furthest placeable price (just inside the filter) so the position
+    is protected — a slightly-tight stop beats no stop. Verified live on testnet
+    2026-08-19 where every arm attempt was rejected and 20 positions stayed naked.
+
+    Above-market stop (short SL): clamp to max_price = market * multiplierUp *
+    (1 - 1% safety margin)."""
     market = 303.10
-    requested_sl = 442.03  # 45.84% above market — outside ±5% filter
+    requested_sl = 442.03  # +45.84% above market — outside ±5% filter
     _stub_filter(
         exchange, market_price=market, multiplier_up=1.05, multiplier_down=0.95
     )
@@ -74,9 +79,45 @@ async def test_h4_refuses_sl_inside_safety_floor_when_filter_is_tight(exchange):
         min_safe_distance_pct=6.0,
     )
 
-    assert is_adjusted is False
-    assert adjusted_price is None
-    assert "sl_unreachable_within_filter" in msg
+    # NEW behavior: clamp instead of refuse — position protected, not naked.
+    assert is_adjusted is True
+    assert adjusted_price is not None
+    expected_max = market * 1.05 * (1 - 0.01)  # furthest placeable above market
+    assert adjusted_price == pytest.approx(expected_max, rel=1e-6)
+    # Clamped price is inside the ±5% filter (deviation < 5%).
+    dev_pct = (adjusted_price - market) / market * 100
+    assert 0 < dev_pct < 5.0
+    assert "CLAMPED" in msg and "#541" in msg
+
+
+@pytest.mark.asyncio
+async def test_541_clamps_below_market_sl_when_floor_exceeds_filter(exchange):
+    """#541 mirror: below-market stop (long SL) with a tight ±5% filter and 6%
+    floor clamps to min_price (just inside the filter) instead of refusing."""
+    market = 100.0
+    requested_sl = 50.0  # -50% — far outside ±5% filter
+    _stub_filter(
+        exchange, market_price=market, multiplier_up=1.05, multiplier_down=0.95
+    )
+
+    (
+        is_adjusted,
+        adjusted_price,
+        msg,
+    ) = await exchange.validate_and_adjust_price_for_percent_filter(
+        symbol="BTCUSDT",
+        price=requested_sl,
+        order_type="STOP_LOSS",
+        min_safe_distance_pct=6.0,
+    )
+
+    assert is_adjusted is True
+    assert adjusted_price is not None
+    expected_min = market * 0.95 * (1 + 0.01)  # furthest placeable below market
+    assert adjusted_price == pytest.approx(expected_min, rel=1e-6)
+    dev_pct = (adjusted_price - market) / market * 100
+    assert -5.0 < dev_pct < 0
+    assert "CLAMPED" in msg and "#541" in msg
 
 
 @pytest.mark.asyncio

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -1089,26 +1089,66 @@ class BinanceFuturesExchange:
                     # Above-market: adjusted ceiling under filter is max_price;
                     # safety floor is floor_hi. Feasible iff max_price >= floor_hi.
                     if max_price < floor_hi:
-                        reason = (
-                            f"sl_unreachable_within_filter: requested ${price:.2f} "
-                            f"({deviation_pct:+.2f}%) cannot satisfy both PERCENT_PRICE "
-                            f"(max {(multiplier_up - 1) * 100:+.2f}%) and safety floor "
-                            f"({min_safe_distance_pct:+.2f}%) for {symbol} {order_type}; "
+                        # #541: the safety floor is FARTHER from market than the
+                        # PERCENT_PRICE filter permits (e.g. floor 6% vs filter
+                        # cap 5%), so NO price satisfies both. Historically this
+                        # refused the SL (returned None) and left the position
+                        # NAKED — strictly worse than an imperfect stop. Clamp to
+                        # the furthest placeable price (just inside the filter) so
+                        # the position is at least protected; the floor's intent
+                        # (#424: avoid stops so tight they trigger on routine
+                        # volatility) is honored best-effort. Emit a warning +
+                        # metric so operators can see the floor/filter conflict.
+                        adjusted_price = max_price
+                        clamp_msg = (
+                            f"⚠️ #541 SL CLAMPED (floor>filter): {symbol} {order_type} "
+                            f"requested ${price:.2f} ({deviation_pct:+.2f}%) exceeds "
+                            f"PERCENT_PRICE cap (max {(multiplier_up - 1) * 100:+.2f}%) "
+                            f"while safety floor is {min_safe_distance_pct:+.2f}%; no "
+                            f"price satisfies both. Clamping to furthest placeable "
+                            f"${adjusted_price:.2f} "
+                            f"({((adjusted_price - current_price) / current_price) * 100:+.2f}%) "
+                            f"to protect the position rather than leave it naked; "
                             f"market=${current_price:.2f}"
                         )
-                        logger.error(reason)
-                        return (False, None, reason)
+                        logger.warning(clamp_msg)
+                        try:
+                            from tradeengine.metrics import (
+                                record_sl_floor_filter_clamp,
+                            )
+
+                            record_sl_floor_filter_clamp(symbol)
+                        except Exception:
+                            pass
+                        return (True, adjusted_price, clamp_msg)
                 elif price < current_price:
                     if min_price > floor_lo:
-                        reason = (
-                            f"sl_unreachable_within_filter: requested ${price:.2f} "
-                            f"({deviation_pct:+.2f}%) cannot satisfy both PERCENT_PRICE "
-                            f"(min {(multiplier_down - 1) * 100:+.2f}%) and safety floor "
-                            f"({-min_safe_distance_pct:+.2f}%) for {symbol} {order_type}; "
+                        # #541: mirror of the above-market case for below-market
+                        # stops (e.g. long SL). Clamp to the furthest placeable
+                        # price (min_price, just inside the filter floor) instead
+                        # of refusing and leaving the position naked.
+                        adjusted_price = min_price
+                        clamp_msg = (
+                            f"⚠️ #541 SL CLAMPED (floor>filter): {symbol} {order_type} "
+                            f"requested ${price:.2f} ({deviation_pct:+.2f}%) exceeds "
+                            f"PERCENT_PRICE cap (min {(multiplier_down - 1) * 100:+.2f}%) "
+                            f"while safety floor is {-min_safe_distance_pct:+.2f}%; no "
+                            f"price satisfies both. Clamping to furthest placeable "
+                            f"${adjusted_price:.2f} "
+                            f"({((adjusted_price - current_price) / current_price) * 100:+.2f}%) "
+                            f"to protect the position rather than leave it naked; "
                             f"market=${current_price:.2f}"
                         )
-                        logger.error(reason)
-                        return (False, None, reason)
+                        logger.warning(clamp_msg)
+                        try:
+                            from tradeengine.metrics import (
+                                record_sl_floor_filter_clamp,
+                            )
+
+                            record_sl_floor_filter_clamp(symbol)
+                        except Exception:
+                            pass
+                        return (True, adjusted_price, clamp_msg)
 
             # Check if adjustment is needed
             if price < min_price:

--- a/tradeengine/metrics.py
+++ b/tradeengine/metrics.py
@@ -169,6 +169,29 @@ oco_cancel_retry_exhausted_total = Counter(
     ["symbol", "reason"],
 )
 
+# #541: the stop-loss safety floor (te_min_sl_distance_pct) is farther from
+# market than the exchange PERCENT_PRICE filter permits, so no price satisfies
+# both. Rather than refuse the SL and leave the position naked, the price
+# adjuster now CLAMPS the stop to the furthest placeable distance (just inside
+# the filter) and increments this counter. A nonzero rate means the configured
+# floor exceeds the exchange cap for that symbol — operators should reconcile
+# te_min_sl_distance_pct with the symbol's PERCENT_PRICE band.
+sl_floor_filter_clamp_total = Counter(
+    "petrosa_tradeengine_sl_floor_filter_clamp_total",
+    "Stop-loss placements clamped to the exchange PERCENT_PRICE cap because the "
+    "safety floor was unreachable (position protected instead of left naked)",
+    ["symbol"],
+)
+
+
+def record_sl_floor_filter_clamp(symbol: str) -> None:
+    """Increment the #541 SL-clamp counter for a symbol (best-effort)."""
+    try:
+        sl_floor_filter_clamp_total.labels(symbol=symbol).inc()
+    except Exception:
+        pass
+
+
 # #426 (RC#2 of #424): the atomic-rollback path itself failed — the
 # OCO-failure cleanup could not close the position on Binance, so the
 # position remains unhedged. Paired with the


### PR DESCRIPTION
## Summary

Fixes **#541**: naked positions that can never be protected because the stop-loss safety floor is farther from market than the exchange PERCENT_PRICE filter allows.

## Root cause (proven live)

`validate_and_adjust_price_for_percent_filter` (`tradeengine/exchange/binance.py`) enforces a safety floor `te_min_sl_distance_pct` (default **6%**) AND the exchange PERCENT_PRICE filter. When the filter cap is **±5%** and the floor is **6%**, `6% > 5%` ⇒ **no price satisfies both**, and the adjuster returned `(False, None, reason)` — refusing the SL and leaving the position **naked**.

Verified live on Binance futures testnet (2026-08-19, after #540 activated the remediator): every arm attempt rejected with `sl_unreachable_within_filter`, **20 positions naked, 0 protective orders**, remediator retrying every ~7s to no effect.

## Fix

When the floor exceeds the filter cap, **clamp** the stop to the furthest placeable price (just inside the filter) and ship it, instead of refusing. A slightly-tight stop protects the position; a refusal leaves it naked (strictly worse). The floor's original intent (#424: avoid stops so tight they trigger on routine volatility) is honored best-effort.

- Above-market stop (short SL) → clamp to `max_price` (filter ceiling).
- Below-market stop (long SL) → clamp to `min_price` (filter floor).
- New counter `petrosa_tradeengine_sl_floor_filter_clamp_total{symbol}` + warning log so operators can see/alert when the configured floor exceeds a symbol's PERCENT_PRICE band and reconcile `te_min_sl_distance_pct`.

## Tests

- Rewrote the two tests that codified the old refuse behavior (`test_min_sl_distance.py`, `test_adversarial_503_oco_percent_filter.py`) to assert clamping.
- Added a below-market clamp test.
- All touched suites pass in isolation (89 tests): `test_min_sl_distance` (7), `test_adversarial_503` (4), `test_adversarial_504` (7), `test_binance_exchange_comprehensive` (64), `test_oco_race_conditions` (7).
- Note: a pre-existing cross-file test-pollution failure in `TestFallbackLogic` exists on `main` independent of this change (files pass individually).

## Post-merge verification (testnet)

With #540 already live (remediator in `arm_only`), after this deploys: the remediator's SL arm attempts should be clamped-and-accepted, and `/orders` should show protective SL/TP appearing for the previously-naked positions.

Closes #541. Depends on #540 (already merged) for the remediator to actually run.
