### PR TITLE
[BUG][P0] Naked-arm fails at exchange — GTE TIF + closePosition (-4509/-4130) block SL/TP placement

### DIFF
--- a/tests/test_issue_352_source_acs.py
+++ b/tests/test_issue_352_source_acs.py
@@ -223,6 +223,114 @@ class TestAC3ClosePositionFlag:
 
 
 # ---------------------------------------------------------------------------
+# #543: closePosition legs MUST send timeInForce=GTE_GTC
+#
+# Binance rejects closePosition=true conditional orders whose TIF resolves to
+# the bare server-side "GTE" default with APIError -4509 ("TIF GTE can only be
+# used with open positions"). The valid value is GTE_GTC, which also lets
+# Binance auto-cancel the sibling leg (preventing the -4130 duplicate storm).
+# ---------------------------------------------------------------------------
+
+
+class TestIssue543GteGtcTimeInForce:
+    """All four closePosition algo builders must send timeInForce=GTE_GTC."""
+
+    def _make_binance(self):
+        from tradeengine.exchange.binance import BinanceFuturesExchange
+
+        exchange = BinanceFuturesExchange.__new__(BinanceFuturesExchange)
+        exchange.client = MagicMock()
+        exchange._symbol_info_cache = {}
+        exchange._format_quantity = lambda sym, qty: str(round(qty, 3))
+        exchange._format_price = lambda sym, price: str(round(price, 2))
+        exchange._execute_with_retry = AsyncMock(
+            return_value={"algoId": "123", "status": "NEW"}
+        )
+        exchange.validate_price_within_percent_filter = AsyncMock(
+            return_value=(True, None)
+        )
+        exchange.validate_and_adjust_price_for_percent_filter = AsyncMock(
+            return_value=(False, 48000.0, None)
+        )
+        return exchange
+
+    @pytest.mark.asyncio
+    async def test_stop_market_sends_gte_gtc(self):
+        exchange = self._make_binance()
+        order = _make_order()
+        order.stop_loss = 48000.0
+        order.position_side = None
+
+        await exchange._execute_stop_order(order)
+
+        flat = exchange._execute_with_retry.call_args[1]
+        assert flat.get("timeInForce") == "GTE_GTC", (
+            "STOP_MARKET closePosition leg must send GTE_GTC (not bare GTE) — #543"
+        )
+
+    @pytest.mark.asyncio
+    async def test_take_profit_market_sends_gte_gtc(self):
+        exchange = self._make_binance()
+        order = _make_order()
+        order.take_profit = 52000.0
+        order.position_side = None
+
+        await exchange._execute_take_profit_order(order)
+
+        flat = exchange._execute_with_retry.call_args[1]
+        assert flat.get("timeInForce") == "GTE_GTC", (
+            "TAKE_PROFIT_MARKET closePosition leg must send GTE_GTC — #543"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_limit_sends_gte_gtc(self):
+        exchange = self._make_binance()
+        order = _make_order()
+        order.stop_loss = 48000.0
+        order.target_price = 47900.0
+        order.position_side = None
+
+        await exchange._execute_stop_limit_order(order)
+
+        flat = exchange._execute_with_retry.call_args[1]
+        assert flat.get("timeInForce") == "GTE_GTC", (
+            "STOP (limit) closePosition leg must send GTE_GTC — #543"
+        )
+
+    @pytest.mark.asyncio
+    async def test_take_profit_limit_sends_gte_gtc(self):
+        exchange = self._make_binance()
+        order = _make_order()
+        order.take_profit = 52000.0
+        order.target_price = 52100.0
+        order.position_side = None
+
+        await exchange._execute_take_profit_limit_order(order)
+
+        flat = exchange._execute_with_retry.call_args[1]
+        assert flat.get("timeInForce") == "GTE_GTC", (
+            "TAKE_PROFIT (limit) closePosition leg must send GTE_GTC — #543"
+        )
+
+    @pytest.mark.asyncio
+    async def test_signal_gtc_tif_does_not_override_close_position_leg(self):
+        """Even when the source order carries a plain GTC TIF, the closePosition
+        legs must still force GTE_GTC — a signal-provided GTC would otherwise
+        resolve to bare GTE server-side and trip -4509."""
+        exchange = self._make_binance()
+        order = _make_order()
+        order.stop_loss = 48000.0
+        order.target_price = 47900.0
+        order.position_side = None
+        order.time_in_force = "GTC"
+
+        await exchange._execute_stop_limit_order(order)
+
+        flat = exchange._execute_with_retry.call_args[1]
+        assert flat.get("timeInForce") == "GTE_GTC"
+
+
+# ---------------------------------------------------------------------------
 # AC-4: reconcile_from_exchange registers orphaned orders individually
 # ---------------------------------------------------------------------------
 

--- a/tradeengine/exchange/binance.py
+++ b/tradeengine/exchange/binance.py
@@ -32,6 +32,15 @@ from tradeengine.services.rate_monitor import RateLimitMonitor
 
 logger = logging.getLogger(__name__)
 
+# #543: Binance rejects closePosition=true conditional (STOP_MARKET /
+# TAKE_PROFIT_MARKET / STOP / TAKE_PROFIT) orders whose TIF resolves to the
+# bare "GTE" server default with APIError -4509 ("TIF GTE can only be used with
+# open positions"). The valid value for close-all protective legs is GTE_GTC,
+# which also makes Binance auto-cancel the sibling leg when the position closes
+# (preventing the -4130 duplicate-closePosition storm). python-binance's enums
+# do not expose this value, so it is defined here.
+TIME_IN_FORCE_GTE_GTC = "GTE_GTC"
+
 
 class BinanceFuturesExchange:
     """Binance Futures exchange client for executing trades"""
@@ -376,7 +385,7 @@ class BinanceFuturesExchange:
         if self.client is None:
             raise RuntimeError("Binance Futures client not initialized")
 
-        params = {
+        params: dict[str, Any] = {
             "symbol": order.symbol,
             "side": SIDE_BUY if order.side == "buy" else SIDE_SELL,
             "type": FUTURE_ORDER_TYPE_MARKET,
@@ -420,7 +429,7 @@ class BinanceFuturesExchange:
         if not is_valid:
             raise ValueError(error_msg)
 
-        params = {
+        params: dict[str, Any] = {
             "symbol": order.symbol,
             "side": SIDE_BUY if order.side == "buy" else SIDE_SELL,
             "type": FUTURE_ORDER_TYPE_LIMIT,
@@ -486,11 +495,14 @@ class BinanceFuturesExchange:
         # AC-3 (#352): use closePosition=true so Binance auto-sweeps the order when the
         # position closes. quantity + reduceOnly=true do NOT auto-cancel CONDITIONAL algo
         # orders — they accumulate indefinitely as orphans.
-        params = {
+        params: dict[str, Any] = {
             "symbol": order.symbol,
             "side": SIDE_BUY if order.side == "buy" else SIDE_SELL,
             "type": FUTURE_ORDER_TYPE_STOP_MARKET,
             "algoType": "CONDITIONAL",  # Required for Binance Algo Order API
+            # #543: closePosition legs MUST send GTE_GTC. Omitting TIF lets the
+            # server default to bare GTE, which Binance rejects with -4509.
+            "timeInForce": TIME_IN_FORCE_GTE_GTC,
             "closePosition": True,
             "triggerPrice": self._format_price(
                 order.symbol, trigger_price
@@ -533,7 +545,9 @@ class BinanceFuturesExchange:
             "side": SIDE_BUY if order.side == "buy" else SIDE_SELL,
             "type": FUTURE_ORDER_TYPE_STOP,
             "algoType": "CONDITIONAL",  # Required for Binance Algo Order API
-            "timeInForce": order.time_in_force or TIME_IN_FORCE_GTC,
+            # #543: closePosition legs MUST send GTE_GTC (not GTC) — a bare/GTC
+            # TIF resolves to server-side GTE and is rejected with -4509.
+            "timeInForce": TIME_IN_FORCE_GTE_GTC,
             "closePosition": True,
             "price": self._format_price(order.symbol, order.target_price),
             "triggerPrice": self._format_price(
@@ -562,11 +576,14 @@ class BinanceFuturesExchange:
         if order.take_profit is None:
             raise ValueError("Take profit price required for take profit orders")
         # AC-3 (#352): closePosition=true; omit quantity/reduceOnly so Binance auto-sweeps.
-        params = {
+        params: dict[str, Any] = {
             "symbol": order.symbol,
             "side": SIDE_BUY if order.side == "buy" else SIDE_SELL,
             "type": FUTURE_ORDER_TYPE_TAKE_PROFIT_MARKET,
             "algoType": "CONDITIONAL",  # Required for Binance Algo Order API
+            # #543: closePosition legs MUST send GTE_GTC. Omitting TIF lets the
+            # server default to bare GTE, which Binance rejects with -4509.
+            "timeInForce": TIME_IN_FORCE_GTE_GTC,
             "closePosition": True,
             "triggerPrice": self._format_price(
                 order.symbol, order.take_profit
@@ -611,7 +628,9 @@ class BinanceFuturesExchange:
             "side": SIDE_BUY if order.side == "buy" else SIDE_SELL,
             "type": FUTURE_ORDER_TYPE_TAKE_PROFIT,
             "algoType": "CONDITIONAL",  # Required for Binance Algo Order API
-            "timeInForce": order.time_in_force or TIME_IN_FORCE_GTC,
+            # #543: closePosition legs MUST send GTE_GTC (not GTC) — a bare/GTC
+            # TIF resolves to server-side GTE and is rejected with -4509.
+            "timeInForce": TIME_IN_FORCE_GTE_GTC,
             "closePosition": True,
             "price": self._format_price(order.symbol, order.target_price),
             "triggerPrice": self._format_price(


### PR DESCRIPTION
## Summary

Fixes the third and final layer of the naked-position chain (follows #540, #541).
Protective SL/TP orders were failing at the Binance API with **-4509** ("TIF GTE
can only be used with open positions"), leaving positions naked with 0 protective
orders on the exchange.

## Root cause

The naked-position remediator (`naked_position_remediator._rearm`) builds SL/TP
`TradeOrder`s with `time_in_force` unset — it defaults to `None`
(`contracts/order.py:93`). Those orders route by `type` to the two **MARKET**
algo builders (`_execute_stop_order`, `_execute_take_profit_order`), which sent
**no `timeInForce` at all**. For `closePosition=true` conditional orders Binance
then applies its bare server-side `GTE` default, which it immediately rejects
with **-4509**. The `-4130` ("open stop/TP with GTE and closePosition already
existing") was the downstream symptom of the retry loop re-submitting.

## Fix

Force `timeInForce=GTE_GTC` on all four `closePosition` algo builders:

- `_execute_stop_order` (STOP_MARKET) — was sending no TIF
- `_execute_take_profit_order` (TAKE_PROFIT_MARKET) — was sending no TIF
- `_execute_stop_limit_order` (STOP) — was `order.time_in_force or GTC`
- `_execute_take_profit_limit_order` (TAKE_PROFIT) — was `order.time_in_force or GTC`

`GTE_GTC` is the valid close-all TIF. It **also makes Binance auto-cancel the
sibling leg** when the position closes, which structurally prevents the `-4130`
duplicate-`closePosition` conflict. The existing #483
`_reconcile_4130_against_truth` guard continues to absorb any residual `-4130`
as already-protected (no retry storm).

`python-binance`'s enums do not expose `GTE_GTC`; a module-level
`TIME_IN_FORCE_GTE_GTC` constant is added. Params dicts annotated
`dict[str, Any]` for `mypy --strict`.

## Acceptance criteria

- [x] Remediator-armed SL/TP send a valid TIF (`GTE_GTC`) — no more -4509.
- [x] `GTE_GTC` auto-cancels the sibling leg → no duplicate `closePosition` (-4130);
      existing #483 reconcile guard remains as backstop.
- [x] No duplicate `closePosition` submissions / retry storms.
- [ ] Live testnet: previously-naked positions show protective SL/TP in
      `/fapi/v1/openOrders` (verified post-deploy).

## Tests

`TestIssue543GteGtcTimeInForce` (5 cases) asserts every `closePosition` builder
emits `timeInForce=GTE_GTC`, including when the source order carries a plain
`GTC` TIF. Full suite: **1926 passed, 12 skipped**, coverage 81%.

Closes #543
