### PR TITLE
fix: 551 - enforce market-side placeability for protective stops

### DIFF
--- a/scripts/e2e_wrong_side_sl_551.py
+++ b/scripts/e2e_wrong_side_sl_551.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Live futures-testnet E2E for tradeengine#551.
+
+Reproduces the wrong-side stop-loss immediate-trigger (-2021) failure and
+proves the fix: for a SHORT whose market has crossed ABOVE entry, the naive
+entry-derived / entry-floored stop sits BELOW markPrice and Binance rejects it
+with -2021 ("Order would immediately trigger"), leaving the position naked. The
+fix (`enforce_market_side_stop`) re-anchors the stop to the correct side of the
+LIVE market so the protective STOP_MARKET is accepted.
+
+Runs against Binance USDT-M futures TESTNET only. Requires env:
+  BINANCE_API_KEY, BINANCE_API_SECRET
+  BINANCE_FUTURES_URL (default https://testnet.binancefuture.com)
+
+Exit 0 = fix verified. Non-zero = failure (E2E gate must block PR).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from tradeengine.risk.sl_tp_direction import enforce_market_side_stop
+
+FUT = os.environ.get("BINANCE_FUTURES_URL", "https://testnet.binancefuture.com")
+KEY = os.environ["BINANCE_API_KEY"]
+SECRET = os.environ["BINANCE_API_SECRET"]
+SYMBOL = "XLMUSDT"
+FLOOR_PCT = 0.06  # matches te_min_sl_distance_pct default (6%)
+
+
+def _sign(params: dict) -> str:
+    q = urllib.parse.urlencode(params)
+    sig = hmac.new(SECRET.encode(), q.encode(), hashlib.sha256).hexdigest()
+    return f"{q}&signature={sig}"
+
+
+def _req(method: str, path: str, params: dict | None = None, signed: bool = False):
+    params = dict(params or {})
+    if signed:
+        params["timestamp"] = int(time.time() * 1000)
+        params["recvWindow"] = 5000
+        qs = _sign(params)
+    else:
+        qs = urllib.parse.urlencode(params)
+    url = f"{FUT}{path}?{qs}" if qs else f"{FUT}{path}"
+    req = urllib.request.Request(url, method=method)
+    req.add_header("X-MBX-APIKEY", KEY)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return r.status, json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode())
+
+
+def _tick_round(price: float) -> str:
+    # XLMUSDT futures tick size is 0.0001
+    return f"{round(price / 0.0001) * 0.0001:.4f}"
+
+
+def main() -> int:
+    assert "testnet" in FUT, f"refusing to run against non-testnet URL: {FUT}"
+
+    _, prem = _req("GET", "/fapi/v1/premiumIndex", {"symbol": SYMBOL})
+    mark = float(prem["markPrice"])
+    print(f"[live] {SYMBOL} markPrice={mark:.5f}")
+
+    # Resolve the live SHORT size so we can place a reduce-only protective
+    # STOP_MARKET on the standard order endpoint (the -2021 immediate-trigger
+    # path the engine hits for reduce-only legs). Fall back to a nominal qty.
+    _, prisk = _req("GET", "/fapi/v2/positionRisk", {"symbol": SYMBOL}, signed=True)
+    short_amt = 0.0
+    for p in prisk:
+        if p.get("positionSide") == "SHORT":
+            short_amt = abs(float(p.get("positionAmt") or 0.0))
+    qty = f"{short_amt:.0f}" if short_amt > 0 else "10"
+    print(f"[live] SHORT positionAmt={short_amt} -> reduce-only qty={qty}")
+
+    # Clean slate: cancel any pre-existing SHORT algo stops so the repro is not
+    # masked by -4130 ("order already existing"). Leaves the position naked,
+    # which is exactly the state #551 concerns.
+    _, existing = _req(
+        "GET", "/fapi/v1/openAlgoOrders", {"symbol": SYMBOL}, signed=True
+    )
+    erows = existing.get("orders", existing) if isinstance(existing, dict) else existing
+    for o in erows or []:
+        if o.get("positionSide") == "SHORT":
+            aid = o.get("algoId") or o.get("orderId")
+            _req(
+                "DELETE",
+                "/fapi/v1/algoOrder",
+                {"symbol": SYMBOL, "algoId": aid},
+                signed=True,
+            )
+            print(f"[setup] cancelled pre-existing SHORT algo order {aid}")
+
+    # --- Reproduce the bug: a SHORT stop BELOW market must be -2021 ---------
+    wrong_side_sl = _tick_round(mark * 0.98)  # 2% BELOW mark => immediate trigger
+
+    # Mirror the engine's exact CONDITIONAL algo params (binance.py
+    # _execute_stop_order): closePosition + GTE_GTC + triggerPrice + priceProtect.
+    def _algo_stop(trigger: str) -> tuple[int, dict]:
+        return _req(
+            "POST",
+            "/fapi/v1/algoOrder",
+            {
+                "symbol": SYMBOL,
+                "side": "BUY",
+                "type": "STOP_MARKET",
+                "algoType": "CONDITIONAL",
+                "timeInForce": "GTE_GTC",
+                "closePosition": "true",
+                "triggerPrice": trigger,
+                "workingType": "MARK_PRICE",
+                "priceProtect": "true",
+                "positionSide": "SHORT",
+            },
+            signed=True,
+        )
+
+    print(
+        f"[repro] placing WRONG-side SHORT STOP_MARKET triggerPrice={wrong_side_sl} "
+        f"(below mark {mark:.5f}) — expect APIError -2021"
+    )
+    code, resp = _algo_stop(wrong_side_sl)
+    if not (code >= 400 and resp.get("code") == -2021):
+        print(f"[repro] FAIL: expected -2021, got HTTP {code} {resp}")
+        # clean up if it unexpectedly placed
+        if code < 400 and resp.get("orderId"):
+            _req(
+                "DELETE",
+                "/fapi/v1/order",
+                {"symbol": SYMBOL, "orderId": resp["orderId"]},
+                signed=True,
+            )
+        return 1
+    print(
+        f"[repro] OK: Binance rejected wrong-side stop with {resp['code']} "
+        f"'{resp['msg']}' (naked-position trigger reproduced)"
+    )
+
+    # --- Apply the fix: enforce_market_side_stop re-anchors above market ----
+    decision = enforce_market_side_stop(
+        position_side="SHORT",
+        stop_price=float(wrong_side_sl),
+        market_price=mark,
+        min_distance_pct=FLOOR_PCT,
+    )
+    print(
+        f"[fix]  enforce_market_side_stop -> price={decision.price} "
+        f"reanchored={decision.was_reanchored} flatten={decision.should_flatten} "
+        f"reason={decision.reason!r}"
+    )
+    assert decision.was_reanchored and not decision.should_flatten
+    assert decision.price > mark, "re-anchored SHORT SL must be ABOVE mark"
+
+    fixed_sl = _tick_round(decision.price)
+    print(
+        f"[fix]  placing CORRECT-side SHORT STOP_MARKET triggerPrice={fixed_sl} "
+        f"(above mark {mark:.5f}) — expect acceptance"
+    )
+    code, resp = _algo_stop(fixed_sl)
+    if code >= 400:
+        print(f"[fix]  FAIL: re-anchored stop rejected HTTP {code} {resp}")
+        return 1
+    algo_id = resp.get("algoId") or resp.get("orderId")
+    print(
+        f"[fix]  OK: STOP_MARKET accepted algoId={algo_id} "
+        f"status={resp.get('algoStatus') or resp.get('status')}"
+    )
+
+    # --- Assert via openAlgoOrders that the protective leg is live & above mark
+    # (CONDITIONAL closePosition legs do NOT appear in /fapi/v1/openOrders — the
+    #  ticket calls for openAlgoOrders specifically). -----------------------
+    _, algo = _req("GET", "/fapi/v1/openAlgoOrders", {"symbol": SYMBOL}, signed=True)
+    rows = algo.get("orders", algo) if isinstance(algo, dict) else algo
+    protective = [
+        o
+        for o in rows
+        if o.get("orderType", o.get("type")) == "STOP_MARKET"
+        and o.get("positionSide") == "SHORT"
+    ]
+
+    def _trig(o: dict) -> float:
+        return float(o.get("triggerPrice") or o.get("stopPrice") or 0.0)
+
+    print(
+        f"[verify] live SHORT STOP_MARKET algo legs: "
+        f"{[(o.get('algoId', o.get('orderId')), _trig(o)) for o in protective]}"
+    )
+    assert any(_trig(o) > mark for o in protective), (
+        "no SHORT protective stop above mark — position would be naked"
+    )
+    print("[verify] OK: SHORT position protected by stop ABOVE mark (not naked)")
+
+    # --- Cleanup: cancel the test algo order (leave account as found) -------
+    _req(
+        "DELETE",
+        "/fapi/v1/algoOrder",
+        {"symbol": SYMBOL, "algoId": algo_id},
+        signed=True,
+    )
+    print(f"[cleanup] cancelled test algoId={algo_id}")
+
+    print(
+        "\nE2E #551 PASS: wrong-side stop rejected (-2021), "
+        "fix re-anchored above market and was accepted."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_market_side_stop_551.py
+++ b/tests/test_market_side_stop_551.py
@@ -1,0 +1,165 @@
+"""Tests for tradeengine#551 — wrong-side SL after market crosses entry.
+
+Root cause: ``correct_protective_price`` only guarantees a stop is on the
+correct side of ENTRY. Once the market crosses entry (position underwater), an
+entry-side-correct stop can sit on the WRONG side of the LIVE market and be
+rejected by Binance with ``APIError(-2021)`` "Order would immediately trigger",
+which cancels the surviving OCO leg and leaves the position NAKED.
+
+The live repro was XLMUSDT SHORT: entry≈0.1637, market rose to ≈0.171, requested
+SL=0.16500 (below market → immediate trigger). A SHORT stop must sit ABOVE
+market. These tests pin ``enforce_market_side_stop`` (the market-relative gate)
+and the mirror LONG case.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tradeengine.risk.sl_tp_direction import (
+    MarketSideDecision,
+    correct_protective_price,
+    enforce_market_side_stop,
+)
+
+# ---------------------------------------------------------------------------
+# AC1 — XLMUSDT SHORT live repro: SL below market must re-anchor ABOVE market.
+# ---------------------------------------------------------------------------
+
+
+class TestXLMUSDTShortRepro:
+    """Replay the exact 2026-08-20 XLMUSDT SHORT market-crossed-entry incident."""
+
+    def test_short_sl_below_market_gets_reanchored_above_market(self) -> None:
+        # entry-relative correction: SL 0.165 is ABOVE entry 0.1637 → correct
+        # side of entry, so correct_protective_price leaves it untouched.
+        entry_corr = correct_protective_price(
+            kind="SL",
+            position_side="SHORT",
+            requested_price=0.16500,
+            requested_pct=None,
+            reference_price=0.16370,
+            min_distance_pct=0.06,
+        )
+        assert entry_corr.was_corrected is False
+        assert entry_corr.price == pytest.approx(0.16500)
+
+        # market-relative gate: market has risen to 0.171, so SL 0.165 is BELOW
+        # market → would immediately trigger. Must re-anchor ABOVE market.
+        decision = enforce_market_side_stop(
+            position_side="SHORT",
+            stop_price=entry_corr.price,
+            market_price=0.17100,
+            min_distance_pct=0.06,
+        )
+        assert decision.was_reanchored is True
+        assert decision.should_flatten is False
+        assert decision.price > 0.17100, "SHORT SL must sit ABOVE live market"
+        assert decision.price == pytest.approx(0.17100 * (1 + 0.06))
+
+    def test_short_sl_already_above_market_passes_through(self) -> None:
+        decision = enforce_market_side_stop(
+            position_side="SHORT",
+            stop_price=0.18200,  # ~6.4% above market
+            market_price=0.17100,
+            min_distance_pct=0.06,
+        )
+        assert decision.was_reanchored is False
+        assert decision.should_flatten is False
+        assert decision.price == pytest.approx(0.18200)
+
+
+# ---------------------------------------------------------------------------
+# AC2 — mirror LONG case: SL above market must re-anchor BELOW market.
+# ---------------------------------------------------------------------------
+
+
+class TestLongMarketCrossed:
+    def test_long_sl_above_market_gets_reanchored_below_market(self) -> None:
+        # LONG entry 100, SL 98 is correct side of entry.
+        entry_corr = correct_protective_price(
+            kind="SL",
+            position_side="LONG",
+            requested_price=98.0,
+            requested_pct=None,
+            reference_price=100.0,
+            min_distance_pct=0.06,
+        )
+        assert entry_corr.was_corrected is False
+
+        # Market fell to 95 (LONG underwater). SL 98 is now ABOVE market →
+        # a stop-sell at 98 immediately triggers. Must re-anchor BELOW market.
+        decision = enforce_market_side_stop(
+            position_side="LONG",
+            stop_price=98.0,
+            market_price=95.0,
+            min_distance_pct=0.06,
+        )
+        assert decision.was_reanchored is True
+        assert decision.should_flatten is False
+        assert decision.price < 95.0, "LONG SL must sit BELOW live market"
+        assert decision.price == pytest.approx(95.0 * (1 - 0.06))
+
+    def test_long_sl_already_below_market_passes_through(self) -> None:
+        decision = enforce_market_side_stop(
+            position_side="LONG",
+            stop_price=88.0,  # ~7.4% below market
+            market_price=95.0,
+            min_distance_pct=0.06,
+        )
+        assert decision.was_reanchored is False
+        assert decision.price == pytest.approx(88.0)
+
+
+# ---------------------------------------------------------------------------
+# AC3 — no placeable stop → signal flatten (pathological floor >= cap).
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenEscalation:
+    def test_floor_at_or_above_max_band_signals_flatten(self) -> None:
+        decision = enforce_market_side_stop(
+            position_side="SHORT",
+            stop_price=0.16500,
+            market_price=0.17100,
+            min_distance_pct=0.20,  # equals default max placeable band
+            max_distance_pct=0.20,
+        )
+        assert decision.should_flatten is True
+        assert decision.was_reanchored is False
+
+    def test_inside_floor_band_reanchors_not_flatten_when_placeable(self) -> None:
+        # SHORT SL slightly above market but INSIDE the 6% floor band — must
+        # re-anchor out to the floor, not flatten (floor 6% << 20% cap).
+        decision = enforce_market_side_stop(
+            position_side="SHORT",
+            stop_price=0.17200,  # 0.58% above market — inside 6% floor
+            market_price=0.17100,
+            min_distance_pct=0.06,
+        )
+        assert decision.should_flatten is False
+        assert decision.was_reanchored is True
+        assert decision.price == pytest.approx(0.17100 * (1 + 0.06))
+
+
+class TestEdgeCases:
+    def test_zero_market_price_raises(self) -> None:
+        with pytest.raises(ValueError, match="market_price") as exc_info:
+            enforce_market_side_stop(
+                position_side="SHORT",
+                stop_price=0.165,
+                market_price=0.0,
+                min_distance_pct=0.06,
+            )
+        assert "market_price" in str(exc_info.value)
+
+    def test_decision_carries_original_price(self) -> None:
+        decision = enforce_market_side_stop(
+            position_side="SHORT",
+            stop_price=0.16500,
+            market_price=0.17100,
+            min_distance_pct=0.06,
+        )
+        assert isinstance(decision, MarketSideDecision)
+        assert decision.original_price == pytest.approx(0.16500)
+        assert "#551" in decision.reason

--- a/tests/test_position_coverage_guarantee.py
+++ b/tests/test_position_coverage_guarantee.py
@@ -1,0 +1,459 @@
+"""Extensive end-to-end proof of the no-naked-position guarantee.
+
+Requested by PM/dev review: "confirm that every position gets covered,
+even with close SL/TP". This test drives the REAL production components
+end to end and asserts the closed-loop invariant:
+
+    After a reconcile+remediate cycle, EVERY open Binance position is
+    either (a) hedged with reduceOnly SL+TP or (b) flattened after the
+    grace window. No position is ever left permanently naked — not even
+    when the strategy asks for a stop/target so tight the exchange
+    PERCENT_PRICE filter would reject it.
+
+Components under test (real, not mocked):
+    - tradeengine.position_reconciler.detect_unhedged_positions  (detection)
+    - tradeengine.naked_position_remediator.NakedPositionRemediator (arm/flatten)
+    - tradeengine.naked_position_remediator._derive_protective_prices
+      (safety-floor widening of too-tight stops)
+    - tradeengine.exchange.binance.validate_and_adjust_price_for_percent_filter
+      (real PERCENT_PRICE clamp — the exchange gate a naked SL would hit)
+
+The only fakes are the network boundary: a FakeExchange whose ``execute``
+runs the real price adjuster and mimics Binance's rejection of an
+out-of-filter reduceOnly stop, and a book of open orders that reflects
+what actually got placed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tradeengine.exchange.binance import BinanceFuturesExchange
+from tradeengine.naked_position_remediator import NakedPositionRemediator
+from tradeengine.position_reconciler import detect_unhedged_positions
+
+# ---------------------------------------------------------------------------
+# Fake exchange boundary — enforces the REAL PERCENT_PRICE filter
+# ---------------------------------------------------------------------------
+
+# Binance USDT-M futures PERCENT_PRICE cap used in the incident (#541): ±5%.
+FILTER_UP = 1.05
+FILTER_DOWN = 0.95
+SAFETY_FLOOR_PCT = 6.0  # te_min_sl_distance_pct default
+
+
+class FakeExchange:
+    """Network-boundary stand-in that behaves like Binance Futures.
+
+    ``execute`` runs the REAL price adjuster against the position's mark
+    price. If the adjuster refuses (returns None), the leg is rejected —
+    exactly as Binance rejects an out-of-filter reduceOnly stop with
+    -4131/-2021 — and the order is NOT booked, so the position stays
+    naked for that leg. If the adjuster clamps/accepts, the leg is booked
+    into ``open_orders`` and the position becomes hedged for that leg.
+    """
+
+    def __init__(self, mark_prices: dict[str, float]) -> None:
+        self._mark = mark_prices
+        # symbol -> list of open reduceOnly orders currently on the book
+        self.open_orders: dict[str, list[dict[str, Any]]] = {}
+        # Real adjuster bound to a live-ish exchange object with stubbed I/O.
+        self._adjuster_exc = BinanceFuturesExchange.__new__(BinanceFuturesExchange)
+        self._adjuster_exc.client = MagicMock()
+        self._adjuster_exc.testnet = True
+        self.rejected_legs: list[dict[str, Any]] = []
+
+    def _wire_adjuster(self, symbol: str) -> None:
+        market = self._mark[symbol]
+        self._adjuster_exc._get_current_price = AsyncMock(return_value=market)
+        self._adjuster_exc.get_percent_price_filter = MagicMock(
+            return_value={
+                "multiplierUp": str(FILTER_UP),
+                "multiplierDown": str(FILTER_DOWN),
+            }
+        )
+
+    async def execute(self, order: Any) -> dict[str, Any]:
+        symbol = order.symbol
+        self._wire_adjuster(symbol)
+        is_sl = order.type == "stop"
+        raw_price = order.stop_loss if is_sl else order.take_profit
+        order_type = "STOP_LOSS" if is_sl else "TAKE_PROFIT"
+
+        (
+            _adjusted,
+            final_price,
+            msg,
+        ) = await self._adjuster_exc.validate_and_adjust_price_for_percent_filter(
+            symbol=symbol,
+            price=float(raw_price),
+            order_type=order_type,
+            min_safe_distance_pct=SAFETY_FLOOR_PCT,
+        )
+
+        if final_price is None:
+            # Exchange rejects — leg NOT booked. Position stays naked here.
+            self.rejected_legs.append(
+                {"symbol": symbol, "type": order_type, "reason": msg}
+            )
+            raise RuntimeError(f"exchange rejected {order_type} for {symbol}: {msg}")
+
+        booked = {
+            "symbol": symbol,
+            "positionSide": order.position_side,
+            "type": "STOP_MARKET" if is_sl else "TAKE_PROFIT_MARKET",
+            "reduceOnly": True,
+            "closePosition": True,
+            "price": final_price,
+        }
+        self.open_orders.setdefault(symbol, []).append(booked)
+        return {"status": "FILLED", "price": final_price}
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, s: float) -> None:
+        self.t += s
+
+
+# ---------------------------------------------------------------------------
+# Scenario matrix: entry price x side x requested-SL/TP tightness
+# ---------------------------------------------------------------------------
+
+# Each scenario: (symbol, side, entry, mark, stored_sl, stored_tp)
+# stored_* = None means "no local record" -> fallback derivation kicks in.
+# Deliberately includes SLs FAR tighter than the 6% floor and 5% filter.
+_SCENARIOS = [
+    # LONG, extremely tight stored SL (0.5%) — must be widened, not rejected.
+    ("BTCUSDT", "LONG", 50000.0, 50000.0, 49750.0, 50250.0),
+    # SHORT, extremely tight stored SL (0.5%) above entry.
+    ("ETHUSDT", "SHORT", 3000.0, 3000.0, 3015.0, 2985.0),
+    # LONG, tight SL exactly at 2% (inside 6% floor) — widen to 6%.
+    ("SOLUSDT", "LONG", 150.0, 150.0, 147.0, 153.0),
+    # SHORT, tight SL at 2% above entry.
+    ("BNBUSDT", "SHORT", 600.0, 600.0, 612.0, 588.0),
+    # LONG, no stored record at all — fallback 2% SL, must widen to floor.
+    ("ADAUSDT", "LONG", 0.5, 0.5, None, None),
+    # SHORT, no stored record — fallback path.
+    ("XRPUSDT", "SHORT", 0.6, 0.6, None, None),
+    # LONG, SL already compliant (10% away) — must be left untouched & placed.
+    ("DOGEUSDT", "LONG", 0.1, 0.1, 0.09, 0.11),
+    # SHORT, compliant SL 10% away.
+    ("AVAXUSDT", "SHORT", 30.0, 30.0, 33.0, 27.0),
+    # LONG, mark drifted UP from entry (unrealized profit) + tight SL.
+    ("LTCUSDT", "LONG", 80.0, 84.0, 79.6, 82.0),
+    # SHORT, mark drifted DOWN + tight SL.
+    ("LINKUSDT", "SHORT", 15.0, 14.5, 15.05, 14.0),
+]
+
+
+def _binance_positions_from_scenarios(scenarios):
+    return {
+        (sym, side): {
+            "symbol": sym,
+            "positionSide": side,
+            "positionAmt": 1.0 if side == "LONG" else -1.0,
+            "entryPrice": entry,
+        }
+        for (sym, side, entry, _mark, _sl, _tp) in scenarios
+    }
+
+
+def _local_positions_from_scenarios(scenarios):
+    out: dict[tuple[str, str], dict[str, Any]] = {}
+    for sym, side, _entry, _mark, sl, tp in scenarios:
+        rec: dict[str, Any] = {"position_id": f"pos-{sym}"}
+        if sl is not None:
+            rec["stop_loss_price"] = sl
+        if tp is not None:
+            rec["take_profit_price"] = tp
+        out[(sym, side)] = rec
+    return out
+
+
+def _mark_prices(scenarios):
+    return {sym: mark for (sym, _s, _e, mark, _sl, _tp) in scenarios}
+
+
+def _make_remediator(mode, exchange, local_positions, clock):
+    pm = MagicMock()
+    pm.get_positions = MagicMock(return_value=local_positions)
+    close_cb = AsyncMock(return_value={"status": "success", "position_closed": True})
+    r = NakedPositionRemediator(
+        exchange=exchange,
+        position_manager=pm,
+        close_position=close_cb,
+        mode=mode,
+        flatten_grace_sec=60,
+        fallback_sl_pct=2.0,
+        fallback_tp_pct=4.0,
+        min_sl_distance_pct=SAFETY_FLOOR_PCT,
+        clock=clock,
+    )
+    return r, close_cb
+
+
+def _is_covered(symbol: str, side: str, open_orders) -> bool:
+    """Mirror the exchange truth: hedged iff reduceOnly STOP + TAKE_PROFIT."""
+    divs = detect_unhedged_positions(
+        {(symbol, side): {"symbol": symbol, "positionSide": side, "positionAmt": 1.0}},
+        open_orders,
+    )
+    return len(divs) == 0
+
+
+# ---------------------------------------------------------------------------
+# NEGATIVE CONTROL — proves the assertions above have teeth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_negative_control_both_protections_disabled_places_naked_tight_stop():
+    """Sanity: if BOTH protection layers are disabled — the remediator's
+    safety-floor widening (min_sl_distance_pct=0) AND the exchange's #541
+    PERCENT_PRICE clamp / safety floor (adjuster min_safe_distance_pct=0)
+    — a 0.5% stop is accepted AS-IS at 0.5% from market.
+
+    That is precisely the 2026-05-30 -2021 incident condition. This test
+    documents that the positive tests are not vacuous: with the guards
+    removed, dangerously tight stops DO get through. The two independent
+    layers exercised by the other tests are each load-bearing."""
+    market = 50000.0
+    exc = BinanceFuturesExchange.__new__(BinanceFuturesExchange)
+    exc.client = MagicMock()
+    exc.testnet = True
+    exc._get_current_price = AsyncMock(return_value=market)
+    exc.get_percent_price_filter = MagicMock(
+        return_value={
+            "multiplierUp": str(FILTER_UP),
+            "multiplierDown": str(FILTER_DOWN),
+        }
+    )
+
+    adjusted, price, _msg = await exc.validate_and_adjust_price_for_percent_filter(
+        symbol="BTCUSDT",
+        price=market * (1 - 0.005),  # 0.5% below market
+        order_type="STOP_LOSS",
+        min_safe_distance_pct=0.0,  # floor disabled
+    )
+    assert adjusted is False
+    assert price == pytest.approx(market * (1 - 0.005))
+    dist_pct = abs(price - market) / market * 100
+    assert dist_pct < 1.0, "with both guards off a sub-1% stop leaks through"
+
+
+# ---------------------------------------------------------------------------
+# THE GUARANTEE — arm_only widens every tight SL and covers every position
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arm_only_covers_every_position_even_with_tight_sl_tp():
+    """With arm_only, every naked position — regardless of how tight the
+    requested SL/TP — ends up hedged (reduceOnly SL + TP on the book).
+
+    This is the core no-naked-position proof: the safety-floor widening in
+    _derive_protective_prices plus the #541 PERCENT_PRICE clamp together
+    guarantee a placeable stop for every position."""
+    exchange = FakeExchange(_mark_prices(_SCENARIOS))
+    binance_positions = _binance_positions_from_scenarios(_SCENARIOS)
+    local = _local_positions_from_scenarios(_SCENARIOS)
+    clock = _Clock()
+    r, close_cb = _make_remediator("arm_only", exchange, local, clock)
+
+    # All positions start fully naked (no open orders on the book).
+    unhedged = detect_unhedged_positions(binance_positions, exchange.open_orders)
+    assert len(unhedged) == len(_SCENARIOS), "every position must start naked"
+
+    counts = await r.remediate(unhedged, binance_positions)
+
+    # Every position armed, nothing flattened (arm_only never flattens),
+    # nothing failed — the widening keeps every SL placeable.
+    assert counts["failed"] == 0, f"unexpected arm failures: {exchange.rejected_legs}"
+    assert counts["flattened"] == 0
+    assert counts["armed"] == len(_SCENARIOS)
+
+    # Closed-loop invariant: re-run detection against the resulting book.
+    still_naked = detect_unhedged_positions(binance_positions, exchange.open_orders)
+    assert still_naked == [], (
+        f"positions left naked after arm_only remediation: {still_naked}"
+    )
+
+    # And explicitly per-position for a readable failure.
+    for sym, side, *_rest in _SCENARIOS:
+        assert _is_covered(sym, side, exchange.open_orders), (
+            f"{sym}/{side} not covered after remediation"
+        )
+    close_cb.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_every_armed_sl_respects_safety_floor_or_filter_clamp():
+    """Every SL that lands on the book is either >= the 6% safety floor
+    OR clamped to the furthest placeable price inside the ±5% filter.
+
+    Proves the tight stop was WIDENED/CLAMPED, never placed naked-tight."""
+    exchange = FakeExchange(_mark_prices(_SCENARIOS))
+    binance_positions = _binance_positions_from_scenarios(_SCENARIOS)
+    local = _local_positions_from_scenarios(_SCENARIOS)
+    clock = _Clock()
+    r, _ = _make_remediator("arm_only", exchange, local, clock)
+
+    unhedged = detect_unhedged_positions(binance_positions, exchange.open_orders)
+    await r.remediate(unhedged, binance_positions)
+
+    for sym, booked in exchange.open_orders.items():
+        mark = exchange._mark[sym]
+        for o in booked:
+            if "STOP" not in o["type"]:
+                continue
+            dist_pct = abs(o["price"] - mark) / mark * 100.0
+            # Either it cleared the 6% floor, or it was clamped to just
+            # inside the ±5% filter (>= ~3.9% after the 1% margin). Never
+            # a routine-volatility-triggering sub-3% stop.
+            assert dist_pct >= 3.9, (
+                f"{sym} SL at {o['price']} is only {dist_pct:.2f}% from mark "
+                f"{mark} — too tight, floor/clamp failed"
+            )
+
+
+# ---------------------------------------------------------------------------
+# arm_or_flatten — if arming is genuinely impossible, flatten after grace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arm_or_flatten_flattens_when_arming_impossible():
+    """Fallback guarantee: if a leg can NEVER be placed (exchange always
+    rejects), arm_or_flatten flattens the position after the grace window
+    so it still never stays naked."""
+    scenario = [("BTCUSDT", "LONG", 50000.0, 50000.0, 49750.0, 50250.0)]
+    exchange = FakeExchange(_mark_prices(scenario))
+
+    # Force every leg to be rejected: adjuster returns None regardless.
+    async def _always_reject(order):
+        exchange.rejected_legs.append({"symbol": order.symbol})
+        raise RuntimeError("simulated permanent exchange rejection")
+
+    exchange.execute = _always_reject  # type: ignore[assignment]
+
+    binance_positions = _binance_positions_from_scenarios(scenario)
+    local = _local_positions_from_scenarios(scenario)
+    clock = _Clock()
+    r, close_cb = _make_remediator("arm_or_flatten", exchange, local, clock)
+
+    unhedged = detect_unhedged_positions(binance_positions, exchange.open_orders)
+
+    # Pass 1: first-seen recorded, arm attempted, arm fails (still naked).
+    c1 = await r.remediate(unhedged, binance_positions)
+    assert c1["armed"] == 0
+    assert c1["flattened"] == 0
+    assert c1["failed"] == 1
+    close_cb.assert_not_called()
+
+    # Advance past grace -> pass 2 escalates to flatten.
+    clock.advance(61)
+    c2 = await r.remediate(unhedged, binance_positions)
+    assert c2["flattened"] == 1
+    close_cb.assert_awaited_once()
+    assert close_cb.await_args.kwargs["reason"] == "naked_position_grace_expired"
+
+
+@pytest.mark.asyncio
+async def test_partially_hedged_positions_get_missing_leg_only():
+    """A position missing ONLY the SL (TP already on book) gets its SL
+    armed and becomes fully covered — the other leg is not disturbed."""
+    scenario = [("ETHUSDT", "LONG", 3000.0, 3000.0, 2985.0, 3120.0)]
+    exchange = FakeExchange(_mark_prices(scenario))
+    # Pre-seed a TP already on the book.
+    exchange.open_orders["ETHUSDT"] = [
+        {
+            "symbol": "ETHUSDT",
+            "positionSide": "LONG",
+            "type": "TAKE_PROFIT_MARKET",
+            "reduceOnly": True,
+            "closePosition": True,
+            "price": 3120.0,
+        }
+    ]
+    binance_positions = _binance_positions_from_scenarios(scenario)
+    local = _local_positions_from_scenarios(scenario)
+    clock = _Clock()
+    r, _ = _make_remediator("arm_only", exchange, local, clock)
+
+    unhedged = detect_unhedged_positions(binance_positions, exchange.open_orders)
+    assert len(unhedged) == 1
+    assert unhedged[0]["tp_present"] is True
+    assert unhedged[0]["sl_present"] is False
+
+    await r.remediate(unhedged, binance_positions)
+
+    # Now fully covered; exactly one SL added, TP untouched.
+    assert _is_covered("ETHUSDT", "LONG", exchange.open_orders)
+    sl_orders = [o for o in exchange.open_orders["ETHUSDT"] if "STOP" in o["type"]]
+    tp_orders = [
+        o for o in exchange.open_orders["ETHUSDT"] if "TAKE_PROFIT" in o["type"]
+    ]
+    assert len(sl_orders) == 1
+    assert len(tp_orders) == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_no_naked_across_repeated_cycles():
+    """Running the full cycle repeatedly never regresses a covered
+    position back to naked and never double-flattens."""
+    exchange = FakeExchange(_mark_prices(_SCENARIOS))
+    binance_positions = _binance_positions_from_scenarios(_SCENARIOS)
+    local = _local_positions_from_scenarios(_SCENARIOS)
+    clock = _Clock()
+    r, close_cb = _make_remediator("arm_or_flatten", exchange, local, clock)
+
+    for cycle in range(4):
+        clock.advance(5)
+        unhedged = detect_unhedged_positions(binance_positions, exchange.open_orders)
+        await r.remediate(unhedged, binance_positions)
+        # After the first cycle everything should be covered and stay so.
+        residual = detect_unhedged_positions(binance_positions, exchange.open_orders)
+        assert residual == [], f"cycle {cycle}: positions went naked: {residual}"
+
+    # Never flattened a healthy position (all were armable well within grace).
+    close_cb.assert_not_called()
+
+
+@pytest.mark.parametrize("side", ["LONG", "SHORT"])
+@pytest.mark.parametrize("tight_pct", [0.1, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 5.9])
+@pytest.mark.asyncio
+async def test_every_tightness_below_floor_still_gets_covered(side, tight_pct):
+    """Sweep: for SLs from 0.1% up to just under the 6% floor, on both
+    sides, the position always ends up covered — never naked."""
+    entry = 1000.0
+    if side == "LONG":
+        sl = entry * (1 - tight_pct / 100.0)
+        tp = entry * (1 + tight_pct / 100.0)
+    else:
+        sl = entry * (1 + tight_pct / 100.0)
+        tp = entry * (1 - tight_pct / 100.0)
+    scenario = [("BTCUSDT", side, entry, entry, sl, tp)]
+    exchange = FakeExchange(_mark_prices(scenario))
+    binance_positions = _binance_positions_from_scenarios(scenario)
+    local = _local_positions_from_scenarios(scenario)
+    clock = _Clock()
+    r, _ = _make_remediator("arm_only", exchange, local, clock)
+
+    unhedged = detect_unhedged_positions(binance_positions, exchange.open_orders)
+    counts = await r.remediate(unhedged, binance_positions)
+
+    assert counts["failed"] == 0, (
+        f"{side} SL at {tight_pct}% failed to arm: {exchange.rejected_legs}"
+    )
+    assert _is_covered("BTCUSDT", side, exchange.open_orders), (
+        f"{side} position with {tight_pct}% SL left naked"
+    )

--- a/tests/unit/test_naked_position_remediator.py
+++ b/tests/unit/test_naked_position_remediator.py
@@ -320,7 +320,7 @@ async def test_resolved_key_drops_from_first_seen() -> None:
 
 def test_derive_uses_fallback_for_long_when_no_local_record() -> None:
     r, _, _, _, _ = _make_remediator(mode="arm_only")
-    sl, tp = r._derive_protective_prices(
+    sl, tp, _ = r._derive_protective_prices(
         "BTCUSDT", "LONG", _binance_positions(entry=100.0)
     )
     assert sl == pytest.approx(98.0)  # 100 * (1 - 2%)
@@ -329,7 +329,7 @@ def test_derive_uses_fallback_for_long_when_no_local_record() -> None:
 
 def test_derive_uses_fallback_for_short_when_no_local_record() -> None:
     r, _, _, _, _ = _make_remediator(mode="arm_only")
-    sl, tp = r._derive_protective_prices(
+    sl, tp, _ = r._derive_protective_prices(
         "BTCUSDT", "SHORT", _binance_positions("BTCUSDT", "SHORT", 100.0)
     )
     assert sl == pytest.approx(102.0)  # 100 * (1 + 2%)
@@ -338,7 +338,7 @@ def test_derive_uses_fallback_for_short_when_no_local_record() -> None:
 
 def test_derive_returns_none_for_missing_entry_price() -> None:
     r, _, _, _, _ = _make_remediator(mode="arm_only")
-    sl, tp = r._derive_protective_prices(
+    sl, tp, _ = r._derive_protective_prices(
         "BTCUSDT", "LONG", {("BTCUSDT", "LONG"): {"entryPrice": 0}}
     )
     assert sl is None and tp is None
@@ -361,7 +361,7 @@ def test_derive_widens_too_tight_stored_long_sl_to_floor() -> None:
     r._position_manager.get_positions = MagicMock(
         return_value={("BTCUSDT", "LONG"): {"stop_loss_price": 97.6}}
     )
-    sl, _ = r._derive_protective_prices("BTCUSDT", "LONG", positions)
+    sl, _, _ = r._derive_protective_prices("BTCUSDT", "LONG", positions)
     assert sl == pytest.approx(94.0)  # widened to floor, not left at 97.6
 
 
@@ -376,7 +376,7 @@ def test_derive_widens_too_tight_stored_short_sl_to_floor() -> None:
     r._position_manager.get_positions = MagicMock(
         return_value={("BTCUSDT", "SHORT"): {"stop_loss_price": 102.4}}
     )
-    sl, _ = r._derive_protective_prices("BTCUSDT", "SHORT", positions)
+    sl, _, _ = r._derive_protective_prices("BTCUSDT", "SHORT", positions)
     assert sl == pytest.approx(106.0)
 
 
@@ -387,7 +387,7 @@ def test_derive_leaves_compliant_stored_sl_untouched() -> None:
     r._position_manager.get_positions = MagicMock(
         return_value={("BTCUSDT", "LONG"): {"stop_loss_price": 90.0}}  # 10% away
     )
-    sl, _ = r._derive_protective_prices("BTCUSDT", "LONG", positions)
+    sl, _, _ = r._derive_protective_prices("BTCUSDT", "LONG", positions)
     assert sl == pytest.approx(90.0)
 
 
@@ -400,7 +400,7 @@ def test_derive_fallback_sl_clears_floor_when_configured() -> None:
     r, _, _, _, _ = _make_remediator(
         mode="arm_only", fallback_sl_pct=2.0, min_sl_distance_pct=6.0
     )
-    sl, _ = r._derive_protective_prices(
+    sl, _, _ = r._derive_protective_prices(
         "BTCUSDT", "LONG", _binance_positions("BTCUSDT", "LONG", 100.0)
     )
     assert sl == pytest.approx(94.0)
@@ -412,7 +412,7 @@ def test_derive_no_clamp_when_floor_disabled() -> None:
     r._position_manager.get_positions = MagicMock(
         return_value={("BTCUSDT", "LONG"): {"stop_loss_price": 99.0}}
     )
-    sl, _ = r._derive_protective_prices(
+    sl, _, _ = r._derive_protective_prices(
         "BTCUSDT", "LONG", _binance_positions("BTCUSDT", "LONG", 100.0)
     )
     assert sl == pytest.approx(99.0)  # left tight, not widened
@@ -435,8 +435,78 @@ async def test_empty_divergence_list_is_no_op_in_all_modes() -> None:
             "skipped": 0,
             "failed": 0,
         }
-        ex.execute.assert_not_called()
-        close_cb.assert_not_called()
+    ex.execute.assert_not_called()
+    close_cb.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #551 — market-crossed-entry SL must not re-arm a guaranteed -2021 price.
+# ---------------------------------------------------------------------------
+
+
+def _binance_positions_with_mark(
+    symbol: str, side: str, entry: float, mark: float
+) -> dict[tuple[str, str], dict[str, Any]]:
+    return {
+        (symbol, side): {
+            "symbol": symbol,
+            "positionSide": side,
+            "positionAmt": 1.0 if side == "LONG" else -1.0,
+            "entryPrice": entry,
+            "markPrice": mark,
+        }
+    }
+
+
+def test_derive_reanchors_short_sl_to_correct_side_of_market() -> None:
+    """XLMUSDT SHORT: entry 0.1637, mark risen to 0.171. Entry-floored SL
+    (0.1637*1.06=0.1735) is still BELOW mark → would immediately trigger.
+    Must re-anchor ABOVE mark (0.171*1.06)."""
+    r, _, _, _, _ = _make_remediator(mode="arm_only", min_sl_distance_pct=6.0)
+    positions = _binance_positions_with_mark("XLMUSDT", "SHORT", 0.16370, 0.17100)
+    sl, _tp, must_flatten = r._derive_protective_prices("XLMUSDT", "SHORT", positions)
+    assert must_flatten is False
+    assert sl is not None and sl > 0.17100, "SHORT SL must sit above live mark"
+    assert sl == pytest.approx(0.17100 * (1 + 0.06))
+
+
+def test_derive_signals_flatten_when_no_placeable_stop() -> None:
+    """Pathological floor >= max placeable band → no stop can avoid immediate
+    trigger; must_flatten is signalled instead of manufacturing a dead price."""
+    r, _, _, _, _ = _make_remediator(mode="arm_or_flatten", min_sl_distance_pct=20.0)
+    positions = _binance_positions_with_mark("XLMUSDT", "SHORT", 0.16370, 0.17100)
+    _sl, _tp, must_flatten = r._derive_protective_prices("XLMUSDT", "SHORT", positions)
+    assert must_flatten is True
+
+
+@pytest.mark.asyncio
+async def test_rearm_escalates_to_flatten_when_unplaceable_in_arm_or_flatten() -> None:
+    """When no placeable stop exists, arm_or_flatten flattens instead of
+    re-arming the identical -2021 price (the observed naked-forever loop)."""
+    r, ex, _, close_cb, _ = _make_remediator(
+        mode="arm_or_flatten", grace_sec=9999, min_sl_distance_pct=20.0
+    )
+    positions = _binance_positions_with_mark("XLMUSDT", "SHORT", 0.16370, 0.17100)
+    div = _unhedged_div("XLMUSDT", "SHORT", qty=100.0)
+    # grace not expired (9999s) — normally this is the arm path, but the
+    # unplaceable-stop escalation flattens regardless of grace.
+    counts = await r.remediate([div], positions)
+    close_cb.assert_awaited_once()
+    ex.execute.assert_not_called()  # never ships the guaranteed-dead SL
+    assert counts["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_rearm_does_not_retry_dead_price_in_arm_only() -> None:
+    """arm_only cannot flatten, but must still NOT re-arm a guaranteed -2021
+    price — it records a failure so operators see the stuck position."""
+    r, ex, _, close_cb, _ = _make_remediator(mode="arm_only", min_sl_distance_pct=20.0)
+    positions = _binance_positions_with_mark("XLMUSDT", "SHORT", 0.16370, 0.17100)
+    div = _unhedged_div("XLMUSDT", "SHORT", qty=100.0)
+    counts = await r.remediate([div], positions)
+    ex.execute.assert_not_called()
+    close_cb.assert_not_called()
+    assert counts["failed"] == 1
 
 
 @pytest.mark.asyncio

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -4267,6 +4267,74 @@ class Dispatcher:
                             f"{tp_corr.reason}"
                         )
                         order.take_profit = tp_corr.price
+
+                # MARKET-SIDE STOP VALIDATION (#551): correct_protective_price
+                # only guarantees the SL is on the correct side of ENTRY. Once
+                # the market crosses entry (position underwater), that same stop
+                # can sit on the WRONG side of the LIVE market → Binance -2021
+                # "immediately trigger" → OCO cancels the surviving leg →
+                # position left NAKED (XLMUSDT SHORT 2026-08-20). Re-anchor the
+                # SL to the correct side of live market, or flatten if no stop
+                # can be placed without immediate trigger.
+                if order.stop_loss and order.stop_loss > 0:
+                    from tradeengine.risk.sl_tp_direction import (
+                        enforce_market_side_stop,
+                    )
+
+                    market_price = 0.0
+                    try:
+                        market_price = float(
+                            await self.exchange._get_current_price(order.symbol)
+                        )
+                    except Exception as mkt_err:
+                        self.logger.warning(
+                            f"⚠️ #551: could not resolve live market for "
+                            f"{order.symbol} market-side SL check: {mkt_err}"
+                        )
+
+                    if market_price > 0:
+                        mkt_decision = enforce_market_side_stop(
+                            position_side=position_side_for_check,  # type: ignore[arg-type]
+                            stop_price=float(order.stop_loss),
+                            market_price=market_price,
+                            min_distance_pct=sl_safety_floor_pct,
+                        )
+                        if mkt_decision.should_flatten:
+                            self.logger.error(
+                                f"🛑 #551 FLATTEN ESCALATION ({position_side_for_check}): "
+                                f"{mkt_decision.reason}. Flattening reduce-only "
+                                f"MARKET instead of shipping a guaranteed -2021 SL."
+                            )
+                            try:
+                                flat_qty = float(
+                                    result.get("amount") or order.amount or 0.0
+                                )
+                            except (TypeError, ValueError):
+                                flat_qty = float(order.amount or 0.0)
+                            if flat_qty > 0:
+                                await self.close_position_with_cleanup(
+                                    position_id=order.position_id or "",
+                                    symbol=order.symbol,
+                                    position_side=order.position_side or "",
+                                    quantity=flat_qty,
+                                    reason="sl_unplaceable_market_crossed_551",
+                                )
+                            else:
+                                self.logger.error(
+                                    f"🛑 #551: cannot flatten {order.symbol} — "
+                                    f"no resolvable quantity (result.amount="
+                                    f"{result.get('amount')}, order.amount="
+                                    f"{order.amount}). Position may be naked."
+                                )
+                            # Do NOT proceed to OCO placement with an
+                            # unplaceable stop.
+                            return
+                        if mkt_decision.was_reanchored:
+                            self.logger.warning(
+                                f"⚠️ SL MARKET-SIDE RE-ANCHOR "
+                                f"({position_side_for_check}): {mkt_decision.reason}"
+                            )
+                            order.stop_loss = mkt_decision.price
             else:
                 self.logger.warning(
                     f"⚠️ Skipping SL/TP direction check for {order.symbol}: "

--- a/tradeengine/naked_position_remediator.py
+++ b/tradeengine/naked_position_remediator.py
@@ -254,9 +254,38 @@ class NakedPositionRemediator:
             ).inc()
             return False
 
-        sl_price, tp_price = self._derive_protective_prices(
+        sl_price, tp_price, must_flatten = self._derive_protective_prices(
             symbol, side, binance_positions
         )
+
+        # #551: no placeable stop exists (market crossed entry such that any SL
+        # would immediately trigger). Retrying the same dead price forever is
+        # exactly the observed naked-forever loop — escalate to a reduce-only
+        # MARKET flatten instead, regardless of the grace window, when the mode
+        # permits flattening. In arm_only mode we cannot flatten, so record a
+        # failure so operators see the position is stuck.
+        if must_flatten:
+            if self._mode == "arm_or_flatten":
+                logger.error(
+                    "NakedPositionRemediator: %s/%s has no placeable SL vs live "
+                    "market — escalating to flatten instead of re-arming a "
+                    "guaranteed -2021 price (#551)",
+                    symbol,
+                    side,
+                )
+                return await self._flatten(div, binance_positions)
+            logger.error(
+                "NakedPositionRemediator: %s/%s has no placeable SL vs live "
+                "market but mode=%s cannot flatten — leaving for grace-window "
+                "flatten; NOT re-arming a guaranteed -2021 price (#551)",
+                symbol,
+                side,
+                self._mode,
+            )
+            naked_position_rearmed_total.labels(
+                symbol=symbol, side=side, outcome="failed"
+            ).inc()
+            return False
 
         sl_missing = not div.get("sl_present")
         tp_missing = not div.get("tp_present")
@@ -397,9 +426,9 @@ class NakedPositionRemediator:
         symbol: str,
         side: str,
         binance_positions: dict[tuple[str, str], dict[str, Any]] | None,
-    ) -> tuple[float | None, float | None]:
-        """Return (sl_price, tp_price) using local-strategy values when
-        present, else fall back to ``entryPrice ± fallback_pct``.
+    ) -> tuple[float | None, float | None, bool]:
+        """Return ``(sl_price, tp_price, must_flatten)`` using local-strategy
+        values when present, else fall back to ``entryPrice ± fallback_pct``.
 
         Local strategy values are preferred so re-arm matches strategy
         intent. Fallback exists because the whole point of #445 is that
@@ -412,9 +441,19 @@ class NakedPositionRemediator:
         degrading arm_or_flatten to flatten-everything. When we know the
         entry price, any SL inside the floor band is WIDENED out to the
         floor so the re-arm can actually place. TP is not floor-constrained.
+
+        Market-crossed-entry fix (#551): the entry-anchored SL floor above
+        only guarantees the stop is correct-side of ENTRY. If the market has
+        crossed entry (position underwater), an entry-side-correct SL can sit
+        on the wrong side of the LIVE ``markPrice`` and immediately trigger
+        (-2021) — the re-arm then retries the identical dead price forever.
+        We re-anchor the SL to the correct side of ``markPrice``; when no stop
+        is placeable without immediate trigger the third return value
+        ``must_flatten`` is True so the caller escalates instead of looping.
         """
         sl_price: float | None = None
         tp_price: float | None = None
+        must_flatten = False
 
         try:
             local = self._position_manager.get_positions().get((symbol, side))
@@ -449,7 +488,7 @@ class NakedPositionRemediator:
         # Without an entry price we cannot compute the floor band or the
         # fallback — return whatever local values we have (legacy behaviour).
         if entry_price is None or entry_price <= 0:
-            return sl_price, tp_price
+            return sl_price, tp_price, must_flatten
 
         # Fill missing legs from the entry-anchored fallback.
         if sl_price is None:
@@ -497,7 +536,53 @@ class NakedPositionRemediator:
                     )
                     sl_price = floor_price
 
-        return sl_price, tp_price
+        # Market-crossed-entry gate (#551): the entry-anchored floor above does
+        # not know where the LIVE market is. If the market has crossed entry,
+        # an entry-side-correct SL can be wrong-side of markPrice and trigger
+        # immediately (-2021). Re-anchor to the correct side of markPrice; if no
+        # placeable stop exists, signal a flatten so the caller stops retrying
+        # the identical dead price.
+        mark_price: float | None = None
+        if binance_positions:
+            bp = binance_positions.get((symbol, side))
+            if bp:
+                try:
+                    mark_price = float(bp.get("markPrice") or 0.0) or None
+                except (TypeError, ValueError):
+                    mark_price = None
+
+        if sl_price is not None and mark_price and mark_price > 0:
+            from tradeengine.risk.sl_tp_direction import enforce_market_side_stop
+
+            decision = enforce_market_side_stop(
+                position_side=side,  # type: ignore[arg-type]
+                stop_price=float(sl_price),
+                market_price=mark_price,
+                min_distance_pct=self._min_sl_distance_pct / 100.0,
+            )
+            if decision.should_flatten:
+                logger.error(
+                    "NakedPositionRemediator: %s/%s SL unplaceable vs live "
+                    "market %s — %s; signalling flatten (#551)",
+                    symbol,
+                    side,
+                    mark_price,
+                    decision.reason,
+                )
+                must_flatten = True
+            elif decision.was_reanchored:
+                logger.warning(
+                    "NakedPositionRemediator: re-anchoring %s/%s SL from %s to "
+                    "%s (correct side of live market %s) (#551)",
+                    symbol,
+                    side,
+                    sl_price,
+                    decision.price,
+                    mark_price,
+                )
+                sl_price = decision.price
+
+        return sl_price, tp_price, must_flatten
 
     def _resolve_position_id(self, symbol: str, side: str) -> str:
         """Best-effort: use the local position's id if known, otherwise

--- a/tradeengine/risk/sl_tp_direction.py
+++ b/tradeengine/risk/sl_tp_direction.py
@@ -245,3 +245,143 @@ def correct_protective_price(
         reason=reason,
         original_price=requested_price,
     )
+
+
+@dataclass(frozen=True)
+class MarketSideDecision:
+    """Outcome of validating a stop-loss against the LIVE market price (#551).
+
+    ``correct_protective_price`` guarantees a stop is on the correct side of the
+    ENTRY price. That is necessary but not sufficient: once the market crosses
+    the entry (position underwater), an entry-side-correct stop can sit on the
+    WRONG side of the *current* market — Binance then rejects it with
+    ``APIError(-2021)`` "Order would immediately trigger", the OCO cancels the
+    surviving leg, and the position is left NAKED (XLMUSDT SHORT 2026-08-20).
+
+    A stop must trigger AWAY from the current market in the closing direction:
+      * SHORT SL is a stop-BUY → it must sit ABOVE market.
+      * LONG  SL is a stop-SELL → it must sit BELOW market.
+
+    Attributes:
+        price: The stop price to submit — re-anchored to the correct side of
+            market when the input was market-wrong-side; unchanged otherwise.
+            Meaningless when ``should_flatten`` is True.
+        was_reanchored: True when the input stop was on the wrong side of market
+            (or inside the market-relative safety floor) and got moved out to
+            ``market * (1 ± floor)`` on the correct side.
+        should_flatten: True when no stop can be placed without immediate trigger
+            — the caller must escalate to a reduce-only MARKET flatten instead of
+            shipping a guaranteed -2021 price (or retrying it forever).
+        reason: Short human-readable explanation; "" when no action was needed.
+        original_price: The input stop price prior to any re-anchor.
+    """
+
+    price: float
+    was_reanchored: bool
+    should_flatten: bool
+    reason: str
+    original_price: float
+
+
+def enforce_market_side_stop(
+    *,
+    position_side: PositionSide,
+    stop_price: float,
+    market_price: float,
+    min_distance_pct: float,
+    max_distance_pct: float = MAX_PLAUSIBLE_DISTANCE_PCT,
+) -> MarketSideDecision:
+    """Validate/re-anchor a stop-loss against the LIVE market price (#551).
+
+    This is the market-relative gate that complements the entry-relative
+    ``correct_protective_price``. It catches the market-crossed-entry case where
+    an entry-side-correct stop would immediately trigger against the current
+    market and leave the position naked.
+
+    Invariant enforced (stop must trigger away from market in the close
+    direction):
+      * SHORT SL must be strictly ABOVE ``market * (1 + min_distance_pct)``.
+      * LONG  SL must be strictly BELOW ``market * (1 - min_distance_pct)``.
+
+    Args:
+        position_side: "LONG" or "SHORT".
+        stop_price: The (already entry-direction-corrected) stop price.
+        market_price: Current mark/last price. MUST be > 0 — callers resolve it.
+        min_distance_pct: Minimum |distance| from market (fraction, e.g. 0.06).
+            A stop closer than this to market — or on the wrong side — is
+            re-anchored out to the floor on the correct side.
+        max_distance_pct: If the re-anchored floor stop would still exceed the
+            widest placeable band (PERCENT_PRICE cap ~ this value), no stop can
+            be placed; signal a flatten instead. Defaults to
+            ``MAX_PLAUSIBLE_DISTANCE_PCT``. Since the floor is normally well
+            inside this cap, ``should_flatten`` only fires when the caller has
+            passed a floor >= the cap (pathological config) — the realistic
+            flatten trigger is the caller acting on a subsequent PERCENT_PRICE
+            rejection of the re-anchored price.
+
+    Returns:
+        MarketSideDecision describing the outcome.
+
+    Raises:
+        ValueError: If ``market_price`` is not strictly positive.
+    """
+    if market_price <= 0:
+        raise ValueError(
+            "market_price must be > 0 — callers must resolve a live market price"
+        )
+
+    # +1 => stop must be ABOVE market (SHORT), -1 => BELOW market (LONG).
+    sign = +1 if position_side == "SHORT" else -1
+    floor_edge = market_price * (1 + sign * min_distance_pct)
+
+    # On the correct side AND at/beyond the market-relative floor → leave alone.
+    beyond_floor = (sign > 0 and stop_price >= floor_edge) or (
+        sign < 0 and stop_price <= floor_edge
+    )
+    if beyond_floor:
+        return MarketSideDecision(
+            price=stop_price,
+            was_reanchored=False,
+            should_flatten=False,
+            reason="",
+            original_price=stop_price,
+        )
+
+    # Wrong side of market, or inside the market-relative floor band: the stop
+    # would immediately trigger (-2021). Re-anchor to the safety floor on the
+    # correct side of the LIVE market.
+    reanchored = floor_edge
+
+    # If even the floor stop exceeds the widest placeable band, no stop can be
+    # placed without immediate trigger — escalate to flatten (#551 AC3).
+    if min_distance_pct >= max_distance_pct:
+        reason = (
+            f"{position_side} SL {stop_price:.6f} is wrong-side/inside floor of "
+            f"live market {market_price:.6f}; required floor "
+            f"{min_distance_pct * 100:.2f}% >= max placeable "
+            f"{max_distance_pct * 100:.2f}% — cannot place any stop without "
+            f"immediate trigger; FLATTEN required (#551)"
+        )
+        logger.error("⚠️ market-side stop unplaceable (#551): %s", reason)
+        return MarketSideDecision(
+            price=stop_price,
+            was_reanchored=False,
+            should_flatten=True,
+            reason=reason,
+            original_price=stop_price,
+        )
+
+    reason = (
+        f"{position_side} SL {stop_price:.6f} would immediately trigger against "
+        f"live market {market_price:.6f} (market crossed entry); RE-ANCHORED to "
+        f"correct side of market at {reanchored:.6f} "
+        f"({sign * min_distance_pct * 100:+.2f}% from market) (#551)"
+    )
+    logger.warning("⚠️ market-side SL re-anchor (#551): %s", reason)
+    return MarketSideDecision(
+        price=reanchored,
+        was_reanchored=True,
+        should_flatten=False,
+        reason=reason,
+        original_price=stop_price,
+    )


### PR DESCRIPTION
## Summary

Fixes the wrong-side stop-loss that left positions **NAKED** (#551, P0).

When the market crossed the entry-derived stop (position underwater), SL
derivation + the #541 PERCENT_PRICE clamp produced a stop on the **wrong side
of the live market**. Binance rejected it with `-2021` ("Order would
immediately trigger"), the OCO cancelled the surviving TP leg, and the naked
remediator retried the identical dead price forever.

**Root cause:** both the dispatcher/OCO path and the naked-position remediator
validated stop side against **entry price only**, never against the live
market. An entry-side-correct SL can still be wrong-side of the current market.

## Changes

- **`tradeengine/risk/sl_tp_direction.py`** — new pure guard
  `enforce_market_side_stop(...)`: SHORT SL must be `>= market*(1+floor)`, LONG
  SL `<= market*(1-floor)`. Re-anchors a wrong-side / too-tight stop to the
  correct side of the live market; signals **flatten** when no placeable stop
  exists (floor >= max plausible distance). Returns a `MarketSideDecision`.
- **`tradeengine/dispatcher.py`** — `_place_risk_management_orders` gates the SL
  against the live market after entry-relative correction: re-anchor, or
  escalate to a reduce-only MARKET flatten (`close_position_with_cleanup`,
  reason `sl_unplaceable_market_crossed_551`) when unplaceable — before OCO.
- **`tradeengine/naked_position_remediator.py`** — `_derive_protective_prices`
  anchors SL to the correct side of `markPrice` (not just `entryPrice`);
  `_rearm` escalates to flatten in `arm_or_flatten` mode instead of retrying a
  guaranteed `-2021` price, and records a failure (no retry loop) in `arm_only`.

## Tests

- `tests/test_market_side_stop_551.py` — XLMUSDT SHORT entry 0.1637 / mark 0.171
  / requested SL 0.165 asserts placed SL > market; mirror LONG; flatten
  escalation; edge cases.
- `tests/unit/test_naked_position_remediator.py` — market re-anchor, flatten
  escalation, no-retry-of-dead-price.
- `tests/test_position_coverage_guarantee.py` — SL-coverage regression guard.
- Full gated suite: **1737 passed, 10 skipped, coverage 74.87%** (gate 40).

## Live E2E (MANDATORY — futures testnet)

`scripts/e2e_wrong_side_sl_551.py`, `SIMULATION_ENABLED=false`, engine-identical
CONDITIONAL algo params. XLMUSDT SHORT (underwater), mark 0.17213:

1. Wrong-side SHORT `STOP_MARKET` triggerPrice **0.1687** (below mark)
   → Binance **`-2021`** "Order would immediately trigger" — **bug reproduced**.
2. `enforce_market_side_stop` re-anchored to **0.1825** (+6% above mark).
3. Re-anchored stop **ACCEPTED** (`algoId 1000000173709342`, status NEW).
4. Verified via `GET /fapi/v1/openAlgoOrders`: SHORT `STOP_MARKET` leg
   triggerPrice **0.1825 > mark** → position **not naked**.
5. Cleaned up. Exit 0.

Closes #551
