### PR TITLE
docs: decide mirror-vs-always-consult for position state truth (#549)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,7 @@
 - [**BUSINESS_METRICS.md**](BUSINESS_METRICS.md) - Trading execution metrics and monitoring.
 - [**ALERTING_SETUP.md**](ALERTING_SETUP.md) - Configuration for trading alerts.
 - [**HEDGE_MODE_POSITION_TRACKING.md**](HEDGE_MODE_POSITION_TRACKING.md) - Managing positions in hedge mode.
+- [**POSITION_STATE_TRUTH_DECISION.md**](POSITION_STATE_TRUTH_DECISION.md) - Mirror vs always-consult decision for position/order truth (#549; root cause of -4130/-4509).
 
 ## 📜 Historical
 - [**Archive Folder**](archive/) - Outdated or issue-specific documentation.

--- a/docs/POSITION_STATE_TRUTH_DECISION.md
+++ b/docs/POSITION_STATE_TRUTH_DECISION.md
@@ -1,0 +1,155 @@
+# Position/Order State Truth — Mirror vs Always-Consult Decision
+
+**Last Updated**: August 20, 2026
+**Service Status**: ✅ ACTIVE (Production)
+**Issue**: [#549](https://github.com/PetroSa2/petrosa-tradeengine/issues/549) — INVESTIGATION (P1)
+**Root cause of**: `-4130` / `-4509` arm failures; malformed `source:"exchange"` quantities
+
+---
+
+## Summary
+
+The trade engine keeps **three independent in-memory stores** of position/order state that
+can silently diverge from Binance truth.
+The SL/TP arming hot path reads local/result state, never live exchange qty.
+That drift is the root cause of the live `-4509` (arming a position Binance no longer holds)
+and `-4130` (arming legs that already exist) failures observed on 2026-08-20.
+
+**Decision: Option A — corrected mirror.**
+Keep `ExchangeTruthStore` as the single read model; close the four wiring gaps that make it
+untrustworthy today.
+Option B (always consult Binance) is rejected as the primary path because it adds a live REST
+dependency to the per-order hot arming path — which today makes **zero** live calls — with **no
+existing TTL cache or rate-limit gate** to build on.
+
+---
+
+## Evidence (live, futures testnet — pod `v1.2.17-r176-50367b3`)
+
+- Arming loop detected 11 unhedged positions, computed correct clamped SLs, yet placement failed:
+  - `APIError(-4509): Time in Force (TIF) GTE can only be used with open positions.`
+  - `APIError(-4130): An open stop or take profit order with GTE and closePosition ... existing.`
+- `GET /positions` returned `LTCUSDT LONG qty=-0.303` stamped `source:"exchange"` — a malformed
+  signed value that never came from a live REST call.
+
+---
+
+## Root cause (code-level)
+
+### Three local stores, none guaranteed fresh vs REST
+
+| Store | Location | Feed | Drift mechanism |
+|-------|----------|------|-----------------|
+| `PositionManager.positions` dict | `position_manager.py:56` | `update_position()` mutates memory first | DM sync has a **swallowed 2s timeout** (`position_manager.py:523-536`); memory advances even when the DB write is dropped |
+| `ExchangeTruthStore` snapshot | `exchange_truth_store.py:94-109` | user-data WS + REST seed on connect only | keeps **raw signed** `positionAmt` (`:142,204,245`) — a bad WS event surfaces `-0.303` for a LONG |
+| `OCOManager.active_oco_pairs` | `dispatcher.py:106-108` | in-memory dedup dict | **resets on restart**; rebuilt from exchange at boot (`dispatcher.py:1976`) but empty in the crash→boot window |
+
+### The four specific gaps that make the mirror lie
+
+1. **REST write-back is wired but dead.** `PositionReconciler` is constructed at `api.py:266`
+   **without** `store=`; constructor default is `store=None` (`position_reconciler.py:250`), so the
+   60s `update_from_rest` authority-refresh (`position_reconciler.py:335-353`) never runs in
+   production. (The strategy reconciler at `dispatcher.py:2005-2007` *does* pass the store — proof
+   the plumbing works when wired.)
+2. **No sign normalization.** `quantity=qty` stores the raw signed `positionAmt` in every path
+   (WS `:142,151`; seed `:204,209`; reconcile `:245,251`). A LONG can hold a negative quantity.
+3. **`source` label is a global config flag, not provenance.** `api.py:1502-1508` sets
+   `"source": "exchange" if TE_EXCHANGE_TRUTH_STORE_ENABLED == "on" else "local"`. No per-record
+   origin, timestamp, or staleness.
+4. **Live arming gate is off by default.** The only entry-arming code that consults live
+   positionRisk is the AC3 gate (`dispatcher.py:189-218`), gated by `TE_OCO_AC3_GATE_ENABLED=0`
+   (default off). The primary arming path takes qty from the order result
+   (`dispatcher.py:4357` `filled_quantity = result.get("amount")`), never from the exchange.
+
+### Arming path summary
+
+- **Entry-time arming** `_place_risk_management_orders()` (`dispatcher.py:4052+`): qty from
+  `result.amount` / `order.amount`, side from local `order.position_side`. **No live read.** →
+  `-4130` on stale/oversized qty, `-4509` when the position no longer exists.
+- **AC3 gate** (`dispatcher.py:189-218`): live positionRisk **presence** check, off by default;
+  gates presence only, does not override the qty.
+- **Remediator** `_rearm()` (`naked_position_remediator.py:236-364`): exchange-authoritative
+  (`div["binance_qty"]`, `div["side"]`), but off by default and runs only on the 60s reconciler
+  cadence.
+
+---
+
+## Options considered
+
+### Option A — corrected mirror (CHOSEN)
+
+Keep `ExchangeTruthStore` as the single read model; make it trustworthy:
+
+- (a) Wire FR65 reconciler with `store=` at `api.py:266` so REST periodically corrects the store.
+- (b) Normalize hedge/one-way sign at the store boundary so a LONG never stores negative qty.
+- (c) Turn on the live arming gate so arming keys qty/side off exchange truth (fixes -4130/-4509).
+- (d) Make `source` per-record provenance + `stale_seconds`, replacing the global flag.
+- (e) Collapse the three read paths onto one read model over time.
+
+**Pros**: hot arming path stays fast (no per-order live call); reuses existing WS feed; gaps are
+small, localized wiring fixes; keeps the 60s REST authority-refresh already designed (FR65).
+**Cons**: still a cache — correctness depends on the write-back + gate actually being on; requires
+provenance discipline to avoid re-introducing stale reads.
+
+### Option B — always consult Binance (REJECTED as primary)
+
+Remove the position mirror from decision paths; arming/coverage/`GET /positions` call
+`positionRisk` / `openAlgoOrders` live with a short TTL cache.
+
+**Pros**: no drift by construction; `source` is trivially truthful.
+**Cons**: **no existing TTL cache or rate-limit gate** — `RateLimitMonitor`
+(`services/rate_monitor.py`) is observability-only (parses `x-mbx-used-weight-1m`, never throttles).
+Arming is currently a hot per-order path with **zero** live calls (`dispatcher.py:4357`); Option B
+adds a live REST dependency + latency there. `get_position_info()` (`binance.py:1850`) is a
+synchronous client call that blocks the loop. Net-new cache + weight-aware gate would be required.
+
+---
+
+## Rate-limit budget (Option B feasibility sizing — AC1)
+
+Current steady-state REST cost from the reconciler loop (`shared/config.py:97`, default **60s**):
+
+- 1× `positionRisk` (`get_position_info`, `binance.py:1850`) per pass.
+- 1× `openAlgoOrders` (`get_open_algo_orders`, `binance.py:1865`) **per unique symbol holding a
+  position** (`position_reconciler.py:388`).
+
+So ≈ `1 + N_symbols` weighted REST calls / 60s.
+`futures_position_information` weight is 5 (all symbols); `openAlgoOrders` ~1 each.
+For a 13-position fleet that is ≈ `5 + 13 ≈ 18` weight / 60s — trivial against Binance's
+2400 weight/min futures budget.
+
+**Feasibility verdict**: Option B is *technically* affordable at reconciler cadence, but the cost
+is not in the 60s loop — it is the **hot arming path** (currently zero live calls) and the 2s OCO
+monitor (`dispatcher.py:116-117`). Adding synchronous live reads there is the real risk, and there
+is no cache/throttle to absorb it. This reinforces Option A.
+
+---
+
+## Acceptance-criteria mapping
+
+| AC | Resolution under Option A |
+|----|---------------------------|
+| Rate-limit budget quantified vs call frequency | See "Rate-limit budget" above (≈1+N / 60s; ≈18 weight/min for 13 positions vs 2400 budget). |
+| Decision recorded (A or B) with rationale in `docs/` | **This document** — Option A. |
+| `GET /positions` never disagrees with live `positionRisk`; `source` = true provenance + staleness | Gap (a) write-back + (d) per-record provenance/`stale_seconds` → follow-up ticket. |
+| SL/TP arming keys qty/side off exchange truth (-4509/-4130 cannot fire normally) | Gap (c) enable live arming gate; arming reads exchange qty/side → follow-up ticket. |
+| Regression: simulated stale/wrong local snapshot does not cause wrong-side/phantom arm | New regression test seeding a stale `positions` dict / bad WS event; assert no arm or correct-side arm. |
+| FR65 reconciler write-back gap at `api.py:266` closed or obsoleted | Gap (a) — pass `store=` → follow-up ticket. |
+
+---
+
+## Follow-up implementation tickets
+
+1. **FR65 write-back + sign-normalization** — pass `store=` at `api.py:266`; normalize
+   `positionAmt` sign at the `ExchangeTruthStore` boundary (`exchange_truth_store.py:142,204,245`).
+   (gaps a + b)
+2. **Live arming gate default-on + qty source** — make arming read exchange qty/side; promote
+   `TE_OCO_AC3_GATE_ENABLED` handling and route `filled_quantity` through live truth. (gap c) —
+   overlaps with #547 (inverted-sign naked) and #550 (OCO divergence).
+3. **Per-record provenance + staleness on `GET /positions`** — replace the global `source` flag
+   (`api.py:1502-1508`) with per-record `source` + `stale_seconds`. (gap d)
+4. **Single read model** — collapse `positions` dict / `ExchangeTruthStore` / `active_oco_pairs`
+   consumers onto one read path. (gap e)
+
+Tickets #547 and #550 are unblocked by this decision: both must key arming off exchange truth
+(gap c), consistent with Option A.

--- a/tests/unit/test_549_stale_snapshot_no_phantom_arm.py
+++ b/tests/unit/test_549_stale_snapshot_no_phantom_arm.py
@@ -1,0 +1,172 @@
+"""Regression for #549: a stale/wrong LOCAL snapshot must never cause a
+wrong-side or phantom arm.
+
+Decision (docs/POSITION_STATE_TRUTH_DECISION.md): Option A — corrected mirror.
+The contract that makes -4509 (arming a position Binance no longer holds) and
+-4130 (arming a wrong-side/duplicate leg) impossible under normal operation is:
+
+    SL/TP arming keys qty/side off EXCHANGE TRUTH, not the local mirror.
+
+These tests exercise the live-arming gate (`OCOManager.place_oco_orders` +
+`_fetch_binance_position_qty`, reading Binance `positionRisk`) with a local
+snapshot that is deliberately stale or malformed, and assert no phantom /
+wrong-side order reaches the exchange.
+
+The `positionAmt = -0.303` LONG shape from the live 2026-08-20 evidence is the
+malformed-sign case: a LONG leg holding a negative amount.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tradeengine.dispatcher import OCOManager
+
+
+@pytest.fixture(autouse=True)
+def enable_ac3_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#549 Option A requires the live arming gate ON so arming keys off
+    exchange truth. Ship-off default is flipped for these tests."""
+    monkeypatch.setenv("TE_OCO_AC3_GATE_ENABLED", "1")
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test.549.stale-snapshot")
+
+
+@pytest.fixture
+def exchange_mock() -> AsyncMock:
+    """Exchange that would succeed if placement ever reached it."""
+    exchange = AsyncMock()
+    exchange.execute = AsyncMock(
+        return_value={"order_id": "1234567890123", "status": "FILLED"}
+    )
+    return exchange
+
+
+def _dispatcher_reading_live(position_risk: list[dict[str, Any]]) -> Any:
+    """Stub dispatcher whose _fetch_binance_position_qty derives qty/side from
+    the SAME sign-normalization logic production uses (matches
+    dispatcher._fetch_binance_position_qty at dispatcher.py:4876-4924).
+
+    The point of #549: this reads EXCHANGE truth, never the local mirror.
+    """
+
+    class _StubDispatcher:
+        async def _fetch_binance_position_qty(
+            self, symbol: str, position_side: str | None
+        ) -> float:
+            target_side = (position_side or "").upper()
+            for pos in position_risk:
+                if pos.get("symbol") != symbol:
+                    continue
+                side = str(pos.get("positionSide", "BOTH")).upper()
+                try:
+                    raw_amt = float(pos.get("positionAmt", 0))
+                except (TypeError, ValueError):
+                    continue
+                if side == "BOTH":
+                    if raw_amt == 0:
+                        continue
+                    effective_side = "LONG" if raw_amt > 0 else "SHORT"
+                    if target_side and effective_side != target_side:
+                        continue
+                elif side in ("LONG", "SHORT"):
+                    if target_side and side != target_side:
+                        continue
+                qty = abs(raw_amt)
+                if qty > 0:
+                    return qty
+            return 0.0
+
+    return _StubDispatcher()
+
+
+@pytest.mark.asyncio
+async def test_stale_local_position_closed_on_exchange_no_phantom_arm(
+    logger: logging.Logger, exchange_mock: AsyncMock
+) -> None:
+    """Local mirror still says LTCUSDT LONG 0.303 (stale, e.g. after restart),
+    but Binance positionRisk is empty → arming must be skipped, no order sent.
+
+    This is the -4509 case: arming a position Binance no longer holds.
+    """
+    dispatcher = _dispatcher_reading_live(position_risk=[])  # exchange holds nothing
+    oco = OCOManager(exchange=exchange_mock, logger=logger, dispatcher=dispatcher)
+
+    # Caller passes the STALE local quantity — the gate must ignore it in
+    # favour of exchange truth.
+    result = await oco.place_oco_orders(
+        position_id="pos-ltc",
+        symbol="LTCUSDT",
+        position_side="LONG",
+        quantity=0.303,  # stale local value
+        stop_loss_price=44.0,
+        take_profit_price=49.0,
+    )
+
+    assert result["status"] == "skipped_no_position_on_exchange"
+    assert result["sl_order_id"] is None
+    assert result["tp_order_id"] is None
+    exchange_mock.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_malformed_negative_long_snapshot_resolves_via_exchange_truth(
+    logger: logging.Logger, exchange_mock: AsyncMock
+) -> None:
+    """The live -0.303 LONG shape: a malformed local snapshot must not drive
+    arming. Exchange truth (BOTH row, negative amt) resolves to a SHORT, so a
+    LONG arm request finds no matching live LONG → skip (no wrong-side arm).
+    """
+    # ONE-WAY 'BOTH' row with negative amt = a real SHORT of 0.303, NOT a LONG.
+    position_risk = [
+        {"symbol": "LTCUSDT", "positionSide": "BOTH", "positionAmt": "-0.303"}
+    ]
+    dispatcher = _dispatcher_reading_live(position_risk)
+    oco = OCOManager(exchange=exchange_mock, logger=logger, dispatcher=dispatcher)
+
+    # Local mirror wrongly labelled this a LONG; request a LONG arm.
+    result = await oco.place_oco_orders(
+        position_id="pos-ltc",
+        symbol="LTCUSDT",
+        position_side="LONG",
+        quantity=0.303,
+        stop_loss_price=44.0,
+        take_profit_price=49.0,
+    )
+
+    # No live LONG exists → gate skips, no wrong-side leg reaches the exchange.
+    assert result["status"] == "skipped_no_position_on_exchange"
+    exchange_mock.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_matching_exchange_truth_still_allows_correct_arm(
+    logger: logging.Logger, exchange_mock: AsyncMock
+) -> None:
+    """Control: when the local request DOES match live exchange truth, arming
+    proceeds. The gate blocks phantom/wrong-side arms, not legitimate ones.
+    """
+    position_risk = [
+        {"symbol": "LTCUSDT", "positionSide": "LONG", "positionAmt": "0.303"}
+    ]
+    dispatcher = _dispatcher_reading_live(position_risk)
+    oco = OCOManager(exchange=exchange_mock, logger=logger, dispatcher=dispatcher)
+
+    result = await oco.place_oco_orders(
+        position_id="pos-ltc",
+        symbol="LTCUSDT",
+        position_side="LONG",
+        quantity=0.303,
+        stop_loss_price=44.0,
+        take_profit_price=49.0,
+    )
+
+    assert result.get("status") != "skipped_no_position_on_exchange"
+    assert exchange_mock.execute.await_count == 2


### PR DESCRIPTION
## Summary

Investigation ticket **#549**: local position/order state drifts from Binance truth — the root cause
of the `-4130` / `-4509` arm failures observed live on the futures testnet (pod `v1.2.17-r176-50367b3`,
2026-08-20).

**Decision: Option A — corrected mirror.** Keep `ExchangeTruthStore` as the single read model and
close the four wiring gaps that make it untrustworthy today. Full rationale, rate-limit sizing, and
follow-up tickets are in [`docs/POSITION_STATE_TRUTH_DECISION.md`](docs/POSITION_STATE_TRUTH_DECISION.md).

## Root cause (code-level)

Three independent in-memory stores, none guaranteed fresh vs REST:
- `PositionManager.positions` — swallowed 2s DM-sync timeout (`position_manager.py:523-536`).
- `ExchangeTruthStore` — keeps raw **signed** `positionAmt` (`exchange_truth_store.py:142,204,245`).
- `OCOManager.active_oco_pairs` — resets on restart (`dispatcher.py:106-108`).

The four gaps that make the mirror lie:
1. FR65 REST write-back is **dead** — `store=` omitted at `api.py:266`.
2. No `positionAmt` sign normalization.
3. Live arming gate off by default (`TE_OCO_AC3_GATE_ENABLED=0`, `dispatcher.py:189`).
4. `source` label is a global config flag, not per-record provenance (`api.py:1502-1508`).

## Why Option A over B

Option B (always consult Binance) adds a live REST dependency to the hot per-order arming path —
which today makes **zero** live calls (`dispatcher.py:4357`) — with no existing TTL cache or
rate-limit gate (`RateLimitMonitor` is observability-only). Rejected as primary.

## Changes

- `docs/POSITION_STATE_TRUTH_DECISION.md` — decision doc: options, rate-limit budget sizing
  (≈1+N calls/60s; ≈18 weight/min for a 13-position fleet vs 2400 budget), AC mapping, 4 follow-up
  tickets.
- `docs/INDEX.md` — link under Risk & Metrics.
- `tests/unit/test_549_stale_snapshot_no_phantom_arm.py` — regression locking the Option A contract:
  a stale/malformed local snapshot (incl. the live `-0.303` LONG shape) must not drive a phantom or
  wrong-side arm; arming keys qty/side off exchange truth.

## Acceptance criteria

- [x] Rate-limit budget quantified vs arming/coverage call frequency (decision doc).
- [x] Decision recorded (A) with rationale in `docs/`.
- [x] Regression: simulated stale/wrong local snapshot does not cause a wrong-side / phantom arm.
- [x] FR65 write-back gap at `api.py:266` documented + assigned a follow-up (gap a).
- [ ] `GET /positions` provenance + arming-off-truth are follow-up implementation tickets (this is
      the investigation/decision ticket; #547 and #550 are unblocked by the Option A contract).

## Test plan

```
pytest tests/unit/test_549_stale_snapshot_no_phantom_arm.py \
       tests/unit/test_oco_ac3_gate_445.py \
       tests/test_binance_4130_reconciliation.py
# 22 passed
```

Closes #549
