### PR TITLE
fix: classify and remediate inverted-sign malformed positions (#547)

### DIFF
--- a/tests/test_position_coverage_guarantee.py
+++ b/tests/test_position_coverage_guarantee.py
@@ -202,9 +202,21 @@ def _make_remediator(mode, exchange, local_positions, clock):
 
 
 def _is_covered(symbol: str, side: str, open_orders) -> bool:
-    """Mirror the exchange truth: hedged iff reduceOnly STOP + TAKE_PROFIT."""
+    """Mirror the exchange truth: hedged iff reduceOnly STOP + TAKE_PROFIT.
+
+    The ``positionAmt`` is signed by side (LONG>0, SHORT<0) to match real
+    Binance ``positionRisk`` semantics; a hardcoded positive amount would
+    trip the #547 malformed-sign detection for SHORT positions.
+    """
+    signed_amt = 1.0 if side == "LONG" else -1.0
     divs = detect_unhedged_positions(
-        {(symbol, side): {"symbol": symbol, "positionSide": side, "positionAmt": 1.0}},
+        {
+            (symbol, side): {
+                "symbol": symbol,
+                "positionSide": side,
+                "positionAmt": signed_amt,
+            }
+        },
         open_orders,
     )
     return len(divs) == 0

--- a/tests/unit/test_naked_position_remediator.py
+++ b/tests/unit/test_naked_position_remediator.py
@@ -8,7 +8,7 @@ derivation, and clean-pass first-seen reset.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -519,3 +519,119 @@ async def test_zero_qty_divergence_does_not_arm_or_flatten() -> None:
     assert counts["failed"] == 1
     ex.execute.assert_not_called()
     close_cb.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #547 — malformed (inverted-sign) position routing
+# ---------------------------------------------------------------------------
+
+
+def _malformed_div(
+    symbol: str = "LTCUSDT",
+    side: str = "LONG",
+    qty: float = 0.303,
+    raw_amt: float = -0.303,
+) -> dict[str, Any]:
+    return {
+        "category": "malformed_position",
+        "symbol": symbol,
+        "side": side,
+        "binance_qty": qty,
+        "raw_position_amt": raw_amt,
+        "local_qty": 0.0,
+        "sl_present": False,
+        "tp_present": False,
+        "detail": "test malformed fixture",
+    }
+
+
+@pytest.mark.asyncio
+async def test_malformed_arm_only_never_arms_and_counts_metric() -> None:
+    """AC3: arm_only must NOT emit a guaranteed-to-fail arm for a malformed
+    position; it increments the malformed metric and records skipped."""
+    from tradeengine import naked_position_remediator as npr
+
+    r, ex, _, close_cb, _ = _make_remediator(mode="arm_only")
+    with patch.object(npr, "malformed_position_total") as mock_metric:
+        counts = await r.remediate([_malformed_div()], _binance_positions("LTCUSDT"))
+    ex.execute.assert_not_called()  # never attempts a direction-invalid arm
+    close_cb.assert_not_called()  # arm_only cannot flatten
+    assert counts["armed"] == 0
+    assert counts["flattened"] == 0
+    assert counts["skipped"] == 1
+    mock_metric.labels.assert_any_call(symbol="LTCUSDT", side="LONG")
+
+
+@pytest.mark.asyncio
+async def test_malformed_arm_only_alerts_once_per_episode() -> None:
+    """AC3: CRITICAL log fires once per detection episode, not every cycle."""
+    from tradeengine import naked_position_remediator as npr
+
+    r, _, _, _, clock = _make_remediator(mode="arm_only")
+    with patch.object(npr.logger, "critical") as mock_crit:
+        await r.remediate([_malformed_div()], _binance_positions("LTCUSDT"))
+        clock.advance(30)
+        await r.remediate([_malformed_div()], _binance_positions("LTCUSDT"))
+    assert mock_crit.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_malformed_arm_or_flatten_flattens_after_grace() -> None:
+    """AC2: arm_or_flatten flattens a malformed position after grace, calling
+    close_position with reason='malformed_position'."""
+    r, ex, _, close_cb, clock = _make_remediator(mode="arm_or_flatten", grace_sec=60)
+    # Pass 1: pre-grace — alert only, no flatten, no arm.
+    counts1 = await r.remediate([_malformed_div()], _binance_positions("LTCUSDT"))
+    assert counts1["flattened"] == 0
+    close_cb.assert_not_called()
+    ex.execute.assert_not_called()
+    # Pass 2: past grace — flatten.
+    clock.advance(61)
+    counts2 = await r.remediate([_malformed_div()], _binance_positions("LTCUSDT"))
+    assert counts2["flattened"] == 1
+    close_cb.assert_awaited_once()
+    call = close_cb.await_args
+    assert call.kwargs["symbol"] == "LTCUSDT"
+    assert call.kwargs["position_side"] == "LONG"
+    assert call.kwargs["quantity"] == pytest.approx(0.303)
+    assert call.kwargs["reason"] == "malformed_position"
+    ex.execute.assert_not_called()  # never arms a malformed position
+
+
+@pytest.mark.asyncio
+async def test_malformed_off_and_dry_run_never_write() -> None:
+    """off/dry_run observe only for malformed positions."""
+    for m in ("off", "dry_run"):
+        r, ex, _, close_cb, _ = _make_remediator(mode=m, grace_sec=0)
+        counts = await r.remediate([_malformed_div()], _binance_positions("LTCUSDT"))
+        assert counts["skipped"] == 1
+        assert counts["flattened"] == 0
+        ex.execute.assert_not_called()
+        close_cb.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_malformed_short_positive_amt_flattens() -> None:
+    """AC2: SHORT with positive amt is also malformed and flattened."""
+    r, ex, _, close_cb, clock = _make_remediator(mode="arm_or_flatten", grace_sec=0)
+    div = _malformed_div(symbol="BTCUSDT", side="SHORT", qty=0.4, raw_amt=0.4)
+    counts = await r.remediate([div], _binance_positions("BTCUSDT", "SHORT"))
+    assert counts["flattened"] == 1
+    call = close_cb.await_args
+    assert call.kwargs["reason"] == "malformed_position"
+    ex.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_malformed_alert_latch_resets_after_clean_pass() -> None:
+    """AC3: once resolved, a re-occurrence alerts CRITICAL again."""
+    from tradeengine import naked_position_remediator as npr
+
+    r, _, _, _, _ = _make_remediator(mode="arm_only")
+    with patch.object(npr.logger, "critical") as mock_crit:
+        await r.remediate([_malformed_div()], _binance_positions("LTCUSDT"))
+        # Clean pass clears state.
+        await r.remediate([], None)
+        # Re-occurs — alerts again.
+        await r.remediate([_malformed_div()], _binance_positions("LTCUSDT"))
+    assert mock_crit.call_count == 2

--- a/tests/unit/test_position_reconciler.py
+++ b/tests/unit/test_position_reconciler.py
@@ -10,6 +10,7 @@ import pytest
 from tradeengine.position_reconciler import (
     PositionReconciler,
     _index_binance_positions,
+    _is_malformed_sign,
     _normalise_side,
     detect_divergences,
     detect_unhedged_positions,
@@ -598,3 +599,134 @@ async def test_reconcile_once_unhedged_check_fails_open_on_order_fetch_error():
 
     categories = [d["category"] for d in divergences]
     assert "unhedged" in categories
+
+
+# ---------------------------------------------------------------------------
+# #547 — malformed (inverted-sign) position detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_malformed_sign_long_negative():
+    assert _is_malformed_sign("LONG", -0.303) is True
+
+
+def test_is_malformed_sign_short_positive():
+    assert _is_malformed_sign("SHORT", 2.5) is True
+
+
+def test_is_malformed_sign_well_formed_long():
+    assert _is_malformed_sign("LONG", 0.5) is False
+
+
+def test_is_malformed_sign_well_formed_short():
+    assert _is_malformed_sign("SHORT", -0.5) is False
+
+
+def test_is_malformed_sign_both_never_malformed():
+    # one-way mode: sign legitimately encodes direction
+    assert _is_malformed_sign("BOTH", -1.0) is False
+    assert _is_malformed_sign("BOTH", 1.0) is False
+
+
+def test_detect_unhedged_classifies_long_negative_as_malformed():
+    """AC1: LONG with positionAmt<0 is malformed_position, not unhedged."""
+    binance_positions = {
+        ("LTCUSDT", "LONG"): {
+            "symbol": "LTCUSDT",
+            "positionSide": "LONG",
+            "positionAmt": -0.303,
+            "entryPrice": 46.08,
+        },
+    }
+    divergences = detect_unhedged_positions(binance_positions, {"LTCUSDT": []})
+    assert len(divergences) == 1
+    d = divergences[0]
+    assert d["category"] == "malformed_position"
+    assert d["symbol"] == "LTCUSDT"
+    assert d["side"] == "LONG"
+    assert d["binance_qty"] == pytest.approx(0.303)
+    assert d["raw_position_amt"] == pytest.approx(-0.303)
+
+
+def test_detect_unhedged_classifies_short_positive_as_malformed():
+    """AC1: SHORT with positionAmt>0 is malformed_position, not unhedged."""
+    binance_positions = {
+        ("BTCUSDT", "SHORT"): {
+            "symbol": "BTCUSDT",
+            "positionSide": "SHORT",
+            "positionAmt": 0.4,
+        },
+    }
+    divergences = detect_unhedged_positions(binance_positions, {"BTCUSDT": []})
+    assert len(divergences) == 1
+    assert divergences[0]["category"] == "malformed_position"
+
+
+def test_detect_unhedged_malformed_not_masked_by_hedged_orders():
+    """AC1: a malformed position with a full SL+TP pair is STILL malformed —
+    the sign mismatch takes precedence over the hedged check (the orders are
+    direction-invalid against a wrong-signed side)."""
+    binance_positions = {
+        ("LTCUSDT", "LONG"): {
+            "symbol": "LTCUSDT",
+            "positionSide": "LONG",
+            "positionAmt": -0.303,
+        },
+    }
+    orders_by_symbol = {
+        "LTCUSDT": [
+            {"positionSide": "LONG", "type": "STOP_MARKET", "reduceOnly": True},
+            {"positionSide": "LONG", "type": "TAKE_PROFIT_MARKET", "reduceOnly": True},
+        ],
+    }
+    divergences = detect_unhedged_positions(binance_positions, orders_by_symbol)
+    assert len(divergences) == 1
+    assert divergences[0]["category"] == "malformed_position"
+
+
+def test_detect_unhedged_well_formed_position_unaffected():
+    """Regression guard: a well-formed LONG (amt>0) with no orders is still
+    plain `unhedged`, not misclassified as malformed."""
+    binance_positions = {
+        ("ETHUSDT", "LONG"): {
+            "symbol": "ETHUSDT",
+            "positionSide": "LONG",
+            "positionAmt": 1.5,
+        },
+    }
+    divergences = detect_unhedged_positions(binance_positions, {"ETHUSDT": []})
+    assert len(divergences) == 1
+    assert divergences[0]["category"] == "unhedged"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_once_malformed_position_ltcusdt_shape():
+    """AC4 regression: the live LTCUSDT LONG amt=-0.303 shape must surface as a
+    malformed_position divergence through the full async reconcile_once path
+    and never remain silently naked."""
+    binance_raw = [
+        {
+            "symbol": "LTCUSDT",
+            "positionSide": "LONG",
+            "positionAmt": "-0.303",
+            "entryPrice": "46.08",
+            "markPrice": "47.02",
+        },
+    ]
+    local: dict = {}
+    reconciler = _make_reconciler(binance_raw, local, open_algo_orders={"LTCUSDT": []})
+
+    with (
+        patch("tradeengine.position_reconciler.reconciliation_evaluator_verdict"),
+        patch("tradeengine.position_reconciler.reconciliation_alert"),
+        patch(
+            "tradeengine.position_reconciler.reconciliation_divergences_total"
+        ) as mock_counter,
+    ):
+        divergences = await reconciler.reconcile_once()
+
+    malformed = [d for d in divergences if d["category"] == "malformed_position"]
+    assert len(malformed) == 1
+    assert malformed[0]["symbol"] == "LTCUSDT"
+    assert malformed[0]["side"] == "LONG"
+    mock_counter.labels.assert_any_call(category="malformed_position", symbol="LTCUSDT")

--- a/tradeengine/naked_position_remediator.py
+++ b/tradeengine/naked_position_remediator.py
@@ -62,6 +62,17 @@ reconcile_lag_seconds = Histogram(
     ["action"],  # action: armed, flattened
 )
 
+# #547: malformed (inverted-sign) positions that can never be armed. Counted
+# separately from naked_position_detected_total so operators can alert on the
+# distinct "position side/sign mismatch" fault rather than lumping it in with
+# ordinary unhedged positions.
+malformed_position_total = Counter(
+    "tradeengine_malformed_position_total",
+    "Malformed hedge-mode positions (LONG with negative amt or SHORT with "
+    "positive amt) observed by the remediator",
+    ["symbol", "side"],
+)
+
 
 # ---------------------------------------------------------------------------
 # Types
@@ -116,6 +127,10 @@ class NakedPositionRemediator:
         self._clock = clock
         # (symbol, side) -> first-seen monotonic timestamp
         self._first_seen: dict[tuple[str, str], float] = {}
+        # #547: (symbol, side) keys already CRITICAL-logged as malformed, so
+        # arm_only emits the alert once per detection episode rather than every
+        # reconcile cycle. Cleared when the key is no longer diverging.
+        self._malformed_alerted: set[tuple[str, str]] = set()
 
     @staticmethod
     def _coerce_mode(mode: str) -> RemediationMode:
@@ -151,6 +166,9 @@ class NakedPositionRemediator:
         if not unhedged_divergences:
             # Clean pass — clear first-seen so future detections start fresh.
             self._first_seen.clear()
+            # #547: also reset the malformed alert latch so a later
+            # re-occurrence re-alerts CRITICAL.
+            self._malformed_alerted.clear()
             return counts
 
         now = self._clock()
@@ -166,6 +184,14 @@ class NakedPositionRemediator:
 
             first_seen_at = self._first_seen.setdefault(key, now)
             elapsed = now - first_seen_at
+
+            # #547: a malformed (inverted-sign) position can never be armed —
+            # a reduceOnly SL/TP against a wrong-signed side is direction-
+            # invalid. Route it to a safe terminal action instead of looping.
+            if div.get("category") == "malformed_position":
+                outcome = await self._handle_malformed(div, elapsed, binance_positions)
+                counts[outcome] += 1
+                continue
 
             if self._mode == "off":
                 counts["skipped"] += 1
@@ -203,6 +229,11 @@ class NakedPositionRemediator:
         stale = [k for k in self._first_seen if k not in currently_unhedged]
         for k in stale:
             self._first_seen.pop(k, None)
+        # #547: reset the once-per-episode malformed alert latch for any key
+        # that resolved, so a future re-occurrence alerts CRITICAL again.
+        for k in list(self._malformed_alerted):
+            if k not in currently_unhedged:
+                self._malformed_alerted.discard(k)
 
         return counts
 
@@ -367,8 +398,14 @@ class NakedPositionRemediator:
         self,
         div: dict[str, Any],
         binance_positions: dict[tuple[str, str], dict[str, Any]] | None,
+        reason: str = "naked_position_grace_expired",
     ) -> bool:
-        """Reduce-only MARKET close via dispatcher.close_position_with_cleanup."""
+        """Reduce-only MARKET close via dispatcher.close_position_with_cleanup.
+
+        ``reason`` defaults to the naked-grace-expired label; #547 passes
+        ``"malformed_position"`` so the audit trail distinguishes a flatten
+        triggered by an inverted-sign position from an ordinary grace flatten.
+        """
         symbol = div["symbol"]
         side = div["side"]
         qty = float(div.get("binance_qty") or 0.0)
@@ -379,7 +416,6 @@ class NakedPositionRemediator:
             return False
 
         position_id = self._resolve_position_id(symbol, side)
-        reason = "naked_position_grace_expired"
         try:
             result = await self._close_position(
                 position_id=position_id,
@@ -416,6 +452,79 @@ class NakedPositionRemediator:
             symbol=symbol, side=side, outcome="flattened" if ok else "failed"
         ).inc()
         return ok
+
+    async def _handle_malformed(
+        self,
+        div: dict[str, Any],
+        elapsed: float,
+        binance_positions: dict[tuple[str, str], dict[str, Any]] | None,
+    ) -> str:
+        """#547: safe terminal handling for an inverted-sign position.
+
+        A malformed position (LONG with negative ``positionAmt`` or SHORT with
+        positive) is un-armable: any ``reduceOnly`` protective order derived
+        from the declared side is direction-invalid. Rather than loop forever:
+
+        - ``off`` / ``dry_run``: observe only (``skipped``).
+        - ``arm_only``: increment ``tradeengine_malformed_position_total``, log
+          CRITICAL once per detection episode, and take NO arm action (a
+          guaranteed-to-fail arm every cycle is exactly the bug). Returns
+          ``skipped`` — the position is stuck pending human/mode intervention.
+        - ``arm_or_flatten``: after ``flatten_grace_sec``, flatten reduce-only
+          MARKET with ``reason="malformed_position"``; before grace, alert like
+          arm_only. Returns ``flattened`` / ``failed`` / ``skipped``.
+        """
+        symbol = div["symbol"]
+        side = div["side"]
+        key = (symbol, side)
+
+        if self._mode in ("off", "dry_run"):
+            if self._mode == "dry_run":
+                logger.warning(
+                    "NakedPositionRemediator[dry_run]: would remediate MALFORMED "
+                    "%s/%s raw_amt=%s (sign/side mismatch) first_seen_age=%.1fs",
+                    symbol,
+                    side,
+                    div.get("raw_position_amt"),
+                    elapsed,
+                )
+            return "skipped"
+
+        # arm_only OR arm_or_flatten before grace → alert, never arm.
+        malformed_position_total.labels(symbol=symbol, side=side).inc()
+        if key not in self._malformed_alerted:
+            self._malformed_alerted.add(key)
+            logger.critical(
+                "NakedPositionRemediator: MALFORMED position %s/%s "
+                "raw_positionAmt=%s (positionSide=%s sign mismatch) — cannot be "
+                "armed with a direction-valid reduceOnly SL/TP. mode=%s. %s (#547)",
+                symbol,
+                side,
+                div.get("raw_position_amt"),
+                side,
+                self._mode,
+                (
+                    "Will flatten after grace window."
+                    if self._mode == "arm_or_flatten"
+                    else "arm_only cannot flatten — position is stuck pending "
+                    "operator action or arm_or_flatten mode."
+                ),
+            )
+
+        should_flatten = (
+            self._mode == "arm_or_flatten" and elapsed >= self._flatten_grace_sec
+        )
+        if not should_flatten:
+            # arm_only always, and arm_or_flatten pre-grace: no arm attempt.
+            return "skipped"
+
+        ok = await self._flatten(div, binance_positions, reason="malformed_position")
+        if ok:
+            reconcile_lag_seconds.labels(action="flattened").observe(elapsed)
+            self._first_seen.pop(key, None)
+            self._malformed_alerted.discard(key)
+            return "flattened"
+        return "failed"
 
     # ------------------------------------------------------------------
     # Helpers

--- a/tradeengine/position_reconciler.py
+++ b/tradeengine/position_reconciler.py
@@ -167,6 +167,27 @@ def _order_is_reduce_only(order: dict[str, Any]) -> bool:
     return bool(order.get("reduceOnly")) or bool(order.get("closePosition"))
 
 
+def _is_malformed_sign(side: str, position_amt: float) -> bool:
+    """#547: detect an inverted-sign hedge-mode position.
+
+    In hedge mode a ``LONG`` leg must carry a positive ``positionAmt`` and a
+    ``SHORT`` leg a negative one. A ``LONG`` row with ``positionAmt < 0`` (or a
+    ``SHORT`` row with ``positionAmt > 0``) is internally inconsistent: any
+    ``reduceOnly`` protective order derived from the declared side is
+    direction-invalid, so the position can never be armed and — under the old
+    ``abs()``-based detection — stayed flagged ``unhedged`` forever without ever
+    being covered or flattened.
+
+    ``BOTH`` (one-way mode) is never malformed: the sign legitimately encodes
+    direction there, so the caller derives the side from the sign instead.
+    """
+    if side == "LONG":
+        return position_amt < 0
+    if side == "SHORT":
+        return position_amt > 0
+    return False
+
+
 def detect_unhedged_positions(
     binance_positions: dict[tuple[str, str], dict[str, Any]],
     binance_open_orders_by_symbol: dict[str, list[dict[str, Any]]],
@@ -184,6 +205,34 @@ def detect_unhedged_positions(
     divergences: list[dict[str, Any]] = []
 
     for (symbol, side), bp in binance_positions.items():
+        raw_amt = float(bp.get("positionAmt", 0) or 0.0)
+
+        # #547: a sign/side mismatch (LONG amt<0 or SHORT amt>0) is a malformed
+        # hedge-mode state. A reduceOnly SL/TP derived from the declared side is
+        # direction-invalid, so this position can never be armed. Classify it as
+        # `malformed_position` and let the remediator take a safe terminal
+        # action (flatten in arm_or_flatten; CRITICAL alert in arm_only) instead
+        # of silently abs()-ing the sign and looping on `unhedged` forever.
+        if _is_malformed_sign(side, raw_amt):
+            divergences.append(
+                {
+                    "category": "malformed_position",
+                    "symbol": symbol,
+                    "side": side,
+                    "binance_qty": abs(raw_amt),
+                    "raw_position_amt": raw_amt,
+                    "local_qty": 0.0,
+                    "sl_present": False,
+                    "tp_present": False,
+                    "detail": (
+                        f"Malformed hedge-mode position: positionSide={side} "
+                        f"but positionAmt={raw_amt} (sign/side mismatch) — "
+                        f"cannot be armed; requires flatten or alert"
+                    ),
+                }
+            )
+            continue
+
         orders = binance_open_orders_by_symbol.get(symbol, []) or []
         sl_present = False
         tp_present = False
@@ -357,10 +406,17 @@ class PositionReconciler:
         # owns its own metrics/logging; failures here must not poison
         # the read-only reconciliation pass.
         if self._remediator is not None:
-            unhedged_only = [d for d in divergences if d.get("category") == "unhedged"]
+            # #547: malformed_position divergences must also reach the
+            # remediator so it can flatten (arm_or_flatten) or alert (arm_only)
+            # instead of the position staying naked forever.
+            remediable = [
+                d
+                for d in divergences
+                if d.get("category") in ("unhedged", "malformed_position")
+            ]
             try:
                 await self._remediator.remediate(
-                    unhedged_only, binance_positions=binance_positions
+                    remediable, binance_positions=binance_positions
                 )
             except Exception:
                 logger.exception(


### PR DESCRIPTION
## Summary

Fixes the inverted-sign naked-position bug (#547). A hedge-mode position with a
malformed quantity — `LONG` with negative `positionAmt`, or `SHORT` with
positive — could **never** be armed with a direction-valid `reduceOnly` SL/TP,
so it stayed naked indefinitely even under `arm_only`. The old `abs()`-based
detection masked the sign and re-flagged the position `unhedged` every cycle
without ever covering or flattening it.

Live evidence (futures testnet, 2026-08-20): `LTCUSDT LONG positionAmt=-0.303`,
0 SL / 0 TP, persisting across reconcile cycles as the fleet's only naked leg.

## Changes

- **`position_reconciler.py`**
  - New `_is_malformed_sign(side, amt)` helper (`BOTH`/one-way is never malformed).
  - `detect_unhedged_positions` emits a distinct `malformed_position` divergence
    (carrying `raw_position_amt`) **before** the SL/TP hedged check, so a
    malformed position is never masked — even if a direction-invalid SL+TP pair
    happens to exist.
  - `reconcile_once` routes `malformed_position` divergences to the remediator
    alongside `unhedged`.
- **`naked_position_remediator.py`**
  - New `tradeengine_malformed_position_total{symbol,side}` counter.
  - `_handle_malformed`: in `arm_or_flatten`, flattens (reduce-only MARKET,
    `reason="malformed_position"`) after `flatten_grace_sec`; in `arm_only`,
    increments the counter and logs CRITICAL **once per detection episode** with
    **no** guaranteed-to-fail arm attempt. `off`/`dry_run` observe only.
  - Alert latch resets on clean pass / key resolution.
  - `_flatten` gains an optional `reason` parameter.
- **Tests**
  - Reconciler: sign-helper units, LONG-neg / SHORT-pos classification,
    precedence over hedged orders, well-formed regression guard, and the
    `LTCUSDT LONG amt=-0.303` shape through the async `reconcile_once` path.
  - Remediator: routing across all four modes, flatten reason assertion,
    once-per-episode alert, latch reset.
  - Fixed `test_position_coverage_guarantee.py::_is_covered` to sign
    `positionAmt` by side (matching real Binance `positionRisk`).

## Acceptance criteria

- [x] AC1 — malformed sign classified as `malformed_position`, not `unhedged`
- [x] AC2 — `arm_or_flatten` flattens after grace with `reason="malformed_position"`
- [x] AC3 — `arm_only` increments `tradeengine_malformed_position_total`, logs
      CRITICAL once, and does not emit a guaranteed-to-fail arm each cycle
- [x] AC4 — regression test reproduces `LTCUSDT LONG amt=-0.303`
- [ ] AC5 — live E2E verification (post-deploy)

## Testing

- Full suite: **1988 passed, 12 skipped**, coverage **81%** (gate 40%).
- `ruff check` + `ruff format` clean. No new mypy errors (46 pre-existing
  strict-mode `TradeOrder` errors are unchanged from `main`).

Closes #547
