### PR TITLE
fix: reconcile OCO tracking against Binance truth (#550)

### DIFF
--- a/tests/test_issue_550_oco_exchange_truth.py
+++ b/tests/test_issue_550_oco_exchange_truth.py
@@ -1,0 +1,231 @@
+"""Tests for issue #550 acceptance criteria.
+
+#550: in-memory ``active_oco_pairs`` diverges from Binance truth.
+
+Covered here:
+- AC-2 (consult exchange truth before placing): when Binance already holds a
+  reduceOnly STOP+TP pair for (symbol, positionSide) AND the in-memory map is
+  empty, ``place_oco_orders`` is a no-op (skipped_exchange_pair_exists).
+- Negative control: an empty exchange (no algo orders) still allows placement.
+- Gauge no-undercount: ``_sync_oco_pairs_gauge`` emits one row per covered
+  (symbol, position_side) after reconcile so the gauge cannot silently
+  undercount post-restart.
+- Best-effort: a failing openAlgoOrders lookup falls through to placement
+  rather than dropping a real protective pair.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tradeengine.dispatcher import OCOManager
+
+
+def _make_oco_manager(algo_orders: list | Exception | None = None) -> OCOManager:
+    exchange = MagicMock()
+    exchange.client = MagicMock()
+    if isinstance(algo_orders, Exception):
+        exchange.get_open_algo_orders = AsyncMock(side_effect=algo_orders)
+    else:
+        exchange.get_open_algo_orders = AsyncMock(return_value=algo_orders or [])
+
+    _exec_call_count = [0]
+
+    async def _fake_execute(order):
+        _exec_call_count[0] += 1
+        return {
+            "order_id": f"order_{_exec_call_count[0]}",
+            "algoId": f"order_{_exec_call_count[0]}",
+            "status": "NEW",
+        }
+
+    exchange.execute = _fake_execute
+
+    mgr = OCOManager(exchange=exchange, logger=logging.getLogger("test-550"))
+    return mgr
+
+
+def _protective_pair(symbol="BTCUSDT", position_side="LONG") -> list[dict]:
+    return [
+        {
+            "symbol": symbol,
+            "positionSide": position_side,
+            "type": "STOP_MARKET",
+            "algoId": "algo-sl-1",
+            "closePosition": True,
+        },
+        {
+            "symbol": symbol,
+            "positionSide": position_side,
+            "type": "TAKE_PROFIT_MARKET",
+            "algoId": "algo-tp-1",
+            "closePosition": True,
+        },
+    ]
+
+
+class TestAC2ExchangeTruthDedup:
+    @pytest.mark.asyncio
+    async def test_covered_on_exchange_empty_map_is_noop(self):
+        """Mandatory unit AC: covered position on the mocked exchange + empty
+        in-memory map => place_oco_orders is a no-op."""
+        mgr = _make_oco_manager(algo_orders=_protective_pair())
+        assert mgr.active_oco_pairs == {}
+
+        result = await mgr.place_oco_orders(
+            position_id="pos1",
+            symbol="BTCUSDT",
+            position_side="LONG",
+            quantity=0.001,
+            stop_loss_price=48000.0,
+            take_profit_price=52000.0,
+            strategy_position_id="strat_a",
+        )
+
+        assert result.get("status") == "skipped_exchange_pair_exists"
+        assert result.get("sl_order_id") is None
+        assert result.get("tp_order_id") is None
+        # no local tracking created for the skipped placement
+        assert mgr.active_oco_pairs.get("BTCUSDT_LONG", []) == []
+
+    @pytest.mark.asyncio
+    async def test_empty_exchange_still_places(self):
+        mgr = _make_oco_manager(algo_orders=[])
+        result = await mgr.place_oco_orders(
+            position_id="pos1",
+            symbol="BTCUSDT",
+            position_side="LONG",
+            quantity=0.001,
+            stop_loss_price=48000.0,
+            take_profit_price=52000.0,
+        )
+        assert result.get("status") != "skipped_exchange_pair_exists"
+
+    @pytest.mark.asyncio
+    async def test_only_stop_on_exchange_still_places(self):
+        """Half-coverage (STOP only, no TP) must NOT be treated as a full
+        pair — the missing leg still needs arming."""
+        half = [_protective_pair()[0]]  # STOP only
+        mgr = _make_oco_manager(algo_orders=half)
+        result = await mgr.place_oco_orders(
+            position_id="pos1",
+            symbol="BTCUSDT",
+            position_side="LONG",
+            quantity=0.001,
+            stop_loss_price=48000.0,
+            take_profit_price=52000.0,
+        )
+        assert result.get("status") != "skipped_exchange_pair_exists"
+
+    @pytest.mark.asyncio
+    async def test_other_position_side_does_not_dedup(self):
+        """A SHORT pair on the exchange must not skip a LONG placement."""
+        mgr = _make_oco_manager(algo_orders=_protective_pair(position_side="SHORT"))
+        result = await mgr.place_oco_orders(
+            position_id="pos1",
+            symbol="BTCUSDT",
+            position_side="LONG",
+            quantity=0.001,
+            stop_loss_price=48000.0,
+            take_profit_price=52000.0,
+        )
+        assert result.get("status") != "skipped_exchange_pair_exists"
+
+    @pytest.mark.asyncio
+    async def test_lookup_failure_falls_through_to_placement(self):
+        mgr = _make_oco_manager(algo_orders=RuntimeError("binance down"))
+        result = await mgr.place_oco_orders(
+            position_id="pos1",
+            symbol="BTCUSDT",
+            position_side="LONG",
+            quantity=0.001,
+            stop_loss_price=48000.0,
+            take_profit_price=52000.0,
+        )
+        assert result.get("status") != "skipped_exchange_pair_exists"
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_env(self, monkeypatch):
+        monkeypatch.setenv("TE_OCO_EXCHANGE_TRUTH_DEDUP", "0")
+        mgr = _make_oco_manager(algo_orders=_protective_pair())
+        result = await mgr.place_oco_orders(
+            position_id="pos1",
+            symbol="BTCUSDT",
+            position_side="LONG",
+            quantity=0.001,
+            stop_loss_price=48000.0,
+            take_profit_price=52000.0,
+        )
+        assert result.get("status") != "skipped_exchange_pair_exists"
+
+
+class TestExchangeHasProtectivePair:
+    @pytest.mark.asyncio
+    async def test_true_when_both_legs_present(self):
+        mgr = _make_oco_manager(algo_orders=_protective_pair())
+        assert await mgr._exchange_has_protective_pair("BTCUSDT", "LONG") is True
+
+    @pytest.mark.asyncio
+    async def test_false_when_no_orders(self):
+        mgr = _make_oco_manager(algo_orders=[])
+        assert await mgr._exchange_has_protective_pair("BTCUSDT", "LONG") is False
+
+    @pytest.mark.asyncio
+    async def test_false_when_only_one_leg(self):
+        mgr = _make_oco_manager(algo_orders=[_protective_pair()[1]])  # TP only
+        assert await mgr._exchange_has_protective_pair("BTCUSDT", "LONG") is False
+
+    @pytest.mark.asyncio
+    async def test_both_position_side_matches_one_way(self):
+        both = _protective_pair(position_side="BOTH")
+        mgr = _make_oco_manager(algo_orders=both)
+        assert await mgr._exchange_has_protective_pair("BTCUSDT", "LONG") is True
+
+
+class TestGaugeNoUndercount:
+    def test_sync_gauge_emits_row_per_covered_position(self):
+        """AC: gauge reflects exchange truth after reconcile (no undercount)."""
+        mgr = _make_oco_manager()
+        mgr.active_oco_pairs = {
+            "BTCUSDT_LONG": [
+                {"symbol": "BTCUSDT", "position_side": "LONG", "status": "active"}
+            ],
+            "ETHUSDT_SHORT": [
+                {"symbol": "ETHUSDT", "position_side": "SHORT", "status": "active"}
+            ],
+            "ADAUSDT_LONG": [
+                {"symbol": "ADAUSDT", "position_side": "LONG", "status": "completed"}
+            ],
+        }
+
+        from tradeengine.metrics import active_oco_pairs_per_position
+
+        mgr._sync_oco_pairs_gauge()
+
+        btc = active_oco_pairs_per_position.labels(
+            symbol="BTCUSDT", position_side="LONG", exchange="binance"
+        )._value.get()
+        eth = active_oco_pairs_per_position.labels(
+            symbol="ETHUSDT", position_side="SHORT", exchange="binance"
+        )._value.get()
+        assert btc == 1
+        assert eth == 1
+
+    def test_sync_gauge_skips_when_no_active_entries(self):
+        mgr = _make_oco_manager()
+        mgr.active_oco_pairs = {
+            "XRPUSDT_LONG": [
+                {"symbol": "XRPUSDT", "position_side": "LONG", "status": "completed"}
+            ],
+        }
+        # must not raise and must not emit a row for a non-active key
+        mgr._sync_oco_pairs_gauge()
+        from tradeengine.metrics import active_oco_pairs_per_position
+
+        xrp = active_oco_pairs_per_position.labels(
+            symbol="XRPUSDT", position_side="LONG", exchange="binance"
+        )._value.get()
+        assert xrp == 0

--- a/tradeengine/dispatcher.py
+++ b/tradeengine/dispatcher.py
@@ -144,6 +144,86 @@ class OCOManager:
                     )
                     return
 
+    async def _exchange_has_protective_pair(
+        self, symbol: str, position_side: str
+    ) -> bool:
+        """AC-2 (#550): return True iff Binance already holds a reduceOnly
+        STOP + TAKE_PROFIT protective pair for ``(symbol, position_side)``.
+
+        Queries ``openAlgoOrders`` (protective legs are ``closePosition=True``
+        conditional/algo orders, NOT standard ``openOrders``) and checks that
+        at least one ``STOP_MARKET`` and one ``TAKE_PROFIT_MARKET`` order exist
+        for the given ``positionSide``. This is the exchange-truth counterpart
+        to the process-local ``active_oco_pairs`` dedup guard: it prevents the
+        orphan over-arm that occurs when local state is empty/stale after a
+        restart but the exchange already covers the position.
+
+        Best-effort: any lookup error propagates to the caller, which falls
+        through to placement rather than dropping a real protective pair.
+        """
+        algo_orders = await self.exchange.get_open_algo_orders(symbol)
+        if not algo_orders:
+            return False
+
+        has_stop = False
+        has_take_profit = False
+        for order in algo_orders:
+            # positionSide gate: HEDGE mode yields LONG/SHORT rows; ONE-WAY
+            # yields BOTH. Treat BOTH as matching any requested side so the
+            # gate still dedups one-way accounts.
+            order_side = str(order.get("positionSide", "")).upper()
+            if order_side not in (position_side.upper(), "BOTH", ""):
+                continue
+            order_type = str(order.get("type") or order.get("orderType") or "").upper()
+            if order_type in ("STOP_MARKET", "STOP"):
+                has_stop = True
+            elif order_type in ("TAKE_PROFIT_MARKET", "TAKE_PROFIT"):
+                has_take_profit = True
+            if has_stop and has_take_profit:
+                return True
+
+        return has_stop and has_take_profit
+
+    def _sync_oco_pairs_gauge(self) -> None:
+        """AC (#550): set active_oco_pairs_per_position from the current
+        active_oco_pairs map so the gauge reflects exchange truth (every
+        covered position gets a row) rather than only positions armed by a
+        live placement in this process.
+
+        Emits one gauge sample per (symbol, position_side) that has at least
+        one ``active`` OCO entry, using the count of active entries as the
+        value. Best-effort — a metrics failure must never break reconcile.
+        """
+        try:
+            from tradeengine.metrics import active_oco_pairs_per_position
+        except Exception:
+            return
+        for key, oco_list in self.active_oco_pairs.items():
+            active_entries = [o for o in oco_list if o.get("status") == "active"]
+            if not active_entries:
+                continue
+            symbol = active_entries[0].get("symbol")
+            position_side = active_entries[0].get("position_side")
+            if not symbol or not position_side:
+                # Fall back to parsing the "SYMBOL_SIDE" key.
+                parsed = key.rsplit("_", 1)
+                if len(parsed) == 2:
+                    symbol, position_side = parsed
+            if not symbol or not position_side:
+                continue
+            try:
+                active_oco_pairs_per_position.labels(
+                    symbol=symbol,
+                    position_side=position_side,
+                    exchange="binance",
+                ).set(len(active_entries))
+            except Exception:
+                self.logger.debug(
+                    "Failed to emit active_oco_pairs_per_position for %s",
+                    key,
+                    exc_info=True,
+                )
+
     async def place_oco_orders(
         self,
         position_id: str,
@@ -232,6 +312,50 @@ class OCOManager:
                 "exchange_position_key": exchange_position_key,
                 "active_pairs": len(active_pairs),
             }
+
+        # AC-2 (#550): consult Binance truth before placing. The local
+        # active_oco_pairs dedup above trusts process-local state only, which
+        # resets on restart and is fed solely by placement events. After a
+        # restart (or any local/exchange divergence) the local map can be empty
+        # for a position that Binance already covers → the engine re-arms and
+        # immediately cancels the extra legs as orphans (oco_orphan_leg_total).
+        # Query openAlgoOrders for (symbol, positionSide); if a reduceOnly
+        # STOP + TP pair already exists on the exchange, skip placement.
+        #
+        # On by default (unlike the AC3 positionRisk gate) because it only
+        # skips when the exchange *already* holds both protective legs — there
+        # is no freshly-filled-entry race that could make it skip a real
+        # unprotected position. Operator can disable with
+        # TE_OCO_EXCHANGE_TRUTH_DEDUP=0 for rollback.
+        _exchange_truth_dedup = os.getenv("TE_OCO_EXCHANGE_TRUTH_DEDUP", "1") == "1"
+        if _exchange_truth_dedup and hasattr(self.exchange, "get_open_algo_orders"):
+            try:
+                if await self._exchange_has_protective_pair(symbol, position_side):
+                    self.logger.warning(
+                        "⛔ OCO dedup (exchange truth #550): %s already has a "
+                        "reduceOnly STOP+TP pair on Binance (openAlgoOrders). "
+                        "Skipping placement for strategy %s to avoid orphan "
+                        "over-arm.",
+                        exchange_position_key,
+                        strategy_position_id,
+                    )
+                    return {
+                        "status": "skipped_exchange_pair_exists",
+                        "exchange_position_key": exchange_position_key,
+                        "sl_order_id": None,
+                        "tp_order_id": None,
+                        "symbol": symbol,
+                        "position_side": position_side,
+                    }
+            except Exception:
+                # Best-effort: never let an exchange-truth lookup failure block
+                # placement of a real protective pair. Fall through to place.
+                self.logger.debug(
+                    "OCO exchange-truth dedup lookup failed for %s — "
+                    "falling through to placement",
+                    exchange_position_key,
+                    exc_info=True,
+                )
 
         self.logger.info(
             f"Placing OCO orders: symbol={symbol}, position_side={position_side}, "
@@ -1115,6 +1239,15 @@ class OCOManager:
                 )
 
         self.logger.info(f"[STARTUP] Rebuilt {rebuilt} active OCO pairs from Binance")
+
+        # AC (#550): emit active_oco_pairs_per_position for every reconciled
+        # (symbol, position_side) so the gauge reflects exchange truth after a
+        # restart instead of silently undercounting. Without this, the gauge is
+        # only ever set on live placement (place_oco_orders success path), so a
+        # freshly-restarted pod that reconciled N covered positions from Binance
+        # would report zero rows until the next placement — the "under-track
+        # (standing)" symptom in #550.
+        self._sync_oco_pairs_gauge()
 
         # Start monitoring for any reconciled pairs so they are tracked going forward
         if rebuilt > 0 and not self.monitoring_active:


### PR DESCRIPTION
## Summary

Fixes #550 — `active_oco_pairs` diverges from Binance truth (orphan over-arm + gauge undercount).

`OCOManager.active_oco_pairs` is process-local: it resets on restart and is fed only by placement events, never reconciled against `openAlgoOrders` for the placement dedup decision. Result:

- **Over-arm (orphans):** after a restart the local map is empty for a position Binance already covers → the #352 dedup guard passes → the engine re-arms → the extra legs are cancelled as orphans (`oco_orphan_leg_total`).
- **Under-track (gauge):** `active_oco_pairs_per_position` is set only on live placement, so a freshly reconciled pod under-reports covered positions.

## Changes (`tradeengine/dispatcher.py`)

1. **`_exchange_has_protective_pair(symbol, position_side)`** — queries `get_open_algo_orders(symbol)` and returns True iff a reduceOnly `STOP_MARKET` + `TAKE_PROFIT_MARKET` pair already exists for the `positionSide` (BOTH matches one-way accounts).
2. **Exchange-truth dedup gate** in `place_oco_orders`, after the local #352 guard: skip with `status="skipped_exchange_pair_exists"` when the exchange already covers the position. On by default (`TE_OCO_EXCHANGE_TRUTH_DEDUP=1`, set `0` to roll back); a lookup failure falls through to placement so a real protective pair is never dropped.
3. **`_sync_oco_pairs_gauge()`** called at the end of `reconcile_from_exchange` so `active_oco_pairs_per_position` emits one row per covered `(symbol, position_side)` after boot — closing the undercount gap. Boot seeding (AC1) already exists via `reconcile_from_exchange`.

## Acceptance criteria

- [x] OCO placement consults `openAlgoOrders` for existing coverage before placing.
- [x] Unit test: covered position on mocked exchange + empty in-memory map ⇒ `place_oco_orders` is a no-op.
- [x] Gauge reflects exchange truth after reconcile (no undercount).
- [x] Boot seed from `openAlgoOrders` (pre-existing `reconcile_from_exchange`, gauge gap now closed).
- [ ] **Live E2E on futures testnet** — mandatory write-condition; executed in deploy-verification/finalize against the running pod (output attached before Done).

## Verification (offline)

- `tests/test_issue_550_oco_exchange_truth.py` — 12 passed.
- Full suite: 2000 passed, 12 skipped, `--cov-fail-under=40` satisfied.
- `ruff check` + `ruff format --check` clean; `mypy --strict` adds 0 new errors on `dispatcher.py`.

Implements #550
